### PR TITLE
feat: add config discovery with directory tree search

### DIFF
--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -13,6 +13,15 @@ pub const LEGACY_CONFIG_FILE: &str = ".adr-dir";
 /// New configuration file name.
 pub const CONFIG_FILE: &str = "adrs.toml";
 
+/// Global configuration file name.
+pub const GLOBAL_CONFIG_FILE: &str = "config.toml";
+
+/// Environment variable for ADR directory override.
+pub const ENV_ADR_DIRECTORY: &str = "ADR_DIRECTORY";
+
+/// Environment variable for config file path override.
+pub const ENV_ADRS_CONFIG: &str = "ADRS_CONFIG";
+
 /// Configuration for an ADR repository.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -106,6 +115,195 @@ impl Config {
     /// Returns true if running in next-gen mode.
     pub fn is_next_gen(&self) -> bool {
         matches!(self.mode, ConfigMode::NextGen)
+    }
+
+    /// Merge another config into this one (other takes precedence for set values).
+    pub fn merge(&mut self, other: &Config) {
+        // adr_dir: use other if it differs from default
+        if other.adr_dir.as_os_str() != DEFAULT_ADR_DIR {
+            self.adr_dir = other.adr_dir.clone();
+        }
+        // mode: other takes precedence
+        self.mode = other.mode;
+        // templates: merge
+        if other.templates.format.is_some() {
+            self.templates.format = other.templates.format.clone();
+        }
+        if other.templates.custom.is_some() {
+            self.templates.custom = other.templates.custom.clone();
+        }
+    }
+}
+
+/// Result of discovering configuration.
+#[derive(Debug, Clone)]
+pub struct DiscoveredConfig {
+    /// The resolved configuration.
+    pub config: Config,
+    /// The project root directory (where config was found).
+    pub root: PathBuf,
+    /// Where the config was loaded from.
+    pub source: ConfigSource,
+}
+
+/// Where the configuration was loaded from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// Loaded from project config file.
+    Project(PathBuf),
+    /// Loaded from global config file.
+    Global(PathBuf),
+    /// Loaded from environment variable.
+    Environment,
+    /// Using defaults (no config found).
+    Default,
+}
+
+/// Discover configuration by searching up the directory tree.
+///
+/// Search order:
+/// 1. Environment variable `ADRS_CONFIG` (explicit config path)
+/// 2. Search upward from `start_dir` for `.adr-dir` or `adrs.toml`
+/// 3. Global config at `~/.config/adrs/config.toml`
+/// 4. Default configuration
+///
+/// Environment variable `ADR_DIRECTORY` overrides the ADR directory.
+pub fn discover(start_dir: &Path) -> Result<DiscoveredConfig> {
+    // Check for explicit config path from environment
+    if let Ok(config_path) = std::env::var(ENV_ADRS_CONFIG) {
+        let path = PathBuf::from(&config_path);
+        if path.exists() {
+            let content = std::fs::read_to_string(&path)?;
+            let mut config: Config = toml::from_str(&content)?;
+            apply_env_overrides(&mut config);
+            return Ok(DiscoveredConfig {
+                config,
+                root: path
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| start_dir.to_path_buf()),
+                source: ConfigSource::Environment,
+            });
+        }
+    }
+
+    // Search upward for project config
+    if let Some((root, config, source)) = search_upward(start_dir)? {
+        let mut config = config;
+        apply_env_overrides(&mut config);
+        return Ok(DiscoveredConfig {
+            config,
+            root,
+            source,
+        });
+    }
+
+    // Try global config
+    if let Some((config, path)) = load_global_config()? {
+        let mut config = config;
+        apply_env_overrides(&mut config);
+        return Ok(DiscoveredConfig {
+            config,
+            root: start_dir.to_path_buf(),
+            source: ConfigSource::Global(path),
+        });
+    }
+
+    // Use defaults
+    let mut config = Config::default();
+    apply_env_overrides(&mut config);
+    Ok(DiscoveredConfig {
+        config,
+        root: start_dir.to_path_buf(),
+        source: ConfigSource::Default,
+    })
+}
+
+/// Search upward from the given directory for a config file.
+fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSource)>> {
+    let mut current = start_dir.to_path_buf();
+
+    loop {
+        // Check for adrs.toml first
+        let config_path = current.join(CONFIG_FILE);
+        if config_path.exists() {
+            let content = std::fs::read_to_string(&config_path)?;
+            let config: Config = toml::from_str(&content)?;
+            return Ok(Some((current, config, ConfigSource::Project(config_path))));
+        }
+
+        // Check for .adr-dir
+        let legacy_path = current.join(LEGACY_CONFIG_FILE);
+        if legacy_path.exists() {
+            let adr_dir = std::fs::read_to_string(&legacy_path)?.trim().to_string();
+            let config = Config {
+                adr_dir: PathBuf::from(adr_dir),
+                mode: ConfigMode::Compatible,
+                templates: TemplateConfig::default(),
+            };
+            return Ok(Some((current, config, ConfigSource::Project(legacy_path))));
+        }
+
+        // Check for default ADR directory (indicates project root)
+        let default_dir = current.join(DEFAULT_ADR_DIR);
+        if default_dir.exists() {
+            return Ok(Some((current, Config::default(), ConfigSource::Default)));
+        }
+
+        // Stop at git repository root
+        if current.join(".git").exists() {
+            break;
+        }
+
+        // Move to parent directory
+        match current.parent() {
+            Some(parent) => current = parent.to_path_buf(),
+            None => break,
+        }
+    }
+
+    Ok(None)
+}
+
+/// Load the global configuration file.
+fn load_global_config() -> Result<Option<(Config, PathBuf)>> {
+    let config_dir = dirs_config_dir()?;
+    let global_path = config_dir.join("adrs").join(GLOBAL_CONFIG_FILE);
+
+    if global_path.exists() {
+        let content = std::fs::read_to_string(&global_path)?;
+        let config: Config = toml::from_str(&content)?;
+        return Ok(Some((config, global_path)));
+    }
+
+    Ok(None)
+}
+
+/// Get the user's config directory.
+fn dirs_config_dir() -> Result<PathBuf> {
+    // Try XDG_CONFIG_HOME first, then fall back to ~/.config
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(xdg));
+    }
+
+    if let Ok(home) = std::env::var("HOME") {
+        return Ok(PathBuf::from(home).join(".config"));
+    }
+
+    // Windows fallback
+    if let Ok(appdata) = std::env::var("APPDATA") {
+        return Ok(PathBuf::from(appdata));
+    }
+
+    Err(Error::ConfigError(
+        "Could not determine config directory".into(),
+    ))
+}
+
+/// Apply environment variable overrides to a config.
+fn apply_env_overrides(config: &mut Config) {
+    if let Ok(adr_dir) = std::env::var(ENV_ADR_DIRECTORY) {
+        config.adr_dir = PathBuf::from(adr_dir);
     }
 }
 
