### PR TITLE
fix: use workspace dependency for adrs-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ clap = { version = "4", features = ["derive", "env", "string"] }
 edit = "0.1"
 whoami = "1"
 
+# Internal
+adrs-core = { path = "crates/adrs-core", version = "0.4.0" }
+
 # Testing
 serial_test = "3"
 assert_cmd = "2"

--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -13,7 +13,7 @@ name = "adrs"
 path = "src/main.rs"
 
 [dependencies]
-adrs-core = { path = "../adrs-core", version = "0.4.0" }
+adrs-core.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 edit.workspace = true


### PR DESCRIPTION
## Summary

Fix the CI failure in release workflow caused by version mismatch between `adrs` and `adrs-core`.

## Problem

The release workflow failed with:
```
error: failed to select a version for the requirement `adrs-core = "^0.4.0"`
candidate versions found which didn't match: 0.5.0
```

This happened because:
1. `adrs-core` was bumped to 0.5.0 by release-plz
2. `adrs/Cargo.toml` still had `version = "0.4.0"` hardcoded

## Solution

Move the `adrs-core` dependency to the workspace level in root `Cargo.toml`:
```toml
adrs-core = { path = "crates/adrs-core", version = "0.4.0" }
```

Then reference it in `crates/adrs/Cargo.toml`:
```toml
adrs-core.workspace = true
```

Now release-plz only needs to update the version in one place (root Cargo.toml).