### PR TITLE
feat: add template variants (full, minimal, bare)

### DIFF
--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -25,5 +25,5 @@ pub use config::{Config, ConfigMode};
 pub use error::{Error, Result};
 pub use parse::Parser;
 pub use repository::Repository;
-pub use template::{Template, TemplateEngine, TemplateFormat};
+pub use template::{Template, TemplateEngine, TemplateFormat, TemplateVariant};
 pub use types::{Adr, AdrLink, AdrStatus, LinkKind};

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Adr, AdrLink, AdrStatus, Config, ConfigMode, Error, LinkKind, Parser, Result, Template,
-    TemplateEngine, TemplateFormat,
+    TemplateEngine, TemplateFormat, TemplateVariant,
 };
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
@@ -115,6 +115,12 @@ impl Repository {
     /// Set the template format.
     pub fn with_template_format(mut self, format: TemplateFormat) -> Self {
         self.template_engine = self.template_engine.with_format(format);
+        self
+    }
+
+    /// Set the template variant.
+    pub fn with_template_variant(mut self, variant: TemplateVariant) -> Self {
+        self.template_engine = self.template_engine.with_variant(variant);
         self
     }
 

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -1,9 +1,10 @@
 //! New ADR command.
 
-use adrs_core::{AdrStatus, LinkKind, Repository, TemplateFormat};
+use adrs_core::{AdrStatus, LinkKind, Repository, TemplateFormat, TemplateVariant};
 use anyhow::{Context, Result};
 use std::path::Path;
 
+#[allow(clippy::too_many_arguments)]
 pub fn new(
     root: &Path,
     _ng: bool,
@@ -11,6 +12,7 @@ pub fn new(
     supersedes: Option<u32>,
     link: Option<String>,
     format: Option<String>,
+    variant: Option<String>,
     status: Option<String>,
 ) -> Result<()> {
     // Parse template format if specified
@@ -19,6 +21,14 @@ pub fn new(
             .context("Invalid template format. Use 'nygard' or 'madr'.")?
     } else {
         TemplateFormat::default()
+    };
+
+    // Parse template variant if specified
+    let template_variant = if let Some(ref var) = variant {
+        var.parse::<TemplateVariant>()
+            .context("Invalid template variant. Use 'full', 'minimal', or 'bare'.")?
+    } else {
+        TemplateVariant::default()
     };
 
     // Parse status if specified
@@ -30,7 +40,8 @@ pub fn new(
 
     let repo = Repository::open(root)
         .context("ADR repository not found. Run 'adrs init' first.")?
-        .with_template_format(template_format);
+        .with_template_format(template_format)
+        .with_template_variant(template_variant);
 
     let (mut adr, path) = if let Some(superseded) = supersedes {
         repo.supersede(&title, superseded)

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -48,6 +48,10 @@ enum Commands {
         #[arg(short, long, value_name = "FORMAT")]
         format: Option<String>,
 
+        /// Template variant [default: full]
+        #[arg(short, long, value_name = "VARIANT")]
+        variant: Option<String>,
+
         /// Initial status [default: Proposed]
         #[arg(long)]
         status: Option<String>,
@@ -149,8 +153,11 @@ fn main() -> Result<()> {
             supersedes,
             link,
             format,
+            variant,
             status,
-        } => commands::new(&root, cli.ng, title, supersedes, link, format, status),
+        } => commands::new(
+            &root, cli.ng, title, supersedes, link, format, variant, status,
+        ),
         Commands::Edit { adr } => commands::edit(&root, &adr),
         Commands::List => commands::list(&root),
         Commands::Link {


### PR DESCRIPTION
## Summary

Add template variants to support different levels of detail in ADR templates.

## Template Variants

| Variant | Description |
|---------|-------------|
| `full` | Complete template with all sections and guidance text (default) |
| `minimal` | Essential sections only, no guidance |
| `bare` | Just the structure, no content |

## Usage

```bash
# Create with minimal template
adrs new -v minimal "Quick Decision"

# Create MADR with bare template
adrs new -f madr --variant bare "Empty Template"

# Explicit full (same as default)
adrs new -f nygard -v full "Detailed Decision"
```

## CLI Changes

New `--variant` / `-v` flag for `adrs new`:

```
Options:
  -f, --format <FORMAT>    Template format to use [default: nygard]
  -v, --variant <VARIANT>  Template variant [default: full]
```

## API Changes

- `TemplateVariant` enum: `Full`, `Minimal`, `Bare`
- `Template::builtin_with_variant(format, variant)`
- `TemplateEngine::with_variant(variant)`
- `Repository::with_template_variant(variant)`

## Templates Added

- `nygard-minimal` - Nygard format, essential sections
- `nygard-bare` - Nygard format, just structure
- `madr-minimal` - MADR format, core sections only
- `madr-bare` - MADR format, minimal frontmatter and structure

## Tests

302 tests total (261 lib + 26 CLI + 15 integration)

New tests:
- TemplateVariant parsing and display
- Variant template rendering for all combinations
- Template engine variant support

## Closes

Closes #58