### PR TITLE
chore: release v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adrs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fuzzy-matcher",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -42,7 +42,7 @@ edit = "0.1"
 whoami = "1"
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.5.0" }
+adrs-core = { path = "crates/adrs-core", version = "0.5.1" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-01-22
+
+### Features
+
+- Add status command to change ADR status
+
+
 ## [0.5.0] - 2026-01-22
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-01-22
+
+### Documentation
+
+- Refresh README for v0.5.0
+
+### Features
+
+- Add status command to change ADR status
+
+### Testing
+
+- Add integration tests for status command
+
+
 ## [0.5.0] - 2026-01-22
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `adrs`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.5.1] - 2026-01-22

### Features

- Add status command to change ADR status
</blockquote>

## `adrs`

<blockquote>

## [0.5.1] - 2026-01-22

### Documentation

- Refresh README for v0.5.0

### Features

- Add status command to change ADR status

### Testing

- Add integration tests for status command
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).