### PR TITLE
fix(bug): new should assume doc/adr

### DIFF
--- a/src/adr.rs
+++ b/src/adr.rs
@@ -1,4 +1,4 @@
-use std::fs::{read_dir, read_to_string};
+use std::fs::{create_dir_all, read_dir, read_to_string};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -206,6 +206,16 @@ pub(crate) fn read_adr_dir_file() -> Result<PathBuf> {
     Ok(PathBuf::from(dir.trim()))
 }
 
+// find the ADR directory, defaulting to "doc/adr" and creating it if it doesn't exist
+pub(crate) fn find_adr_dir() -> Result<PathBuf> {
+    match read_adr_dir_file() {
+        Ok(dir) => Ok(dir),
+        _ => {
+            create_dir_all("doc/adr")?;
+            Ok(PathBuf::from("doc/adr"))
+        }
+    }
+}
 // get the next ADR number
 pub(crate) fn next_adr_number(path: impl AsRef<Path>) -> Result<i32> {
     let adrs = list_adrs(path.as_ref())?;

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::Args;
 use edit::edit;
 
-use crate::adr::{find_adr, read_adr_dir_file};
+use crate::adr::{find_adr, find_adr_dir};
 
 #[derive(Debug, Args)]
 pub(crate) struct EditArgs {
@@ -13,7 +13,7 @@ pub(crate) struct EditArgs {
 }
 
 pub(crate) fn run(args: &EditArgs) -> Result<()> {
-    let adr_dir = read_adr_dir_file()?;
+    let adr_dir = find_adr_dir()?;
 
     let adr = find_adr(Path::new(&adr_dir), &args.name)?;
     let content = read_to_string(adr.clone())?;

--- a/src/cmd/generate.rs
+++ b/src/cmd/generate.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::adr::{get_links, get_title, list_adrs, read_adr_dir_file};
+use crate::adr::{find_adr_dir, get_links, get_title, list_adrs, read_adr_dir_file};
 use anyhow::Result;
 use clap::{Args, Subcommand};
 
@@ -44,7 +44,7 @@ pub(crate) fn run(args: &GenerateCommands) -> Result<()> {
 }
 
 fn run_toc(args: &TocArgs) -> Result<()> {
-    let adr_dir = read_adr_dir_file()?;
+    let adr_dir = find_adr_dir()?;
     let adrs = list_adrs(Path::new(&adr_dir))?;
 
     println! {"# Architecture Decision Records\n"};

--- a/src/cmd/link.rs
+++ b/src/cmd/link.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 use clap::Args;
 
-use crate::adr::{self, append_status, read_adr_dir_file};
+use crate::adr::{self, append_status, find_adr_dir};
 
 #[derive(Debug, Args)]
 pub(crate) struct LinkArgs {
@@ -18,7 +18,7 @@ pub(crate) struct LinkArgs {
 }
 
 pub(crate) fn run(args: &LinkArgs) -> Result<()> {
-    let adr_dir = read_adr_dir_file()?;
+    let adr_dir = find_adr_dir()?;
 
     let source = adr::find_adr(Path::new(&adr_dir), &args.source)?;
     let source_filename = source.file_name().unwrap().to_str().unwrap();

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use clap::Args;
 
-use crate::adr::{list_adrs, read_adr_dir_file};
+use crate::adr::{find_adr_dir, list_adrs};
 
 #[derive(Debug, Args)]
 pub(crate) struct ListArgs {}
 
 pub(crate) fn run(_args: &ListArgs) -> Result<()> {
-    let adr_dir = read_adr_dir_file()?;
+    let adr_dir = find_adr_dir()?;
 
     let adrs = list_adrs(&adr_dir)?;
     for adr in adrs {

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use tinytemplate::TinyTemplate;
 
 use crate::adr::{
-    append_status, find_adr, format_adr_path, get_title, next_adr_number, now, read_adr_dir_file,
+    append_status, find_adr, find_adr_dir, format_adr_path, get_title, next_adr_number, now,
 };
 
 static NEW_TEMPLATE: &str = include_str!("../../templates/nygard/new.md");
@@ -34,7 +34,7 @@ struct NewAdrContext {
 }
 
 pub(crate) fn run(args: &NewArgs) -> Result<()> {
-    let adr_dir = read_adr_dir_file()?;
+    let adr_dir = find_adr_dir()?;
     let number = next_adr_number(&adr_dir)?;
 
     let title = args.title.join(" ");

--- a/tests/test_new.rs
+++ b/tests/test_new.rs
@@ -138,3 +138,21 @@ fn test_new_link() {
         }
     }
 }
+
+#[test]
+#[serial_test::serial]
+fn test_new_no_current_dir() {
+    let temp = TempDir::new().unwrap();
+    std::env::set_current_dir(temp.path()).unwrap();
+    std::env::set_var("EDITOR", "cat");
+
+    Command::cargo_bin("adrs")
+        .unwrap()
+        .arg("new")
+        .arg("Test new without init")
+        .assert()
+        .success();
+
+    temp.child("doc/adr/0001-test-new-without-init.md")
+        .assert(predicates::path::exists());
+}


### PR DESCRIPTION
`adr-tools` will default to `doc/adr` for the new command, `adrs` should too for compatibility.