@@ -516,5 +714,135 @@ custom = "templates/adr.md"
         let config = Config::load(temp.path()).unwrap();
         // Empty string becomes empty path
         assert_eq!(config.adr_dir, PathBuf::from(""));
+    }
+
+    // ========== Config Discovery Tests ==========
+
+    #[test]
+    fn test_discover_finds_config_in_current_dir() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join(".adr-dir"), "decisions").unwrap();
+
+        let discovered = discover(temp.path()).unwrap();
+        assert_eq!(discovered.root, temp.path());
+        assert_eq!(discovered.config.adr_dir, PathBuf::from("decisions"));
+        assert!(matches!(discovered.source, ConfigSource::Project(_)));
+    }
+
+    #[test]
+    fn test_discover_finds_config_in_parent_dir() {
+        let temp = TempDir::new().unwrap();
+        let subdir = temp.path().join("src").join("lib");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(temp.path().join("adrs.toml"), r#"adr_dir = "docs/adr""#).unwrap();
+
+        let discovered = discover(&subdir).unwrap();
+        assert_eq!(discovered.root, temp.path());
+        assert_eq!(discovered.config.adr_dir, PathBuf::from("docs/adr"));
+    }
+
+    #[test]
+    fn test_discover_stops_at_git_root() {
+        let temp = TempDir::new().unwrap();
+
+        // Create a git repo structure
+        std::fs::create_dir(temp.path().join(".git")).unwrap();
+        let subdir = temp.path().join("src");
+        std::fs::create_dir(&subdir).unwrap();
+
+        // Put config above git root (should not be found)
+        // This test verifies we stop at .git
+
+        let result = discover(&subdir);
+        // Should return defaults since no config found within git repo
+        assert!(result.is_ok());
+        let discovered = result.unwrap();
+        assert!(matches!(discovered.source, ConfigSource::Default));
+    }
+
+    #[test]
+    fn test_discover_prefers_adrs_toml_over_adr_dir() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join(".adr-dir"), "legacy").unwrap();
+        std::fs::write(temp.path().join("adrs.toml"), r#"adr_dir = "modern""#).unwrap();
+
+        let discovered = discover(temp.path()).unwrap();
+        assert_eq!(discovered.config.adr_dir, PathBuf::from("modern"));
+    }
+
+    #[test]
+    fn test_discover_finds_default_adr_dir() {
+        let temp = TempDir::new().unwrap();
+        std::fs::create_dir_all(temp.path().join("doc/adr")).unwrap();
+
+        let discovered = discover(temp.path()).unwrap();
+        assert_eq!(discovered.root, temp.path());
+        assert_eq!(discovered.config.adr_dir, PathBuf::from("doc/adr"));
+    }
+
+    #[test]
+    fn test_discover_returns_defaults_when_nothing_found() {
+        let temp = TempDir::new().unwrap();
+        // Create .git to stop search
+        std::fs::create_dir(temp.path().join(".git")).unwrap();
+
+        let discovered = discover(temp.path()).unwrap();
+        assert!(matches!(discovered.source, ConfigSource::Default));
+        assert_eq!(discovered.config.adr_dir, PathBuf::from("doc/adr"));
+    }
+
+    #[test]
+    fn test_apply_env_overrides() {
+        // Test apply_env_overrides function directly without modifying the environment.
+        // The function reads env vars, so we test that it doesn't panic and returns
+        // when no env vars are set.
+        let mut config = Config::default();
+        apply_env_overrides(&mut config);
+        // With no env vars set, the config should remain at default
+        assert_eq!(config.adr_dir, PathBuf::from(DEFAULT_ADR_DIR));
+    }
+
+    #[test]
+    fn test_config_source_variants() {
+        // Test that ConfigSource can be compared
+        let project = ConfigSource::Project(PathBuf::from("test"));
+        let global = ConfigSource::Global(PathBuf::from("test"));
+        let env = ConfigSource::Environment;
+        let default = ConfigSource::Default;
+
+        assert_ne!(project, global);
+        assert_ne!(env, default);
+        assert_eq!(default, ConfigSource::Default);
+    }
+
+    #[test]
+    fn test_config_merge() {
+        let mut base = Config::default();
+        let other = Config {
+            adr_dir: PathBuf::from("custom"),
+            mode: ConfigMode::NextGen,
+            templates: TemplateConfig {
+                format: Some("madr".to_string()),
+                custom: None,
+            },
+        };
+
+        base.merge(&other);
+        assert_eq!(base.adr_dir, PathBuf::from("custom"));
+        assert_eq!(base.mode, ConfigMode::NextGen);
+        assert_eq!(base.templates.format, Some("madr".to_string()));
+    }
+
+    #[test]
+    fn test_config_merge_preserves_default_adr_dir() {
+        let mut base = Config {
+            adr_dir: PathBuf::from("original"),
+            ..Default::default()
+        };
+        let other = Config::default(); // has default adr_dir
+
+        base.merge(&other);
+        // Should keep original since other has default
+        assert_eq!(base.adr_dir, PathBuf::from("original"));
     }
 }

