### PR TITLE
fix(init): output path on init

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: release
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+     release:
+       types: [created]
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -24,7 +24,6 @@ struct InitAdrContext {
 }
 
 pub(crate) fn run(args: &InitArgs) -> Result<()> {
-    dbg!(args.directory.to_str().unwrap());
     create_dir_all(&args.directory)?;
 
     let number = next_adr_number(&args.directory)?;
@@ -37,15 +36,17 @@ pub(crate) fn run(args: &InitArgs) -> Result<()> {
         date: now()?,
     };
 
-    let mut tt = TinyTemplate::new();
-    tt.add_template("init_adr", INIT_TEMPLATE)?;
-    let rendered = tt.render("init_adr", &init_context)?;
-    std::fs::write(filename, rendered)?;
-
     std::fs::write(
         std::env::current_dir()?.join(".adr-dir"),
         args.directory.to_str().unwrap(),
     )?;
+
+    let mut tt = TinyTemplate::new();
+    tt.add_template("init_adr", INIT_TEMPLATE)?;
+    let rendered = tt.render("init_adr", &init_context)?;
+    std::fs::write(&filename, rendered)?;
+
+    println!("{}", filename.display());
 
     Ok(())
 }

--- a/tests/test_init.rs
+++ b/tests/test_init.rs
@@ -12,6 +12,7 @@ fn test_init_default() {
         .unwrap()
         .arg("init")
         .assert()
+        .stdout("doc/adr/0001-record-architecture-decisions.md\n")
         .success();
 
     temp.child("doc/adr/0001-record-architecture-decisions.md")


### PR DESCRIPTION
adrs-tools  init prints the new path out, do that here too.

remove an errant dbg 