### PR TITLE
feat: add MADR 4.0.0 support

### DIFF
--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -43,6 +43,14 @@ enum Commands {
         /// Link to another ADR (format: "TARGET:KIND:REVERSE_KIND")
         #[arg(short, long)]
         link: Option<String>,
+
+        /// Template format to use [default: nygard]
+        #[arg(short, long, value_name = "FORMAT")]
+        format: Option<String>,
+
+        /// Initial status [default: Proposed]
+        #[arg(long)]
+        status: Option<String>,
     },
 
     /// Edit an existing ADR
@@ -140,7 +148,9 @@ fn main() -> Result<()> {
             title,
             supersedes,
             link,
-        } => commands::new(&root, cli.ng, title, supersedes, link),
+            format,
+            status,
+        } => commands::new(&root, cli.ng, title, supersedes, link, format, status),
         Commands::Edit { adr } => commands::edit(&root, &adr),
         Commands::List => commands::list(&root),
         Commands::Link {


### PR DESCRIPTION
## Summary

Adds support for MADR (Markdown Any Decision Records) 4.0.0 format.

## Changes

### New Adr Fields (MADR 4.0.0)
- `decision_makers`: List of people who made the decision
- `consulted`: People consulted for input (two-way communication)
- `informed`: People kept up-to-date (one-way communication)

### MADR 4.0.0 Template
Updated the MADR template to match the official 4.0.0 format:
- YAML frontmatter with status, date, decision-makers, consulted, informed
- Full template structure with all optional sections
- Comments indicating optional elements

### CLI Improvements
- `--format` / `-f` flag for `adrs new` to select template format (nygard or madr)
- `--status` flag for `adrs new` to set initial status

### Example Usage

```bash
# Create an ADR using MADR 4.0.0 format
adrs new -f madr "Use Kubernetes for Orchestration"

# Create with custom status
adrs new --status accepted "Use PostgreSQL"
```

### Generated MADR Output

```markdown
---
status: proposed
date: 2026-01-21
decision-makers:
  - Alice
  - Bob
consulted:
  - Carol
informed:
  - Dave
---

# Use Kubernetes for Orchestration

## Context and Problem Statement
...
```

## Tests
- 261 tests pass (246 unit + 15 integration)
- Added MADR-specific tests for types, parsing, and templates

## Closes
- Closes #57