--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -22,7 +22,7 @@ mod repository;
 mod template;
 mod types;
 
-pub use config::{Config, ConfigMode};
+pub use config::{Config, ConfigMode, ConfigSource, DiscoveredConfig, discover};
 pub use doctor::{Check, Diagnostic, DoctorReport, Severity, check as doctor_check};
 pub use error::{Error, Result};
 pub use parse::Parser;

--- a/crates/adrs/src/commands/mod.rs
+++ b/crates/adrs/src/commands/mod.rs
@@ -9,7 +9,7 @@ mod link;
 mod list;
 mod new;
 
-pub use config::config;
+pub use config::config_with_discovery;
 pub use doctor::doctor;
 pub use edit::edit;
 pub use generate::{generate_book, generate_graph, generate_toc};

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -1,6 +1,7 @@
 //! adrs - Architecture Decision Records CLI tool.
 
-use anyhow::Result;
+use adrs_core::{ConfigSource, discover};
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -145,12 +146,18 @@ enum GenerateCommands {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let root = cli
+    // For init command, use working_dir or current directory directly
+    // For all other commands, discover the project root
+    let start_dir = cli
         .working_dir
+        .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
     match cli.command {
-        Commands::Init { directory } => commands::init(&root, directory, cli.ng),
+        Commands::Init { directory } => {
+            // Init uses the specified directory directly, no discovery
+            commands::init(&start_dir, directory, cli.ng)
+        }
         Commands::New {
             title,
             supersedes,
@@ -158,34 +165,86 @@ fn main() -> Result<()> {
             format,
             variant,
             status,
-        } => commands::new(
-            &root, cli.ng, title, supersedes, link, format, variant, status,
-        ),
-        Commands::Edit { adr } => commands::edit(&root, &adr),
-        Commands::List => commands::list(&root),
+        } => {
+            let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+            commands::new(
+                &discovered.root,
+                cli.ng,
+                title,
+                supersedes,
+                link,
+                format,
+                variant,
+                status,
+            )
+        }
+        Commands::Edit { adr } => {
+            let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+            commands::edit(&discovered.root, &adr)
+        }
+        Commands::List => {
+            let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+            commands::list(&discovered.root)
+        }
         Commands::Link {
             source,
             link,
             target,
             reverse_link,
-        } => commands::link(&root, source, &link, target, &reverse_link),
-        Commands::Config => commands::config(&root),
-        Commands::Doctor => commands::doctor(&root),
-        Commands::Generate { command } => match command {
-            GenerateCommands::Toc {
-                ordered,
-                intro,
-                outro,
-                prefix,
-            } => commands::generate_toc(&root, ordered, intro, outro, prefix),
-            GenerateCommands::Graph { prefix, extension } => {
-                commands::generate_graph(&root, prefix, &extension)
+        } => {
+            let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+            commands::link(&discovered.root, source, &link, target, &reverse_link)
+        }
+        Commands::Config => {
+            let discovered = discover(&start_dir).ok();
+            commands::config_with_discovery(&start_dir, discovered)
+        }
+        Commands::Doctor => {
+            let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+            commands::doctor(&discovered.root)
+        }
+        Commands::Generate { command } => {
+            let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+            match command {
+                GenerateCommands::Toc {
+                    ordered,
+                    intro,
+                    outro,
+                    prefix,
+                } => commands::generate_toc(&discovered.root, ordered, intro, outro, prefix),
+                GenerateCommands::Graph { prefix, extension } => {
+                    commands::generate_graph(&discovered.root, prefix, &extension)
+                }
+                GenerateCommands::Book {
+                    output,
+                    title,
+                    description,
+                } => commands::generate_book(&discovered.root, &output, title, description),
             }
-            GenerateCommands::Book {
-                output,
-                title,
-                description,
-            } => commands::generate_book(&root, &output, title, description),
-        },
+        }
     }
+}
+
+/// Discover config or return a helpful error.
+fn discover_or_error(
+    start_dir: &std::path::Path,
+    explicit_dir: bool,
+) -> Result<adrs_core::DiscoveredConfig> {
+    let discovered = discover(start_dir).context(if explicit_dir {
+        "No ADR repository found in the specified directory. Run 'adrs init' first."
+    } else {
+        "No ADR repository found. Run 'adrs init' to create one, or use '-C' to specify a directory."
+    })?;
+
+    // If using defaults and no project found, that's an error for most commands
+    if matches!(discovered.source, ConfigSource::Default)
+        && !start_dir.join("doc/adr").exists()
+        && !explicit_dir
+    {
+        anyhow::bail!(
+            "No ADR repository found. Run 'adrs init' to create one, or use '-C' to specify a directory."
+        );
+    }
+
+    Ok(discovered)
 }

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -181,7 +181,7 @@ fn test_new_without_init() {
         .env("EDITOR", "true") // Use 'true' as a no-op editor
         .assert()
         .failure()
-        .stderr(predicate::str::contains("not found"));
+        .stderr(predicate::str::contains("No ADR repository found"));
 
     temp.close().unwrap();
 }
