### PR TITLE
replace 'superceded' option with more correct spelling 'superseded' a…

### DIFF
--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -14,9 +14,9 @@ static NEW_TEMPLATE: &str = include_str!("../../templates/nygard/new.md");
 #[derive(Debug, Args)]
 #[command(version, about, long_about = None)]
 pub(crate) struct NewArgs {
-    /// A reference to a previous decision to supercede with this new one
-    #[arg(short, long)]
-    superceded: Vec<String>,
+    /// A reference to a previous decision to supersede with this new one
+    #[arg(short, long, alias("superceded"))]
+    superseded: Vec<String>,
     /// Link the new Architectural Decision to a previous Architectural Decision Record
     #[arg(short, long)]
     link: Vec<String>,
@@ -30,7 +30,7 @@ struct NewAdrContext {
     number: i32,
     title: String,
     date: String,
-    superceded: Vec<String>,
+    superseded: Vec<String>,
     linked: Vec<String>,
 }
 
@@ -40,8 +40,8 @@ pub(crate) fn run(args: &NewArgs) -> Result<()> {
 
     let title = args.title.join(" ");
 
-    let superceded = args
-        .superceded
+    let superseded = args
+        .superseded
         .iter()
         .map(|adr| {
             let adr_path = find_adr(&adr_dir, adr).expect("No ADR found");
@@ -49,7 +49,7 @@ pub(crate) fn run(args: &NewArgs) -> Result<()> {
 
             remove_status(&adr_path, "Accepted").expect("Unable to update status");
             format!(
-                "Supercedes [{}]({})",
+                "Supersedes [{}]({})",
                 adr_title,
                 adr_path.file_name().unwrap().to_str().unwrap(),
             )
@@ -86,7 +86,7 @@ pub(crate) fn run(args: &NewArgs) -> Result<()> {
         number,
         date: now()?,
         title: title.clone(),
-        superceded,
+        superseded,
         linked,
     };
 

--- a/templates/nygard/new.md
+++ b/templates/nygard/new.md
@@ -5,8 +5,8 @@ Date: {date}
 ## Status
 
 Accepted
-{{ for supercedes in superceded }}
-{supercedes}
+{{ for supersedes in superseded }}
+{supersedes}
 {{- endfor }}
 {{ for link in linked }}
 {link}

--- a/tests/test_adr_tools.rs
+++ b/tests/test_adr_tools.rs
@@ -399,7 +399,7 @@ fn test_generate_graph() {
         .arg("graph")
         .assert()
         .success()
-        .stdout("digraph {\n  node [shape=plaintext]\n  subgraph {\n\t_1 [label=\"1. Record architecture decisions\"; URL=\"0001-record-architecture-decisions.html\"];\n\t_2 [label=\"2. An idea that seems good at the time\"; URL=\"0002-an-idea-that-seems-good-at-the-time.html\"];\n\t_1 -> _2 [style=\"dotted\", weight=1];\n\t_3 [label=\"3. A better idea\"; URL=\"0003-a-better-idea.html\"];\n\t_2 -> _3 [style=\"dotted\", weight=1];\n\t_4 [label=\"4. This will work\"; URL=\"0004-this-will-work.html\"];\n\t_3 -> _4 [style=\"dotted\", weight=1];\n\t_5 [label=\"5. The end\"; URL=\"0005-the-end.html\"];\n\t_4 -> _5 [style=\"dotted\", weight=1];\n  }\n  _3 -> _2 [label=\"Supercedes\", weight=0];\n  _5 -> _3 [label=\"Supercedes\", weight=0];\n}\n");
+        .stdout("digraph {\n  node [shape=plaintext]\n  subgraph {\n\t_1 [label=\"1. Record architecture decisions\"; URL=\"0001-record-architecture-decisions.html\"];\n\t_2 [label=\"2. An idea that seems good at the time\"; URL=\"0002-an-idea-that-seems-good-at-the-time.html\"];\n\t_1 -> _2 [style=\"dotted\", weight=1];\n\t_3 [label=\"3. A better idea\"; URL=\"0003-a-better-idea.html\"];\n\t_2 -> _3 [style=\"dotted\", weight=1];\n\t_4 [label=\"4. This will work\"; URL=\"0004-this-will-work.html\"];\n\t_3 -> _4 [style=\"dotted\", weight=1];\n\t_5 [label=\"5. The end\"; URL=\"0005-the-end.html\"];\n\t_4 -> _5 [style=\"dotted\", weight=1];\n  }\n  _3 -> _2 [label=\"Supersedes\", weight=0];\n  _5 -> _3 [label=\"Supersedes\", weight=0];\n}\n");
 
     Command::cargo_bin("adrs")
         .unwrap()
@@ -411,7 +411,7 @@ fn test_generate_graph() {
         .arg(".xxx")
         .assert()
         .success()
-    .stdout("digraph {\n  node [shape=plaintext]\n  subgraph {\n\t_1 [label=\"1. Record architecture decisions\"; URL=\"http://example.com/0001-record-architecture-decisions.xxx\"];\n\t_2 [label=\"2. An idea that seems good at the time\"; URL=\"http://example.com/0002-an-idea-that-seems-good-at-the-time.xxx\"];\n\t_1 -> _2 [style=\"dotted\", weight=1];\n\t_3 [label=\"3. A better idea\"; URL=\"http://example.com/0003-a-better-idea.xxx\"];\n\t_2 -> _3 [style=\"dotted\", weight=1];\n\t_4 [label=\"4. This will work\"; URL=\"http://example.com/0004-this-will-work.xxx\"];\n\t_3 -> _4 [style=\"dotted\", weight=1];\n\t_5 [label=\"5. The end\"; URL=\"http://example.com/0005-the-end.xxx\"];\n\t_4 -> _5 [style=\"dotted\", weight=1];\n  }\n  _3 -> _2 [label=\"Supercedes\", weight=0];\n  _5 -> _3 [label=\"Supercedes\", weight=0];\n}\n");
+    .stdout("digraph {\n  node [shape=plaintext]\n  subgraph {\n\t_1 [label=\"1. Record architecture decisions\"; URL=\"http://example.com/0001-record-architecture-decisions.xxx\"];\n\t_2 [label=\"2. An idea that seems good at the time\"; URL=\"http://example.com/0002-an-idea-that-seems-good-at-the-time.xxx\"];\n\t_1 -> _2 [style=\"dotted\", weight=1];\n\t_3 [label=\"3. A better idea\"; URL=\"http://example.com/0003-a-better-idea.xxx\"];\n\t_2 -> _3 [style=\"dotted\", weight=1];\n\t_4 [label=\"4. This will work\"; URL=\"http://example.com/0004-this-will-work.xxx\"];\n\t_3 -> _4 [style=\"dotted\", weight=1];\n\t_5 [label=\"5. The end\"; URL=\"http://example.com/0005-the-end.xxx\"];\n\t_4 -> _5 [style=\"dotted\", weight=1];\n  }\n  _3 -> _2 [label=\"Supersedes\", weight=0];\n  _5 -> _3 [label=\"Supersedes\", weight=0];\n}\n");
 }
 
 #[test]

--- a/tests/test_new.rs
+++ b/tests/test_new.rs
@@ -49,7 +49,7 @@ fn test_new_default() {
 
 #[test]
 #[serial_test::serial]
-fn test_new_superceded() {
+fn test_new_superseded() {
     let temp = TempDir::new().unwrap();
     std::env::set_current_dir(temp.path()).unwrap();
     std::env::set_var("EDITOR", "cat");
@@ -76,6 +76,8 @@ fn test_new_superceded() {
     Command::cargo_bin("adrs")
         .unwrap()
         .arg("new")
+        // `superceded` is a hidden alias for the correct spelling: `superseded`
+        // and is maintained for backwards compatibility
         .arg("--superceded")
         .arg("2")
         .arg("Test new")


### PR DESCRIPTION
…nd keep 'supercedes' as a hidden alias

Resolves https://github.com/joshrotenberg/adrs/issues/39