### PR TITLE
Add '--ordered option' to toc generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "predicates",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
+ "regex",
  "serde",
  "serial_test",
  "time",
@@ -671,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ pulldown-cmark-to-cmark = "11.2.0"
 walkdir = "2.4.0"
 fuzzy-matcher = "0.3.7"
 whoami = "1.5.1"
+regex = "1.10.4"
 
 [dev-dependencies]
 serial_test = "3.0.0"

--- a/src/cmd/generate/toc.rs
+++ b/src/cmd/generate/toc.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use clap::Args;
+use regex::Regex;
 
 use crate::adr::{find_adr_dir, get_title, list_adrs};
 
@@ -19,6 +20,38 @@ pub(crate) struct TocArgs {
     /// Prefix each decision file link with the given string
     #[clap(long, short)]
     prefix: Option<String>,
+    /// Generate an ordered list with numbered ADR titles
+    #[clap(long, short = 'O', default_value_t = false)]
+    ordered: bool,
+}
+
+pub fn get_ordinal(title: &String) -> Result<(u32, String)> {
+    let re = Regex::new(r"^(?<ordinal>\d{1,9})[.)]\s*(?<text>.+$)").unwrap();
+    match re.captures(title) {
+        Some(caps) => Ok((
+            caps["ordinal"].parse::<u32>().unwrap(),
+            caps["text"].to_string(),
+        )),
+        None => Err(anyhow::anyhow!(
+            "No ordered list marker found in title '{}'",
+            title
+        )),
+    }
+}
+
+pub fn print_ordered_toc(mut toc_lines: Vec<(u32, String, PathBuf)>) -> Result<()> {
+    toc_lines.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut expected_next_ordinal = 1;
+    for line in toc_lines {
+        if line.0 != expected_next_ordinal {
+            return Err(anyhow::anyhow!(
+                "ADR ordering must start at 1 and increase linearly with no gaps"
+            ));
+        }
+        expected_next_ordinal += 1;
+        println!("1. [{}]({})", line.1, line.2.display());
+    }
+    Ok(())
 }
 
 pub fn run_toc(args: &TocArgs) -> Result<()> {
@@ -29,6 +62,8 @@ pub fn run_toc(args: &TocArgs) -> Result<()> {
     if let Some(intro) = &args.intro {
         println!("{}", read_to_string(intro)?);
     }
+
+    let mut toc_lines = Vec::<(u32, String, PathBuf)>::new();
     for path in adrs {
         let title = get_title(&path)?;
         let mut path = PathBuf::from(&path.file_name().unwrap().to_str().unwrap().to_owned());
@@ -38,8 +73,17 @@ pub fn run_toc(args: &TocArgs) -> Result<()> {
             None => path,
         };
 
-        println!("* [{}]({})", title, &path.display());
+        if !args.ordered {
+            println!("* [{}]({})", title, &path.display());
+        } else {
+            let (ordinal, text) = get_ordinal(&title).unwrap();
+            toc_lines.push((ordinal, text, path));
+        }
     }
+    if args.ordered {
+        print_ordered_toc(toc_lines).unwrap();
+    }
+
     if let Some(outro) = &args.outro {
         println!("\n{}", read_to_string(outro)?);
     }

--- a/tests/test_generate.rs
+++ b/tests/test_generate.rs
@@ -32,6 +32,15 @@ fn test_generate_toc() {
         .stdout("# Architecture Decision Records\n\n* [1. Record architecture decisions](0001-record-architecture-decisions.md)\n* [2. Test new](0002-test-new.md)\n")
         .success();
 
+    Command::cargo_bin("adrs")
+        .unwrap()
+        .arg("generate")
+        .arg("toc")
+        .arg("--ordered")
+        .assert()
+        .stdout("# Architecture Decision Records\n\n1. [Record architecture decisions](0001-record-architecture-decisions.md)\n1. [Test new](0002-test-new.md)\n")
+        .success();
+
     temp.child("intro.txt").write_str("intro text").unwrap();
     temp.child("outro.txt").write_str("outro text").unwrap();
 


### PR DESCRIPTION
Functionally backwards compatible. Moves the regex crate from dev-dependencies into the main dependencies.

In many (probably most) cases, the Table of Contents generated will look like this:

```
* [1. foo](0001-foo.md)
* [2. bar](0002-bar.md)
* [3. baz](0003-baz.md)
```

In my opinion this is ugly markdown, since it generates an unordered list and adds unsyntactic ordering after the fact. When rendered, it will look a lot like an ordered list, but with useless bullets in front of each item.

This patch adds a flag to leverage the common title structure generated by adrs to create a cleanly ordered list:

```
1. [foo](0001-foo.md)
1. [bar](0002-bar.md)
1. [baz](0003-baz.md)
```

Without the flag, output is unchanged. A few notes on error catching:

* This feature is implemented against the commonmark standard, so only up to 9 digits are allowed in the identifier in the title. Please do not write a billion ADRs and attempt to generate a TOC with this flag.
* While these cases will not come up if ADRs are generated with adrs, some allowances are made for custom setups:
  * Ordering is done entirely based on title contents. If the file has a conflicting number, or none at all, it will be disregarded. This allows for a slightly DRYer setup if desired.
  * Numbers cannot be missing, as commonmark has no allowances for out-of-order ordered lists.
  * All ADR titles must start with a valid ordered list identifier. This feature does not allow mixing and matching between styles.