### PR TITLE
Update time to 0.3.36/fix compilation on Rust 1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -874,9 +874,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.80"
 clap = { version = "4.5.1", features = ["derive"] }
 tinytemplate = "1.1"
 serde = { version = "1.0", features = ["derive"] }
-time = { version = "0.3.34", features = ["local-offset", "formatting", "macros"] }
+time = { version = "0.3.36", features = ["local-offset", "formatting", "macros"] }
 edit = "0.1.5"
 pulldown-cmark = "0.9"
 pulldown-cmark-to-cmark = "11.2.0"


### PR DESCRIPTION
Fixes a compile issue (type annotations needed for `Box<_>`) on Rust 1.80.

See https://github.com/rust-lang/rust/issues/127343 (and https://github.com/NixOS/nixpkgs/issues/332957).