### PR TITLE
chore: set up release-plz for automated releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,34 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: release-plz
+  cancel-in-progress: false
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.COMMITTER_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          # Use COMMITTER_TOKEN (PAT) so tag pushes trigger the Release workflow
+          # GITHUB_TOKEN actions don't trigger other workflows (security feature)
+          GITHUB_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,22 @@
+[workspace]
+# Changelog configuration
+changelog_update = true
+git_tag_enable = true
+# Validate semantic versioning
+semver_check = true
+# PR configuration
+pr_labels = ["release"]
+
+# Core library
+[[package]]
+name = "adrs-core"
+publish = true
+git_release_enable = false
+git_tag_name = "adrs-core-v{{ version }}"
+
+# CLI binary - let cargo-dist handle GitHub releases
+[[package]]
+name = "adrs"
+publish = true
+git_release_enable = true
+git_tag_name = "v{{ version }}"


### PR DESCRIPTION
## Summary

Set up [release-plz](https://release-plz.iec.io/) to automate versioning, changelog generation, and crates.io publishing.

## What release-plz Does

- Analyzes commits since last release using conventional commits
- Automatically bumps versions based on commit types (feat, fix, etc.)
- Generates/updates CHANGELOG.md
- Creates release PRs with version bumps and changelog updates
- Publishes to crates.io on merge

## Files Added

### `.github/workflows/release-plz.yml`
GitHub Action that runs on push to main:
- Checks out repo with full history
- Runs release-plz to create release PRs or publish

### `release-plz.toml`
Configuration for the workspace:
- `adrs-core`: Library, publish to crates.io only
- `adrs`: CLI binary, publish to crates.io and create GitHub release

## Integration with cargo-dist

- release-plz handles: version bumps, changelogs, crates.io publishing
- cargo-dist handles: binary artifacts, installers, GitHub release assets
- When release-plz creates a GitHub release for `adrs`, cargo-dist is triggered

## Required Secrets

You'll need to add these repository secrets:
- `COMMITTER_TOKEN`: GitHub PAT with repo permissions (so tag pushes trigger cargo-dist)
- `CARGO_REGISTRY_TOKEN`: crates.io API token for publishing

## Closes

Closes #62