### PR TITLE
fix: add version to adrs-core dependency for cargo publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Bug Fixes
+
+- Align MADR templates with official adr/madr repository
+
+### Features
+
+- Add doctor command for repository health checks
+- Add Docker image support
+## [0.4.0] - 2026-01-22
+
+### Documentation
+
+- Add ADRs for v2 rewrite decisions
+
+### Features
+
+- Rework CI and add Windows binary support
+- V2 rewrite with library-first architecture
+- Add MADR 4.0.0 support
+- Add template variants (full, minimal, bare)
+
+### Miscellaneous
+
+- Set up release-plz for automated releases
+
+### Testing
+
+- Add comprehensive test suite for adrs-core
+- Add CLI integration tests
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,51 @@
+# git-cliff configuration for adrs
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") | trim_start_matches(pat="adrs-core-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous" },
+    { body = ".*security", group = "Security" },
+]
+protect_breaking_commits = false
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"
+
+# Skip old pre-v2 releases and non-version tags
+skip_tags = "(v0\\.[012]\\..*)|(help)|(main)"

--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -13,7 +13,7 @@ name = "adrs"
 path = "src/main.rs"
 
 [dependencies]
-adrs-core = { path = "../adrs-core" }
+adrs-core = { path = "../adrs-core", version = "0.4.0" }
 anyhow.workspace = true
 clap.workspace = true
 edit.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 # Changelog configuration
 changelog_update = true
+changelog_config = "cliff.toml"
 git_tag_enable = true
 # Validate semantic versioning
 semver_check = true


### PR DESCRIPTION
## Summary

Fixes the release-plz CI failure by adding the required version to the adrs-core dependency.

## Changes

### Cargo.toml Fix
- Added explicit version (`0.4.0`) to `adrs-core` dependency in `crates/adrs/Cargo.toml`
- Required by cargo publish since path-only dependencies are removed during publishing

### Git-cliff Integration
- Added `cliff.toml` for changelog generation with conventional commits
- Updated `release-plz.toml` to use git-cliff for changelog formatting
- Generated `CHANGELOG.md` starting from v0.3.0 (v2 rewrite)
- Skips old pre-v2 releases that don't follow conventional commit format

## CI Error Fixed
```
error: failed to verify manifest at `/home/runner/work/adrs/adrs/crates/adrs/Cargo.toml`

Caused by:
  all dependencies must have a version requirement specified when publishing.
  dependency `adrs-core` does not specify a version
```