### PR TITLE
docs: fix generate command documentation

### DIFF
--- a/book/src/commands/generate.md
+++ b/book/src/commands/generate.md
@@ -14,12 +14,13 @@ adrs generate <SUBCOMMAND>
 |------------|-------------|
 | `toc` | Generate a table of contents |
 | `graph` | Generate a Graphviz dependency graph |
+| `book` | Generate an mdbook |
 
 ---
 
 ## generate toc
 
-Generate a markdown table of contents.
+Generate a markdown table of contents to stdout.
 
 ### Usage
 
@@ -31,10 +32,10 @@ adrs generate toc [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `-o, --output <FILE>` | Output file (default: stdout) |
-| `-i, --intro <TEXT>` | Introduction text |
-| `-l, --link-prefix <PREFIX>` | Prefix for ADR links |
-| `-e, --epilogue <TEXT>` | Epilogue text |
+| `-o, --ordered` | Use ordered list (1. 2. 3.) instead of bullets |
+| `-i, --intro <FILE>` | Prepend content from file |
+| `-O, --outro <FILE>` | Append content from file |
+| `-p, --prefix <PREFIX>` | Prefix for ADR links |
 | `--ng` | Use NextGen mode |
 | `-C, --cwd <DIR>` | Working directory |
 | `-h, --help` | Print help |
@@ -50,29 +51,41 @@ adrs generate toc
 Output:
 
 ```markdown
-# Architecture Decision Records
+* [1. Record architecture decisions](0001-record-architecture-decisions.md)
+* [2. Use PostgreSQL for persistence](0002-use-postgresql-for-persistence.md)
+* [3. API versioning strategy](0003-api-versioning-strategy.md)
+```
 
-* [1. Record architecture decisions](doc/adr/0001-record-architecture-decisions.md)
-* [2. Use PostgreSQL for persistence](doc/adr/0002-use-postgresql-for-persistence.md)
-* [3. API versioning strategy](doc/adr/0003-api-versioning-strategy.md)
+#### Ordered List
+
+```sh
+adrs generate toc --ordered
+```
+
+Output:
+
+```markdown
+1. [1. Record architecture decisions](0001-record-architecture-decisions.md)
+2. [2. Use PostgreSQL for persistence](0002-use-postgresql-for-persistence.md)
+3. [3. API versioning strategy](0003-api-versioning-strategy.md)
 ```
 
 #### Save to File
 
 ```sh
-adrs generate toc -o doc/adr/README.md
+adrs generate toc > doc/adr/README.md
 ```
 
-#### Custom Introduction
+#### With Intro and Outro Files
 
 ```sh
-adrs generate toc -i "# Project Decisions\n\nKey architectural choices:"
+adrs generate toc -i intro.md -O outro.md > doc/adr/README.md
 ```
 
 #### Link Prefix for Wikis
 
 ```sh
-adrs generate toc -l "wiki/adr/"
+adrs generate toc -p "wiki/adr/"
 ```
 
 ---
@@ -91,7 +104,8 @@ adrs generate graph [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `-o, --output <FILE>` | Output file (default: stdout) |
+| `-p, --prefix <PREFIX>` | Prefix for node URLs |
+| `-e, --extension <EXT>` | File extension for links (default: md) |
 | `--ng` | Use NextGen mode |
 | `-C, --cwd <DIR>` | Working directory |
 | `-h, --help` | Print help |
@@ -108,18 +122,22 @@ Output:
 
 ```dot
 digraph {
-  node [shape=box];
+  node [shape=plaintext];
   _1 [label="1. Record architecture decisions"; URL="0001-record-architecture-decisions.md"];
   _2 [label="2. Use PostgreSQL"; URL="0002-use-postgresql.md"];
   _3 [label="3. Use MySQL instead"; URL="0003-use-mysql-instead.md"];
-  _3 -> _2 [style="dashed"; label="Supersedes"];
+  edge [style=dotted, weight=10];
+  _1 -> _2;
+  _2 -> _3;
+  edge [style=solid, weight=1];
+  _3 -> _2 [label="Supersedes"];
 }
 ```
 
 #### Save to File
 
 ```sh
-adrs generate graph -o doc/adr/graph.dot
+adrs generate graph > doc/adr/graph.dot
 ```
 
 #### Render as PNG
@@ -136,27 +154,92 @@ adrs generate graph | dot -Tpng -o doc/adr/graph.png
 adrs generate graph | dot -Tsvg -o doc/adr/graph.svg
 ```
 
+#### HTML Links with Custom Extension
+
+```sh
+adrs generate graph -e html -p "/docs/adr/"
+```
+
 ### Graph Features
 
 - Each ADR is a node with its number and title
-- Links between ADRs are shown as edges
-- Supersedes relationships use dashed lines
+- Sequential ADRs are connected with dotted lines
+- Explicit links between ADRs shown as solid edges with labels
 - Nodes link to their ADR files (clickable in SVG)
+
+---
+
+## generate book
+
+Generate an mdbook from your ADRs.
+
+### Usage
+
+```
+adrs generate book [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <DIR>` | Output directory (default: book) |
+| `-t, --title <TITLE>` | Book title |
+| `-d, --description <DESC>` | Book description |
+| `--ng` | Use NextGen mode |
+| `-C, --cwd <DIR>` | Working directory |
+| `-h, --help` | Print help |
+
+### Examples
+
+#### Basic Book
+
+```sh
+adrs generate book
+```
+
+This creates a `book/` directory with:
+- `book.toml` - mdbook configuration
+- `src/SUMMARY.md` - table of contents
+- `src/*.md` - copies of all ADR files
+
+#### Custom Output Directory
+
+```sh
+adrs generate book -o docs/decisions
+```
+
+#### Custom Title and Description
+
+```sh
+adrs generate book -t "Project Architecture" -d "Key decisions for the project"
+```
+
+#### Build and Serve
+
+After generating:
+
+```sh
+adrs generate book
+cd book
+mdbook serve
+```
 
 ### Integration with CI
 
-Generate and commit the graph automatically:
+Generate and deploy the book automatically:
 
 ```yaml
-- name: Generate ADR graph
+- name: Generate ADR book
   run: |
-    adrs generate graph -o doc/adr/graph.dot
-    dot -Tsvg doc/adr/graph.dot -o doc/adr/graph.svg
+    adrs generate book
+    cd book && mdbook build
 
-- name: Commit graph
-  run: |
-    git add doc/adr/graph.*
-    git commit -m "docs: update ADR graph" || true
+- name: Deploy to GitHub Pages
+  uses: peaceiris/actions-gh-pages@v3
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    publish_dir: ./book/book
 ```
 
 ## Related


### PR DESCRIPTION
Update generate.md to match actual CLI behavior:

- Add missing `generate book` subcommand documentation
- Fix toc options: `--ordered` flag, `--intro/--outro` read from files
- Fix option names: `-p/--prefix` instead of `-l/--link-prefix`
- Fix graph options: add `-p/--prefix` and `-e/--extension`
- Remove non-existent `-o/--output` options (commands write to stdout)
- Update examples to match actual output format