### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adrs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "fuzzy-matcher",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.5.0] - 2026-01-22
+
+### Bug Fixes
+
+- Align MADR templates with official adr/madr repository
+
+### Features
+
+- Add doctor command for repository health checks
+- Add config discovery with directory tree search
+

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.5.0] - 2026-01-22
+
+### Bug Fixes
+
+- Add version to adrs-core dependency for cargo publish
+
+### Features
+
+- V2 rewrite with library-first architecture
+- Add MADR 4.0.0 support
+- Add template variants (full, minimal, bare)
+- Add doctor command for repository health checks
+- Add config discovery with directory tree search
+
+### Testing
+
+- Add CLI integration tests
+

--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -13,7 +13,11 @@ name = "adrs"
 path = "src/main.rs"
 
 [dependencies]
+<<<<<<< Updated upstream
 adrs-core = { path = "../adrs-core" }
+=======
+adrs-core = { path = "../adrs-core", version = "0.5.0" }
+>>>>>>> Stashed changes
 anyhow.workspace = true
 clap.workspace = true
 edit.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `adrs`: 0.4.0 -> 0.5.0

### ⚠ `adrs-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant TemplateVariant:BareMinimal in /tmp/.tmpp2K3wh/adrs/crates/adrs-core/src/template.rs:59
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.5.0] - 2026-01-22

### Bug Fixes

- Align MADR templates with official adr/madr repository

### Features

- Add doctor command for repository health checks
- Add config discovery with directory tree search
</blockquote>

## `adrs`

<blockquote>

## [0.5.0] - 2026-01-22

### Bug Fixes

- Add version to adrs-core dependency for cargo publish

### Features

- V2 rewrite with library-first architecture
- Add MADR 4.0.0 support
- Add template variants (full, minimal, bare)
- Add doctor command for repository health checks
- Add config discovery with directory tree search

### Testing

- Add CLI integration tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).