### PR TITLE
Slight changes to template handling

### DIFF
--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::Args;
 
@@ -11,10 +13,26 @@ pub(crate) fn run(_args: &ConfigArgs) -> Result<()> {
         "adrs_bin_dir={}",
         std::env::current_exe().unwrap().parent().unwrap().display()
     );
-    println!("adrs_template_dir=embedded");
+
+    // find the template directory. if ADRS_TEMPLATE is set, use that. otherwise, check
+    // to see if there is an adr dir, and if it has a templates directory, use that.
+    // otherwise use embedded
+    if let Ok(template_file) = std::env::var("ADRS_TEMPLATE") {
+        let mut path = PathBuf::from(template_file);
+        path.pop();
+        println!("adrs_template_dir={}", path.display());
+    } else if let Ok(adr_dir) = read_adr_dir_file() {
+        if adr_dir.join("templates").exists() {
+            println!("adrs_template_dir={}", adr_dir.join("templates").display());
+        } else {
+            println!("adrs_template_dir=embedded");
+        }
+    } else {
+        println!("adrs_template_dir=embedded");
+    }
+
     if let Ok(adr_dir) = read_adr_dir_file() {
         println!("adrs_dir={}", adr_dir.display());
-        return Ok(());
     }
     Ok(())
 }

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -17,3 +17,37 @@ fn test_config() {
                 .and(predicate::str::contains("adrs_template_dir=embedded")),
         );
 }
+
+#[test]
+#[serial_test::serial]
+fn test_config_with_embedded_template() {
+    let temp = TempDir::new().unwrap();
+    std::env::set_current_dir(temp.path()).unwrap();
+    // std::env::set_var(
+    //     "ADRS_TEMPLATE",
+    //     temp.path().join("templates").to_str().unwrap(),
+    // );
+    std::env::set_var("EDITOR", "cat");
+
+    Command::cargo_bin("adrs")
+        .unwrap()
+        .arg("init")
+        .assert()
+        .success();
+
+    Command::cargo_bin("adrs")
+        .unwrap()
+        .arg("new")
+        .arg("Test new")
+        .assert()
+        .success();
+
+    Command::cargo_bin("adrs")
+        .unwrap()
+        .arg("config")
+        .assert()
+        .stdout(
+            predicate::str::contains("adrs_template_dir=embedded")
+                .and(predicate::str::contains("adrs_dir=doc/adr")),
+        );
+}

--- a/tests/test_new.rs
+++ b/tests/test_new.rs
@@ -209,7 +209,7 @@ fn test_new_template() {
     Command::cargo_bin("adrs")
         .unwrap()
         .arg("new")
-        .arg("-T")
+        .arg("-t")
         .arg(custom_location_template_path)
         .arg("Test template custom location")
         .assert()


### PR DESCRIPTION
Some minor changes to the new template feature:

1) Changed the environment variable option to be ADRS_TEMPLATE instead of ADRS_TEMPLATE_DIR since the arg points to the file itself
2) Changed the flag to be lowercase '-t'
3) Changed the behavior to be the following:
   * if a file is explicitly specified via the flag or ADRS_TEMPLATE, that file is used as the template
   * if no flag or env is specified, use $adr_dir/templates/template.md 
   * if no #adr_dir/templates/template.md exists, use the built in default template

Fixes #47.

@lbenezriravin Let me know what you think about these changes when you have time.