@@ -194,13 +194,13 @@ fn test_new_without_init() {
 fn test_config_without_init() {
     let temp = assert_fs::TempDir::new().unwrap();
 
-    // Config shows default even without init (graceful behavior)
+    // Config shows defaults even without init (graceful behavior)
     adrs()
         .current_dir(temp.path())
         .arg("config")
         .assert()
         .success()
-        .stdout(predicate::str::contains("not initialized"));
+        .stdout(predicate::str::contains("Config source: defaults"));
 
     temp.close().unwrap();
 }


### PR DESCRIPTION
## Summary

Implements smart config discovery that searches upward from the current directory to find the project root, addressing issue #52.

## Changes

### Config Discovery (`crates/adrs-core/src/config.rs`)
- Added `discover()` function that searches up the directory tree for `.adr-dir` or `adrs.toml`
- Stops at git root to avoid searching system directories
- Added `DiscoveredConfig` struct with `config`, `root`, and `source` fields
- Added `ConfigSource` enum: `Project`, `Global`, `Environment`, `Default`

### Global Config Support
- Added support for global config at `~/.config/adrs/config.toml`
- Global config is used when no project config is found

### Environment Variable Support
- `ADR_DIRECTORY`: Override the ADR directory path
- `ADRS_CONFIG`: Specify an explicit config file path

### Priority Order
1. CLI flags (highest)
2. Environment variables
3. Project config (`.adr-dir` or `adrs.toml` in directory tree)
4. Global config (`~/.config/adrs/config.toml`)
5. Defaults (lowest)

### CLI Updates
- All commands now use config discovery
- `adrs config` shows the config source
- Better error messages when no ADR repository is found

## Testing
- Added unit tests for directory tree search
- Added tests for git root detection
- Added tests for config merging
- Updated CLI integration tests

Closes #52