### PR TITLE
docs: rewrite book and improve CLI help for v2

### DIFF
--- a/book/.mdbook-lint.toml
+++ b/book/.mdbook-lint.toml
@@ -1,0 +1,21 @@
+# mdbook-lint configuration
+
+[rules]
+# Disable line length check (markdown often has long lines for URLs, etc.)
+MD013 = false
+
+# Allow duplicate headings (common in command docs with repeated sections)
+MD024 = false
+MDBOOK004 = false
+
+# Allow tables without blank lines (common in markdown)
+MD058 = false
+
+# Disable proper names check (too aggressive)
+MD044 = false
+
+# Allow lists without preceding blank lines
+MD032 = false
+
+# Disable hidden code prefix suggestions (info level, not errors)
+MDBOOK017 = false

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["josh rotenberg"]
 language = "en"
-multilingual = false
 src = "src"
 title = "adrs documentation"
 
@@ -17,3 +16,8 @@ enable = true
 [preprocessor.toc]
 command = "mdbook-toc"
 renderer = ["html"]
+
+# Lint is run manually: mdbook-lint book/src
+# [preprocessor.lint]
+# command = "mdbook-lint"
+# renderer = ["html"]

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -1,7 +1,90 @@
 # Introduction
 
-`adrs` is a command line tool for creating and managing [Architectural Decision Records](https://adr.github.io).
-It is a Rust rewrite of the original [adr-tools](https://github.com/npryce/adr-tools), attempting to balance backwards
-compatibilty with new features.
+`adrs` is a command line tool for creating and managing [Architecture Decision Records](https://adr.github.io) (ADRs).
 
-See the [Resources](./resources.md) section for more information about ADRs in general.
+## What are ADRs?
+
+Architecture Decision Records are short documents that capture important architectural decisions made during a project. Each ADR describes a single decision, including the context, the decision itself, and its consequences.
+
+## Features
+
+- **adr-tools compatible**: Works with existing ADR repositories created by [adr-tools](https://github.com/npryce/adr-tools)
+- **Multiple formats**: Supports both Nygard (classic) and [MADR 4.0.0](https://adr.github.io/madr/) formats
+- **Template variants**: Full, minimal, and bare templates for each format
+- **Cross-platform**: Binaries available for Linux, macOS, and Windows
+- **Library support**: Use `adrs-core` as a Rust library in your own tools
+
+## Quick Start
+
+### Installation
+
+Using the shell installer (Linux/macOS):
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/joshrotenberg/adrs/releases/latest/download/adrs-installer.sh | sh
+```
+
+Using PowerShell (Windows):
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/joshrotenberg/adrs/releases/latest/download/adrs-installer.ps1 | iex"
+```
+
+Using Homebrew:
+
+```sh
+brew install joshrotenberg/brew/adrs
+```
+
+Using Cargo:
+
+```sh
+cargo install adrs
+```
+
+### Initialize a Repository
+
+```sh
+adrs init
+```
+
+This creates:
+- A `.adr-dir` file pointing to `doc/adr`
+- The `doc/adr` directory
+- An initial ADR: `0001-record-architecture-decisions.md`
+
+### Create a New ADR
+
+```sh
+adrs new "Use PostgreSQL for persistence"
+```
+
+This opens your editor with a new ADR from the default template. Save and close to create the record.
+
+### List ADRs
+
+```sh
+adrs list
+```
+
+### Link ADRs
+
+```sh
+adrs link 2 "Amends" 1 "Amended by"
+```
+
+## Migration from adr-tools
+
+`adrs` is designed to be a drop-in replacement for adr-tools. Your existing ADR repository will work without changes:
+
+1. Install `adrs`
+2. Run commands as usual - `adrs` reads the existing `.adr-dir` file and ADR documents
+
+For new features like MADR format or YAML frontmatter, see the [Configuration](./configuration.md) chapter.
+
+## Next Steps
+
+- [Configuration](./configuration.md) - Learn about configuration options
+- [Commands](./commands/README.md) - Detailed command reference
+- [Templates](./templates.md) - Customize ADR templates
+- [Formats](./formats.md) - Nygard vs MADR format comparison

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,7 +1,10 @@
 # Summary
 
 - [Introduction](./README.md)
+- [Installation](./installation.md)
 - [Configuration](./configuration.md)
+- [Formats](./formats.md)
+- [Templates](./templates.md)
 - [Commands](./commands/README.md)
   - [init](./commands/init.md)
   - [new](./commands/new.md)
@@ -9,8 +12,9 @@
   - [link](./commands/link.md)
   - [list](./commands/list.md)
   - [config](./commands/config.md)
+  - [doctor](./commands/doctor.md)
   - [generate](./commands/generate.md)
+- [Library Usage](./library.md)
 - [Resources](./resources.md)
 - [Contributing](./contributing.md)
-- [Project ADRs](./adrs.md)
 - [License](./license.md)

--- a/book/src/adrs.md
+++ b/book/src/adrs.md
@@ -1,9 +1,0 @@
-# Project ADRs
-
-<!-- toc -->
-
-{{#include ../../doc/adr/0001-record-architecture-decisions.md}}
-
-{{#include ../../doc/adr/0002-rewrite-it-in-rust.md}}
-
-{{#include ../../doc/adr/0003-use-mdbook-for-documentation.md}}

--- a/book/src/caveats.md
+++ b/book/src/caveats.md
@@ -1,1 +1,0 @@
-# Caveats

--- a/book/src/commands/README.md
+++ b/book/src/commands/README.md
@@ -1,17 +1,50 @@
 # Commands
 
-`adrs` is a command line tool for creating and managing Architectural Decision Records based on
-the original [adr-tools](https://github.com/npryce/adr-tools).
+`adrs` provides commands for managing Architecture Decision Records.
 
-`adrs` supports the following list of commands:
+## Overview
 
-```shell
-  init      Initializes the directory of Architecture Decision Records
-  new       Create a new, numbered Architectural Decision Record
-  edit      Edit an existing Architectural Decision Record
-  link      Link Architectural Decision Records
-  list      List Architectural Decision Records
-  config    Show the current configuration
-  generate  Generates summary documentation about the Architectural Decision Records
+| Command | Description |
+|---------|-------------|
+| [init](./init.md) | Initialize a new ADR repository |
+| [new](./new.md) | Create a new ADR |
+| [edit](./edit.md) | Edit an existing ADR |
+| [link](./link.md) | Link two ADRs together |
+| [list](./list.md) | List all ADRs |
+| [config](./config.md) | Show configuration |
+| [doctor](./doctor.md) | Check repository health |
+| [generate](./generate.md) | Generate documentation |
+
+## Global Options
+
+These options are available for all commands:
+
+| Option | Description |
+|--------|-------------|
+| `--ng` | Use NextGen mode (YAML frontmatter) |
+| `-C, --cwd <DIR>` | Run as if started in `<DIR>` |
+| `-h, --help` | Print help information |
+| `-V, --version` | Print version information |
+
+## Usage
+
+```
+adrs [OPTIONS] <COMMAND>
+
+Commands:
+  init      Initialize a new ADR repository
+  new       Create a new ADR
+  edit      Edit an existing ADR
+  list      List all ADRs
+  link      Link two ADRs together
+  config    Show configuration
+  doctor    Check repository health
+  generate  Generate documentation
   help      Print this message or the help of the given subcommand(s)
+
+Options:
+      --ng                 Use next-gen mode (YAML frontmatter, enhanced features)
+  -C, --cwd <WORKING_DIR>  Working directory (defaults to current directory)
+  -h, --help               Print help
+  -V, --version            Print version
 ```

--- a/book/src/commands/config.md
+++ b/book/src/commands/config.md
@@ -1,27 +1,70 @@
 # config
 
-## Overview
+Show the current configuration.
 
-`config` shows the current configuration.
+## Usage
 
-## Help
-
-```sh
-Show the current configuration
-
-Usage: adrs config
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
+```
+adrs config [OPTIONS]
 ```
 
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--ng` | Use NextGen mode |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+## Description
+
+Displays the current configuration, including where it was loaded from.
+
 ## Examples
+
+### Basic Usage
 
 ```sh
 adrs config
 ```
 
-## Issues
+Output:
 
-See the [cmd-config](https://github.com/joshrotenberg/adrs/labels/cmd-config) label for command specific issues.
+```
+Project root: /home/user/myproject
+Config source: adrs.toml
+ADR directory: doc/adr
+Full path: /home/user/myproject/doc/adr
+Mode: Compatible
+```
+
+### Without Initialization
+
+```sh
+adrs config
+```
+
+Output when no ADR repository is found:
+
+```
+Project root: /home/user/myproject
+Config source: defaults
+ADR directory: doc/adr
+Full path: /home/user/myproject/doc/adr
+Mode: Compatible
+```
+
+## Config Sources
+
+| Source | Description |
+|--------|-------------|
+| `adrs.toml` | TOML configuration file |
+| `.adr-dir` | Legacy adr-tools configuration |
+| `global (~/.config/adrs/config.toml)` | User-wide configuration |
+| `environment` | Environment variable override |
+| `defaults` | Built-in defaults |
+
+## Related
+
+- [Configuration](../configuration.md) - Configuration options
+- [init](./init.md) - Initialize a repository

--- a/book/src/commands/doctor.md
+++ b/book/src/commands/doctor.md
@@ -1,0 +1,101 @@
+# doctor
+
+Check the health of your ADR repository.
+
+## Usage
+
+```
+adrs doctor [OPTIONS]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--ng` | Use NextGen mode |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+## Description
+
+Runs diagnostic checks on your ADR repository and reports any issues found.
+
+## Checks Performed
+
+| Check | Description |
+|-------|-------------|
+| File Naming | ADR files follow the `NNNN-title.md` pattern |
+| Duplicate Numbers | No two ADRs have the same number |
+| Numbering Gaps | Sequential numbering without gaps |
+| Broken Links | All referenced ADRs exist |
+| Superseded Status | Superseded ADRs have corresponding links |
+| Parse Errors | All ADRs can be parsed correctly |
+
+## Examples
+
+### Healthy Repository
+
+```sh
+adrs doctor
+```
+
+Output:
+
+```
+Checking ADR repository health...
+
+[OK] File naming: All 5 ADRs follow naming convention
+[OK] Duplicate numbers: No duplicates found
+[OK] Numbering gaps: Numbers are sequential
+[OK] Broken links: All links are valid
+[OK] Superseded status: All superseded ADRs have links
+[OK] Parse errors: All ADRs parsed successfully
+
+Health check passed!
+```
+
+### Repository with Issues
+
+```sh
+adrs doctor
+```
+
+Output:
+
+```
+Checking ADR repository health...
+
+[OK] File naming: All 5 ADRs follow naming convention
+[WARN] Numbering gaps: Gap after ADR 3 (next is 5)
+[ERROR] Broken links: ADR 4 links to non-existent ADR 99
+[WARN] Superseded status: ADR 2 is superseded but has no "Superseded by" link
+
+Health check found 3 issue(s)
+```
+
+## Severity Levels
+
+| Level | Description |
+|-------|-------------|
+| OK | Check passed |
+| WARN | Potential issue, but not critical |
+| ERROR | Problem that should be fixed |
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | All checks passed |
+| 1 | One or more checks failed |
+
+This allows using `doctor` in CI pipelines:
+
+```yaml
+- name: Check ADR health
+  run: adrs doctor
+```
+
+## Related
+
+- [list](./list.md) - List ADRs
+- [link](./link.md) - Fix broken links

--- a/book/src/commands/edit.md
+++ b/book/src/commands/edit.md
@@ -1,33 +1,64 @@
 # edit
 
-## Overview
+Edit an existing Architecture Decision Record.
 
-`edit` opens an ADR in your `VISUAL` or `EDITOR` that matches the given NAME argument.
+## Usage
 
-## Help
-
-```sh
-Edit an existing Architectural Decision Record
-
-Usage: adrs edit <NAME>
-
-Arguments:
-  <NAME>  The number of the ADR to edit
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
 ```
+adrs edit [OPTIONS] <ADR>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<ADR>` | ADR to edit (number or search term) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--ng` | Use NextGen mode |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+## Description
+
+Opens an existing ADR in your editor. The ADR can be specified by:
+- Number (e.g., `1`, `12`)
+- Partial title match (fuzzy search)
 
 ## Examples
 
+### By Number
+
 ```sh
-# find and edit the first ADR
-adrs edit 1  # looks for 0001-...
-# find and edit the first ADR with the string "data" in the filename
-adrs edit data
+adrs edit 1
 ```
 
-## Issues
+Opens `0001-record-architecture-decisions.md` in your editor.
 
-See the [cmd-edit](https://github.com/joshrotenberg/adrs/labels/cmd-edit) label for command specific issues.
+### By Title
+
+```sh
+adrs edit postgresql
+```
+
+Finds and opens the ADR with "postgresql" in its title.
+
+### Fuzzy Matching
+
+```sh
+adrs edit "database"
+```
+
+Opens the best matching ADR containing "database".
+
+## Editor
+
+Uses the `$EDITOR` environment variable. See [new](./new.md#editor) for configuration.
+
+## Related
+
+- [new](./new.md) - Create a new ADR
+- [list](./list.md) - List ADRs to find the one to edit

--- a/book/src/commands/init.md
+++ b/book/src/commands/init.md
@@ -1,41 +1,102 @@
 # init
 
-## Overview
+Initialize a new ADR repository.
 
-The `init` command initializes a new ADR directory, using `doc/adr` by default. An alternate directory can optionally be supplied to the command
-to store ADRs in a different location. `init` will also create the `.adr-dir` file to store the directory location so that other commands
-can find the top level directory.
+## Usage
 
-`init` creates an initial ADR for you as well, noting the decision you've made to document your Architectural Decisions using ADRs.
-Good job by you.
-
-## Help
-
-```sh
-Initializes the directory of Architecture Decision Records
-
-Usage: adrs init [DIRECTORY]
-
-Arguments:
-  [DIRECTORY]  Directory to initialize [default: doc/adr]
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
 ```
+adrs init [OPTIONS] [DIRECTORY]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `[DIRECTORY]` | ADR directory path (default: `doc/adr`) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--ng` | Use NextGen mode (YAML frontmatter) |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+## Description
+
+The `init` command creates:
+
+1. A `.adr-dir` file in the current directory containing the ADR directory path
+2. The ADR directory (creates parent directories if needed)
+3. An initial ADR: `0001-record-architecture-decisions.md`
 
 ## Examples
 
-```sh
-# use the default location
-# an initial ADR will be created in doc/adr/0001-record-architecture-decisions.md
-adrs init
+### Basic Initialization
 
-# put your ADRs somewhere else
-# creates some/other/place/0001-record-architecture-decisions.md
-adrs init some/other/place
+```sh
+adrs init
 ```
 
-## Issues
+Creates:
+```
+.adr-dir          # Contains "doc/adr"
+doc/
+  adr/
+    0001-record-architecture-decisions.md
+```
 
-See the [cmd-init](https://github.com/joshrotenberg/adrs/labels/cmd-init) label for command specific issues.
+### Custom Directory
+
+```sh
+adrs init decisions
+```
+
+Creates:
+```
+.adr-dir          # Contains "decisions"
+decisions/
+  0001-record-architecture-decisions.md
+```
+
+### Nested Directory
+
+```sh
+adrs init docs/architecture/decisions
+```
+
+Creates the full directory path.
+
+### NextGen Mode
+
+```sh
+adrs init --ng
+```
+
+Creates the initial ADR with YAML frontmatter:
+
+```markdown
+---
+status: accepted
+date: 2024-01-15
+---
+
+# Record Architecture Decisions
+
+...
+```
+
+## Error Handling
+
+If the repository is already initialized (`.adr-dir` exists), the command will fail:
+
+```
+Error: ADR repository already initialized
+```
+
+To reinitialize, remove the `.adr-dir` file first.
+
+## Related
+
+- [config](./config.md) - Show current configuration
+- [new](./new.md) - Create additional ADRs

--- a/book/src/commands/link.md
+++ b/book/src/commands/link.md
@@ -1,63 +1,112 @@
 # link
 
-## Overview
+Link two Architecture Decision Records together.
 
-The `link` command links together the SOURCE and TARGET ADRs.
+## Usage
 
-## Help
-
-```sh
-Link Architectural Decision Records
-
-Usage: adrs link <SOURCE> <LINK> <TARGET> <REVERSE_LINK>
-
-Arguments:
-  <SOURCE>        The source Architectural Decision Record number or file name match
-  <LINK>          Description of the link to create in the source Architectural Decision Record
-  <TARGET>        The target Architectural Decision Record number or file name match
-  <REVERSE_LINK>  Description of the link to create in the target Architectural Decision Record
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
 ```
+adrs link [OPTIONS] <SOURCE> <LINK> <TARGET> <REVERSE_LINK>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<SOURCE>` | Source ADR number |
+| `<LINK>` | Link description from source to target |
+| `<TARGET>` | Target ADR number |
+| `<REVERSE_LINK>` | Reverse link description from target to source |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--ng` | Use NextGen mode |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+## Description
+
+Creates bidirectional links between two ADRs. The link is added to the status section of both ADRs.
 
 ## Examples
 
+### Amends Relationship
+
 ```sh
-# start a new ADR directory
-adr init
-# create a new ADR
-adrs new Do something new
-# create another new ADR
-adrs new Do something else
-# we have three ADRs
-ls doc/adr/
-0001-record-architecture-decisions.md
-0002-do-something-new.md
-0003-do-something-else.md
-# link the third to the second with an "Amends" link
-adrs link 3 Amends 2 "Amended by"
+adrs link 3 "Amends" 1 "Amended by"
 ```
 
-Now the status in `0003-do-something-else.md` will be:
+Result in ADR #3:
+```markdown
+## Status
 
+Proposed
+
+Amends [1. Record architecture decisions](0001-record-architecture-decisions.md)
+```
+
+Result in ADR #1:
 ```markdown
 ## Status
 
 Accepted
 
-Amends [2. Do something new](0002-do-something-new.md)
+Amended by [3. Clarify decision format](0003-clarify-decision-format.md)
 ```
 
-```markdown
-## Status
+### Extends Relationship
 
-Accepted
-
-Amended by [3. Do something else](0003-do-something-else.md)
+```sh
+adrs link 4 "Extends" 2 "Extended by"
 ```
 
-## Issues
+### Custom Relationship
 
-See the [cmd-link](https://github.com/joshrotenberg/adrs/labels/cmd-link) label for command specific issues.
+```sh
+adrs link 5 "Depends on" 3 "Dependency of"
+```
+
+## Common Link Types
+
+| Forward Link | Reverse Link | Use Case |
+|--------------|--------------|----------|
+| Amends | Amended by | Modifying a previous decision |
+| Extends | Extended by | Building on a previous decision |
+| Supersedes | Superseded by | Replacing a decision |
+| Relates to | Relates to | General relationship |
+| Depends on | Dependency of | Dependencies |
+
+## Superseding
+
+For superseding relationships, prefer using `adrs new --supersedes`:
+
+```sh
+# Instead of:
+adrs new "New approach"
+adrs link 3 "Supersedes" 2 "Superseded by"
+
+# Use:
+adrs new --supersedes 2 "New approach"
+```
+
+The `--supersedes` option also updates the target ADR's status to "Superseded".
+
+## NextGen Mode
+
+In NextGen mode (`--ng`), links are stored in YAML frontmatter:
+
+```yaml
+---
+status: proposed
+date: 2024-01-15
+links:
+  - kind: Amends
+    target: 1
+---
+```
+
+## Related
+
+- [new](./new.md) - Create ADRs with links
+- [list](./list.md) - Find ADR numbers

--- a/book/src/commands/list.md
+++ b/book/src/commands/list.md
@@ -1,30 +1,67 @@
 # list
 
-## Overview
+List all Architecture Decision Records.
 
-`list` lists the current ADRs found in the configured (or default) directory.
+## Usage
 
-## Help
-
-```sh
-List Architectural Decision Records
-
-Usage: adrs list
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
 ```
+adrs list [OPTIONS]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--ng` | Use NextGen mode |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+## Description
+
+Lists all ADRs in the repository, showing their number, title, and status.
 
 ## Examples
 
+### Basic Usage
+
 ```sh
 adrs list
-0001-record-architecture-decisions.md
-0002-do-something-new.md
-0003-do-something-else.md
 ```
 
-## Issues
+Output:
 
-See the [cmd-list](https://github.com/joshrotenberg/adrs/labels/cmd-list) label for command specific issues.
+```
+1. Record architecture decisions [Accepted]
+2. Use PostgreSQL for persistence [Proposed]
+3. API versioning strategy [Accepted]
+4. Use Redis for caching [Superseded]
+```
+
+### From a Subdirectory
+
+```sh
+cd src/
+adrs list
+```
+
+`adrs` automatically finds the project root.
+
+### Specify Working Directory
+
+```sh
+adrs list -C /path/to/project
+```
+
+## Output Format
+
+Each line shows:
+- ADR number
+- Title
+- Status in brackets
+
+ADRs are sorted by number.
+
+## Related
+
+- [new](./new.md) - Create a new ADR
+- [edit](./edit.md) - Edit an ADR from the list

--- a/book/src/commands/new.md
+++ b/book/src/commands/new.md
@@ -1,45 +1,158 @@
 # new
 
-## Overview
+Create a new Architecture Decision Record.
 
-`new` creates a new ADR, optionally linking it to or superceding a previous ADR. A single call can link
-and/or supercede multiple previous ADRs.
+## Usage
 
-## Help
-
-```sh
-Create a new, numbered Architectural Decision Record
-
-Usage: adrs new [OPTIONS] <TITLE>...
-
-Arguments:
-  <TITLE>...  Title of the new Architectural Decision Record
-
-Options:
-  -s, --superseded <SUPERSEDED>  A reference to a previous decision to supersede with this new one
-  -l, --link <LINK>              Link the new Architectural Decision to a previous Architectural Decision Record
-  -T, --template <TEMPLATE>      Use a custom template when generating the new Architectural Decision Record. Relative paths are resolved with respect to the directory specified in `.adr-dir` [env: ADRS_TEMPLATE_DIR=] [default: templates/template.md]
-  -h, --help                     Print help
-  -V, --version                  Print version
 ```
+adrs new [OPTIONS] <TITLE>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<TITLE>` | Title of the new ADR |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-f, --format <FORMAT>` | Template format: `nygard` or `madr` (default: `nygard`) |
+| `-v, --variant <VARIANT>` | Template variant: `full`, `minimal`, or `bare` (default: `full`) |
+| `--status <STATUS>` | Initial status (default: `Proposed`) |
+| `-s, --supersedes <N>` | ADR number(s) this supersedes |
+| `-l, --link <LINK>` | Link to another ADR |
+| `--ng` | Use NextGen mode (YAML frontmatter) |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+## Description
+
+Creates a new ADR file with the next available number. Opens your `$EDITOR` to edit the document. The ADR is saved when you close the editor.
 
 ## Examples
 
+### Basic Usage
+
 ```sh
-# create a new ADR
-adrs new My New Decision
-
-# create a new ADR that supercedes a previous ADR
-adrs new -s 2 This is a new idea
-
-# create a new ADR that links to a previous ADR
-adrs new -l "2:Amends:Amended by" This is a better idea
-
-# use an alternate template
-# the template is resolved relative to the directory specified in `.adr-dir`
-adrs new -T templates/alternate.md This is a different idea
+adrs new "Use PostgreSQL for persistence"
 ```
 
-## Issues
+Creates `0002-use-postgresql-for-persistence.md` and opens it in your editor.
 
-See the [cmd-new](https://github.com/joshrotenberg/adrs/labels/cmd-new) label for command specific issues.
+### With MADR Format
+
+```sh
+adrs new --format madr "Use PostgreSQL for persistence"
+```
+
+### Minimal Template
+
+```sh
+adrs new --variant minimal "Use PostgreSQL for persistence"
+```
+
+### With Initial Status
+
+```sh
+adrs new --status Accepted "Use PostgreSQL for persistence"
+```
+
+### Superseding an ADR
+
+```sh
+adrs new --supersedes 2 "Use MySQL instead of PostgreSQL"
+```
+
+This creates a new ADR and:
+- Adds a "Supersedes" link in the new ADR
+- Adds a "Superseded by" link in ADR #2
+- Changes ADR #2's status to "Superseded"
+
+### Superseding Multiple ADRs
+
+```sh
+adrs new --supersedes 2 --supersedes 3 "Consolidated database decision"
+```
+
+### Linking to Another ADR
+
+```sh
+adrs new --link "2:Amends:Amended by" "Clarify database choice"
+```
+
+The link format is `TARGET:KIND:REVERSE_KIND`:
+- `TARGET`: The ADR number to link to
+- `KIND`: The relationship from this ADR to the target
+- `REVERSE_KIND`: The reverse relationship added to the target
+
+Common link types:
+- `Amends` / `Amended by`
+- `Extends` / `Extended by`
+- `Relates to` / `Relates to`
+
+### Multiple Links
+
+```sh
+adrs new --link "2:Amends:Amended by" --link "3:Extends:Extended by" "Combined decision"
+```
+
+### NextGen Mode with MADR
+
+```sh
+adrs new --ng --format madr "Use PostgreSQL for persistence"
+```
+
+Creates an ADR with YAML frontmatter:
+
+```markdown
+---
+status: proposed
+date: 2024-01-15
+---
+
+# Use PostgreSQL for Persistence
+
+## Context and Problem Statement
+...
+```
+
+## Editor
+
+The `new` command uses the `$EDITOR` environment variable. If not set, it tries common editors:
+- `vim`
+- `nano`
+- `vi`
+
+Set your preferred editor:
+
+```sh
+export EDITOR="code --wait"  # VS Code
+export EDITOR="nano"         # Nano
+export EDITOR="vim"          # Vim
+```
+
+## File Naming
+
+ADR files are named using the pattern:
+
+```
+NNNN-title-in-kebab-case.md
+```
+
+Where:
+- `NNNN` is the zero-padded ADR number
+- Title is converted to lowercase kebab-case
+- Special characters are removed
+
+Examples:
+- `0001-record-architecture-decisions.md`
+- `0002-use-postgresql-for-persistence.md`
+- `0015-api-versioning-strategy.md`
+
+## Related
+
+- [edit](./edit.md) - Edit an existing ADR
+- [link](./link.md) - Link ADRs together
+- [Templates](../templates.md) - Available templates

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,1 +1,127 @@
 # Configuration
+
+`adrs` supports multiple configuration methods with the following priority (highest to lowest):
+
+1. Command-line flags
+2. Environment variables
+3. Project configuration file (`adrs.toml` or `.adr-dir`)
+4. Global configuration file (`~/.config/adrs/config.toml`)
+5. Default values
+
+## Project Configuration
+
+### Legacy Format (.adr-dir)
+
+For compatibility with adr-tools, `adrs` reads the `.adr-dir` file:
+
+```
+doc/adr
+```
+
+This single-line file specifies the directory where ADRs are stored.
+
+### TOML Format (adrs.toml)
+
+For more options, use `adrs.toml` in your project root:
+
+```toml
+# ADR storage directory (relative to project root)
+adr_dir = "doc/adr"
+
+# Operation mode: "compatible" or "nextgen"
+# - compatible: adr-tools compatible output (default)
+# - nextgen: YAML frontmatter with enhanced features
+mode = "compatible"
+
+# Template configuration
+[templates]
+# Default format: "nygard" or "madr"
+format = "nygard"
+
+# Default variant: "full", "minimal", or "bare"
+variant = "full"
+
+# Path to custom template file (optional)
+# custom = "templates/custom.md"
+```
+
+## Global Configuration
+
+Create `~/.config/adrs/config.toml` for user-wide defaults:
+
+```toml
+# Default mode for new repositories
+mode = "nextgen"
+
+[templates]
+format = "madr"
+variant = "minimal"
+```
+
+Project configuration overrides global configuration.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ADR_DIRECTORY` | Override the ADR directory path |
+| `ADRS_CONFIG` | Path to a specific configuration file |
+| `EDITOR` | Editor to use for `adrs new` and `adrs edit` |
+
+Example:
+
+```sh
+export ADR_DIRECTORY="decisions"
+adrs new "Use Redis for caching"
+```
+
+## Configuration Discovery
+
+When you run an `adrs` command, it searches for configuration by:
+
+1. Looking in the current directory for `adrs.toml` or `.adr-dir`
+2. Searching parent directories up to the git root (or filesystem root)
+3. Checking the global config at `~/.config/adrs/config.toml`
+4. Using defaults if nothing is found
+
+This means you can run `adrs` commands from any subdirectory of your project.
+
+## Modes
+
+### Compatible Mode (default)
+
+Produces output identical to adr-tools:
+
+- Status in the document body
+- Links as markdown text
+- No YAML frontmatter
+
+### NextGen Mode
+
+Enables enhanced features:
+
+- YAML frontmatter for metadata
+- Structured status and links
+- MADR 4.0.0 fields (decision-makers, consulted, informed)
+
+Enable with `--ng` flag or in configuration:
+
+```toml
+mode = "nextgen"
+```
+
+## Show Current Configuration
+
+```sh
+adrs config
+```
+
+Output:
+
+```
+Project root: /path/to/project
+Config source: adrs.toml
+ADR directory: doc/adr
+Full path: /path/to/project/doc/adr
+Mode: Compatible
+```

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -1,19 +1,116 @@
 # Contributing
 
-Help out however you can. See [issues](https://github.com/joshrotenberg/adrs/issues) for ideas.
+Contributions are welcome! See [issues](https://github.com/joshrotenberg/adrs/issues) for ideas or open a new issue to discuss your proposal.
+
+## Development Setup
+
+```sh
+git clone https://github.com/joshrotenberg/adrs
+cd adrs
+cargo build
+```
+
+## Running Tests
+
+```sh
+# Library tests
+cargo test --lib --all-features
+
+# Integration tests
+cargo test --test '*' --all-features
+
+# All tests
+cargo test --all-features
+```
+
+## Code Quality
+
+Before submitting a PR, ensure:
+
+```sh
+# Format code
+cargo fmt --all
+
+# Run lints
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Run tests
+cargo test --all-features
+```
 
 ## Guidelines
 
 ### Compatibility
 
-For now, keep additions compatible with the original [adr-tools](https://github.com/npryce/adr-tools). New features
-can be added, however, as long as they don't break existing functionality. In the future, the tool may
-add incompatible features, but that will be a major version bump.
+The v2 rewrite maintains compatibility with [adr-tools](https://github.com/npryce/adr-tools) repositories. Changes should not break existing ADR directories.
+
+New features that extend beyond adr-tools compatibility should:
+- Work in both Compatible and NextGen modes where possible
+- Be opt-in via flags or configuration
+- Be documented
+
+### Code Style
+
+- Follow Rust 2024 edition idioms
+- Use `thiserror` for library errors
+- Use `anyhow` for CLI errors
+- Add doc comments to public APIs
+- Keep functions focused and testable
 
 ### Testing
 
-Please write new and/or update current tests as appropriate. See the current test suite for examples.
+- Add unit tests for new functionality
+- Add integration tests for CLI changes
+- Test both Compatible and NextGen modes
+- Test edge cases (empty files, special characters, etc.)
 
-### Documentation
+### Commits
 
-All new or augmented features should have documentation.
+Use [conventional commits](https://www.conventionalcommits.org/):
+
+```
+feat: add new feature
+fix: resolve bug
+docs: update documentation
+test: add tests
+refactor: restructure code
+chore: maintenance tasks
+```
+
+### Pull Requests
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feat/my-feature`
+3. Make your changes
+4. Run tests and lints
+5. Commit with conventional commit messages
+6. Push and open a PR
+
+## Project Structure
+
+```
+adrs/
+├── crates/
+│   ├── adrs-core/     # Library crate
+│   │   ├── src/
+│   │   │   ├── config.rs    # Configuration handling
+│   │   │   ├── parse.rs     # ADR parsing
+│   │   │   ├── template.rs  # Template engine
+│   │   │   ├── repository.rs # Repository operations
+│   │   │   ├── doctor.rs    # Health checks
+│   │   │   └── types.rs     # Core types
+│   │   └── Cargo.toml
+│   └── adrs/          # CLI crate
+│       ├── src/
+│       │   ├── main.rs
+│       │   └── commands/    # CLI commands
+│       └── Cargo.toml
+├── book/              # mdbook documentation
+└── Cargo.toml         # Workspace manifest
+```
+
+## Documentation
+
+- Update the mdbook in `book/` for user-facing changes
+- Add doc comments to public APIs
+- Update CHANGELOG.md (handled by release-plz)

--- a/book/src/formats.md
+++ b/book/src/formats.md
@@ -1,0 +1,176 @@
+# Formats
+
+`adrs` supports two ADR formats: Nygard (the original adr-tools format) and MADR 4.0.0.
+
+## Nygard Format
+
+The classic format from [adr-tools](https://github.com/npryce/adr-tools), based on Michael Nygard's blog post.
+
+### Structure
+
+```markdown
+# 1. Record architecture decisions
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard.
+
+## Consequences
+
+See Michael Nygard's article for a detailed description.
+```
+
+### Sections
+
+| Section | Description |
+|---------|-------------|
+| Title | Number and title as H1 heading |
+| Date | When the decision was made |
+| Status | Proposed, Accepted, Deprecated, Superseded |
+| Context | Why is this decision needed? |
+| Decision | What was decided? |
+| Consequences | What are the implications? |
+
+## MADR 4.0.0 Format
+
+[Markdown Architectural Decision Records](https://adr.github.io/madr/) version 4.0.0 provides a more structured format with additional metadata.
+
+### Structure
+
+```markdown
+---
+status: accepted
+date: 2024-01-15
+decision-makers:
+  - Alice
+  - Bob
+consulted:
+  - Carol
+informed:
+  - Dave
+---
+
+# Use PostgreSQL for Persistence
+
+## Context and Problem Statement
+
+We need a database for storing user data.
+
+## Decision Drivers
+
+* Need ACID compliance
+* Team has PostgreSQL experience
+* Open source preferred
+
+## Considered Options
+
+* PostgreSQL
+* MySQL
+* MongoDB
+
+## Decision Outcome
+
+Chosen option: "PostgreSQL", because it meets all requirements and the team is familiar with it.
+
+### Consequences
+
+* Good, because we have team expertise
+* Bad, because it requires more infrastructure than SQLite
+
+### Confirmation
+
+We will confirm this decision after the first production deployment.
+
+## Pros and Cons of the Options
+
+### PostgreSQL
+
+* Good, because ACID compliant
+* Good, because team experience
+* Neutral, because requires server setup
+
+### MySQL
+
+* Good, because widely used
+* Bad, because different SQL dialect
+
+### MongoDB
+
+* Good, because flexible schema
+* Bad, because not ACID compliant by default
+```
+
+### YAML Frontmatter Fields
+
+| Field | Description |
+|-------|-------------|
+| `status` | Decision status |
+| `date` | Date of the decision |
+| `decision-makers` | List of people who made the decision |
+| `consulted` | List of people whose opinions were sought |
+| `informed` | List of people who were informed of the decision |
+
+### Sections
+
+| Section | Required | Description |
+|---------|----------|-------------|
+| Title | Yes | The decision as an H1 heading |
+| Context and Problem Statement | Yes | Why is this decision needed? |
+| Decision Drivers | No | Factors influencing the decision |
+| Considered Options | No | Options that were evaluated |
+| Decision Outcome | Yes | The chosen option and rationale |
+| Consequences | No | Good and bad outcomes |
+| Confirmation | No | How the decision will be validated |
+| Pros and Cons | No | Detailed option comparison |
+| More Information | No | Links and references |
+
+## Choosing a Format
+
+| Use Nygard when... | Use MADR when... |
+|--------------------|------------------|
+| Migrating from adr-tools | Starting a new project |
+| Simplicity is preferred | You need structured metadata |
+| Team is familiar with it | You want decision-maker tracking |
+| | You need detailed option comparison |
+
+## Specifying Format
+
+### Per-command
+
+```sh
+adrs new --format madr "Use PostgreSQL"
+adrs new --format nygard "Use PostgreSQL"
+```
+
+### In Configuration
+
+```toml
+[templates]
+format = "madr"
+```
+
+## Template Variants
+
+Both formats support three variants:
+
+| Variant | Description |
+|---------|-------------|
+| `full` | All sections with guidance comments |
+| `minimal` | Essential sections only |
+| `bare` | Bare structure, no comments |
+
+```sh
+adrs new --format madr --variant minimal "Use PostgreSQL"
+```
+
+See [Templates](./templates.md) for more details.

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -1,0 +1,93 @@
+# Installation
+
+## Pre-built Binaries
+
+Pre-built binaries are available for Linux, macOS, and Windows.
+
+### Shell Installer (Linux/macOS)
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/joshrotenberg/adrs/releases/latest/download/adrs-installer.sh | sh
+```
+
+### PowerShell Installer (Windows)
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/joshrotenberg/adrs/releases/latest/download/adrs-installer.ps1 | iex"
+```
+
+### Homebrew (macOS/Linux)
+
+```sh
+brew install joshrotenberg/brew/adrs
+```
+
+### Manual Download
+
+Download the appropriate binary from the [releases page](https://github.com/joshrotenberg/adrs/releases).
+
+| Platform | Architecture | Download |
+|----------|--------------|----------|
+| Linux | x86_64 | `adrs-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux | aarch64 | `adrs-aarch64-unknown-linux-gnu.tar.gz` |
+| macOS | x86_64 (Intel) | `adrs-x86_64-apple-darwin.tar.gz` |
+| macOS | aarch64 (Apple Silicon) | `adrs-aarch64-apple-darwin.tar.gz` |
+| Windows | x86_64 | `adrs-x86_64-pc-windows-msvc.zip` |
+
+## From Source
+
+### Using Cargo
+
+```sh
+cargo install adrs
+```
+
+### Building from Git
+
+```sh
+git clone https://github.com/joshrotenberg/adrs
+cd adrs
+cargo build --release
+```
+
+The binary will be at `target/release/adrs`.
+
+## Docker
+
+A Docker image is available for running `adrs` in containers:
+
+```sh
+docker pull ghcr.io/joshrotenberg/adrs:latest
+```
+
+Mount your project directory to use it:
+
+```sh
+docker run --rm -v $(pwd):/workspace -w /workspace ghcr.io/joshrotenberg/adrs list
+```
+
+## Verify Installation
+
+```sh
+adrs --version
+```
+
+## Shell Completions
+
+Generate shell completions for your shell:
+
+```sh
+# Bash
+adrs completions bash > ~/.local/share/bash-completion/completions/adrs
+
+# Zsh
+adrs completions zsh > ~/.zfunc/_adrs
+
+# Fish
+adrs completions fish > ~/.config/fish/completions/adrs.fish
+
+# PowerShell
+adrs completions powershell > $PROFILE.CurrentUserAllHosts
+```
+
+Note: Shell completions require rebuilding after updating `adrs`.

--- a/book/src/library.md
+++ b/book/src/library.md
@@ -1,0 +1,305 @@
+# Library Usage
+
+The `adrs-core` crate provides a Rust library for working with ADRs programmatically.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+adrs-core = "0.4"
+```
+
+## Basic Usage
+
+### Opening a Repository
+
+```rust
+use adrs_core::Repository;
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    // Open existing repository
+    let repo = Repository::open(Path::new("."))?;
+    
+    // Or create with defaults if it doesn't exist
+    let repo = Repository::open_or_default(Path::new("."))?;
+    
+    Ok(())
+}
+```
+
+### Listing ADRs
+
+```rust
+use adrs_core::Repository;
+
+fn main() -> anyhow::Result<()> {
+    let repo = Repository::open(Path::new("."))?;
+    
+    for adr in repo.list()? {
+        println!("{}: {} [{}]", adr.number, adr.title, adr.status);
+    }
+    
+    Ok(())
+}
+```
+
+### Creating an ADR
+
+```rust
+use adrs_core::{Repository, Adr, AdrStatus};
+
+fn main() -> anyhow::Result<()> {
+    let repo = Repository::open(Path::new("."))?;
+    
+    let adr = Adr::new(
+        repo.next_number()?,
+        "Use PostgreSQL for persistence".to_string(),
+    );
+    
+    let path = repo.create(&adr)?;
+    println!("Created: {}", path.display());
+    
+    Ok(())
+}
+```
+
+### Finding an ADR
+
+```rust
+use adrs_core::Repository;
+
+fn main() -> anyhow::Result<()> {
+    let repo = Repository::open(Path::new("."))?;
+    
+    // By number
+    let adr = repo.get(1)?;
+    
+    // By search term (fuzzy)
+    let adr = repo.find("postgresql")?;
+    
+    Ok(())
+}
+```
+
+### Linking ADRs
+
+```rust
+use adrs_core::{Repository, LinkKind};
+
+fn main() -> anyhow::Result<()> {
+    let repo = Repository::open(Path::new("."))?;
+    
+    repo.link(
+        3,                          // source
+        LinkKind::Amends,           // link type
+        1,                          // target
+        LinkKind::AmendedBy,        // reverse link type
+    )?;
+    
+    Ok(())
+}
+```
+
+## Configuration
+
+### Loading Configuration
+
+```rust
+use adrs_core::{Config, discover};
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    // Discover configuration from current directory
+    let discovered = discover(Path::new("."))?;
+    
+    println!("Project root: {}", discovered.root.display());
+    println!("ADR directory: {}", discovered.config.adr_dir.display());
+    println!("Source: {:?}", discovered.source);
+    
+    Ok(())
+}
+```
+
+### Creating Configuration
+
+```rust
+use adrs_core::Config;
+
+let config = Config {
+    adr_dir: "decisions".into(),
+    mode: adrs_core::ConfigMode::NextGen,
+    ..Default::default()
+};
+```
+
+## Templates
+
+### Using Built-in Templates
+
+```rust
+use adrs_core::{TemplateEngine, TemplateFormat, TemplateVariant, Adr};
+
+fn main() -> anyhow::Result<()> {
+    let engine = TemplateEngine::new(TemplateFormat::Madr, TemplateVariant::Minimal);
+    
+    let adr = Adr::new(1, "My Decision".to_string());
+    let content = engine.render(&adr)?;
+    
+    println!("{}", content);
+    
+    Ok(())
+}
+```
+
+### Custom Templates
+
+```rust
+use adrs_core::{TemplateEngine, Adr};
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    let engine = TemplateEngine::from_file(Path::new("templates/custom.md"))?;
+    
+    let adr = Adr::new(1, "My Decision".to_string());
+    let content = engine.render(&adr)?;
+    
+    Ok(())
+}
+```
+
+## Parsing ADRs
+
+### Parse from File
+
+```rust
+use adrs_core::Parser;
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    let parser = Parser::new();
+    let adr = parser.parse_file(Path::new("doc/adr/0001-record-decisions.md"))?;
+    
+    println!("Title: {}", adr.title);
+    println!("Status: {}", adr.status);
+    println!("Date: {:?}", adr.date);
+    
+    for link in &adr.links {
+        println!("Link: {} -> ADR {}", link.kind, link.target);
+    }
+    
+    Ok(())
+}
+```
+
+### Parse from String
+
+```rust
+use adrs_core::Parser;
+
+fn main() -> anyhow::Result<()> {
+    let content = r#"
+# 1. Use PostgreSQL
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need a database.
+
+## Decision
+
+Use PostgreSQL.
+
+## Consequences
+
+None significant.
+"#;
+
+    let parser = Parser::new();
+    let adr = parser.parse(content, Some(1))?;
+    
+    Ok(())
+}
+```
+
+## Health Checks
+
+```rust
+use adrs_core::{Repository, doctor_check};
+
+fn main() -> anyhow::Result<()> {
+    let repo = Repository::open(Path::new("."))?;
+    let report = doctor_check(&repo)?;
+    
+    for diagnostic in &report.diagnostics {
+        println!("[{:?}] {}: {}", 
+            diagnostic.severity,
+            diagnostic.check,
+            diagnostic.message
+        );
+    }
+    
+    if report.has_errors() {
+        std::process::exit(1);
+    }
+    
+    Ok(())
+}
+```
+
+## Types
+
+### AdrStatus
+
+```rust
+use adrs_core::AdrStatus;
+
+let status = AdrStatus::Accepted;
+let status = AdrStatus::Superseded;
+let status = AdrStatus::Custom("In Review".to_string());
+```
+
+### LinkKind
+
+```rust
+use adrs_core::LinkKind;
+
+let kind = LinkKind::Supersedes;
+let kind = LinkKind::AmendedBy;
+let kind = LinkKind::Custom("Depends on".to_string());
+```
+
+## Error Handling
+
+The library uses `thiserror` for error types:
+
+```rust
+use adrs_core::{Repository, Error};
+
+fn main() {
+    match Repository::open(Path::new(".")) {
+        Ok(repo) => { /* use repo */ }
+        Err(Error::NotFound(path)) => {
+            eprintln!("ADR repository not found at {}", path.display());
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+        }
+    }
+}
+```
+
+## Feature Flags
+
+The `adrs-core` crate has no optional features currently. All functionality is included by default.
+
+## API Documentation
+
+Full API documentation is available on [docs.rs](https://docs.rs/adrs-core).

--- a/book/src/resources.md
+++ b/book/src/resources.md
@@ -1,6 +1,30 @@
 # Resources
 
-* Architectural Decision Records <https://adr.github.io>
-* adr-tools <https://github.com/npryce/adr-tools>
-* When Should I Write an Architecture Decision Record <https://engineering.atspotify.com/2020/04/when-should-i-write-an-architecture-decision-record>
-* ADR Process <https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html#contents>
+## ADR Background
+
+- [Architectural Decision Records](https://adr.github.io) - The official ADR homepage
+- [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) - Michael Nygard's original blog post
+- [MADR](https://adr.github.io/madr/) - Markdown Architectural Decision Records
+
+## Tools
+
+- [adr-tools](https://github.com/npryce/adr-tools) - The original bash-based ADR tool
+- [adrs](https://github.com/joshrotenberg/adrs) - This project (Rust rewrite)
+- [adr-log](https://github.com/adr/adr-log) - Generate an ADR log from MADR files
+- [pyadr](https://github.com/opinionated-digital-center/pyadr) - Python ADR tool
+
+## Articles
+
+- [When Should I Write an Architecture Decision Record](https://engineering.atspotify.com/2020/04/when-should-i-write-an-architecture-decision-record/) - Spotify Engineering
+- [ADR Process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html) - AWS Prescriptive Guidance
+- [Architecture Decision Records](https://www.thoughtworks.com/radar/techniques/lightweight-architecture-decision-records) - ThoughtWorks Technology Radar
+
+## Templates
+
+- [MADR Templates](https://github.com/adr/madr/tree/main/template) - Official MADR templates
+- [ADR Templates](https://github.com/joelparkerhenderson/architecture-decision-record) - Collection of ADR templates
+
+## Books
+
+- [Documenting Software Architectures](https://www.amazon.com/Documenting-Software-Architectures-Views-Beyond/dp/0321552687) - Clements et al.
+- [Design It!](https://pragprog.com/titles/mkdsa/design-it/) - Michael Keeling

--- a/book/src/templates.md
+++ b/book/src/templates.md
@@ -1,0 +1,219 @@
+# Templates
+
+`adrs` uses templates to generate new ADR documents. You can use built-in templates or create custom ones.
+
+## Built-in Templates
+
+### Formats
+
+| Format | Description |
+|--------|-------------|
+| `nygard` | Classic adr-tools format (default) |
+| `madr` | MADR 4.0.0 format |
+
+### Variants
+
+Each format has three variants:
+
+| Variant | Description |
+|---------|-------------|
+| `full` | Complete template with all sections and guidance comments |
+| `minimal` | Essential sections only, no guidance |
+| `bare` | Minimal structure with placeholders |
+
+### Using Built-in Templates
+
+```sh
+# Default: nygard format, full variant
+adrs new "My Decision"
+
+# MADR format, full variant
+adrs new --format madr "My Decision"
+
+# Nygard format, minimal variant
+adrs new --variant minimal "My Decision"
+
+# MADR format, bare variant
+adrs new --format madr --variant bare "My Decision"
+```
+
+### Template Examples
+
+#### Nygard Full
+
+```markdown
+# {{ number }}. {{ title }}
+
+Date: {{ date }}
+
+## Status
+
+{{ status }}
+
+## Context
+
+<!-- Describe the issue motivating this decision and any context -->
+
+## Decision
+
+<!-- What is the change that we're proposing and/or doing? -->
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->
+```
+
+#### MADR Full
+
+```markdown
+---
+status: {{ status | lower }}
+date: {{ date }}
+---
+
+# {{ title }}
+
+## Context and Problem Statement
+
+<!-- Describe the context and problem statement -->
+
+## Decision Drivers
+
+<!-- List the decision drivers -->
+
+## Considered Options
+
+<!-- List the options considered -->
+
+## Decision Outcome
+
+Chosen option: "", because ...
+
+### Consequences
+
+* Good, because ...
+* Bad, because ...
+```
+
+## Custom Templates
+
+Create custom templates using [Jinja2](https://jinja.palletsprojects.com/) syntax.
+
+### Template Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `number` | ADR number (padded) | `0001` |
+| `title` | ADR title | `Use PostgreSQL` |
+| `date` | Current date | `2024-01-15` |
+| `status` | Initial status | `Proposed` |
+| `links` | Array of links | See below |
+
+### Link Variables
+
+Each link in the `links` array has:
+
+| Variable | Description |
+|----------|-------------|
+| `link.kind` | Link type (e.g., "Supersedes") |
+| `link.target` | Target ADR number |
+| `link.description` | Optional description |
+
+### Creating a Custom Template
+
+1. Create a template file:
+
+```markdown
+# {{ number }}. {{ title }}
+
+**Date**: {{ date }}
+**Status**: {{ status }}
+**Author**: [Your Name]
+
+## Problem
+
+<!-- What problem does this solve? -->
+
+## Solution
+
+<!-- What is the solution? -->
+
+## Alternatives Considered
+
+<!-- What alternatives were considered? -->
+
+## References
+
+<!-- Any relevant links or documents -->
+```
+
+2. Use it when creating ADRs:
+
+```sh
+adrs new --template path/to/template.md "My Decision"
+```
+
+Or configure it in `adrs.toml`:
+
+```toml
+[templates]
+custom = "templates/my-template.md"
+```
+
+### Conditional Sections
+
+Use Jinja2 conditionals for optional content:
+
+```markdown
+{% if links %}
+## Related Decisions
+
+{% for link in links %}
+* {{ link.kind }} [ADR {{ link.target }}]({{ link.target | pad(4) }}-*.md)
+{% endfor %}
+{% endif %}
+```
+
+### Filters
+
+Available filters:
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `lower` | Lowercase | `{{ status \| lower }}` |
+| `upper` | Uppercase | `{{ title \| upper }}` |
+| `pad(n)` | Zero-pad number | `{{ number \| pad(4) }}` |
+
+## Default Configuration
+
+Set defaults in `adrs.toml`:
+
+```toml
+[templates]
+# Default format for new ADRs
+format = "madr"
+
+# Default variant
+variant = "minimal"
+
+# Custom template path (optional)
+# custom = "templates/custom.md"
+```
+
+## NextGen Mode Templates
+
+When using `--ng` flag or `mode = "nextgen"`, templates generate YAML frontmatter:
+
+```markdown
+---
+status: proposed
+date: 2024-01-15
+links:
+  - kind: Supersedes
+    target: 1
+---
+
+# Use PostgreSQL for Persistence
+
+...
+```

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -20,9 +20,7 @@ fn test_help() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "Manage Architecture Decision Records",
-        ));
+        .stdout(predicate::str::contains("Architecture Decision Records"));
 }
 
 #[test]
@@ -352,7 +350,7 @@ fn test_ng_flag() {
         .args(["--ng", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("next-gen mode"));
+        .stdout(predicate::str::contains("NextGen mode"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Complete rewrite of the mdbook documentation and improved CLI help text for the v2 release.

## Book Documentation

### New Pages
- **Installation** - All installation methods (shell/PowerShell installers, Homebrew, Cargo, Docker)
- **Formats** - Comparison of Nygard and MADR 4.0.0 formats with examples
- **Templates** - Built-in templates, variants, and custom template guide
- **Library Usage** - `adrs-core` Rust library documentation with code examples
- **Doctor Command** - Repository health check documentation

### Updated Pages
- **Introduction** - Quick start guide, feature overview, migration from adr-tools
- **Configuration** - Config discovery, TOML format, environment variables, modes
- **All Command Pages** - Updated with current CLI options and examples
- **Contributing** - Updated development setup and guidelines
- **Resources** - Expanded links to ADR resources

### Removed
- Outdated caveats page
- Empty adrs page

## CLI Improvements

- Added detailed `long_about` with getting started guide and examples
- Improved option descriptions throughout
- Updated tests for new help text

## Configuration

- Added `.mdbook-lint.toml` for markdown linting (run manually)
- Fixed book.toml for newer mdbook versions

Closes #12
Closes #60