### PR TITLE
feat: automatic cross-reference renumbering (Phase 2 of #100)

### DIFF
--- a/crates/adrs/src/commands/import.rs
+++ b/crates/adrs/src/commands/import.rs
@@ -86,10 +86,26 @@ pub fn import_json(
         println!("No ADRs to import.");
     }
 
-    // Warn about renumbering limitations
+    // Show renumbering info and warnings
     if renumber && result.imported > 0 && !dry_run {
         println!("\nNote: ADRs have been renumbered sequentially.");
-        println!("Cross-references within imported ADRs may need manual adjustment.");
+        println!("Internal cross-references have been updated automatically.");
+
+        // Count broken link warnings
+        let broken_links: Vec<&String> = result
+            .warnings
+            .iter()
+            .filter(|w| w.contains("links to ADR") && w.contains("not in the import set"))
+            .collect();
+
+        if !broken_links.is_empty() {
+            println!(
+                "\nWarning: {} broken cross-reference(s) detected:",
+                broken_links.len()
+            );
+            println!("These links reference ADRs that were not included in the import.");
+            println!("You may need to manually fix these references.");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Phase 2 implementation for #100

## Overview

This PR adds **automatic cross-reference renumbering** when importing ADRs with `--renumber`/`--append`. Links within imported ADRs are now updated automatically to match their new numbers.

**Base branch:** `feat/json-adr-export` (depends on Phase 1)

## What Changed

### ✨ Automatic Link Renumbering

When importing with `--renumber`:
- **Internal links** (within imported set) are updated automatically
- **External links** (to ADRs not imported) are preserved but flagged

**Example:**
```bash
# Import ADRs 1, 2, 3 into repo with existing ADRs 1-3
# They become ADRs 4, 5, 6

# Source ADR 1 -> ADR 4
# - Had link to ADR 3 -> now links to ADR 6 ✅

# Source ADR 2 -> ADR 5  
# - Had link to ADR 1 -> now links to ADR 4 ✅

# Source ADR 3 -> ADR 6
# - Had links to ADRs 1 and 2 -> now links to ADRs 4 and 5 ✅
```

### 🔍 Broken Link Detection

Detects when imported ADRs reference ADRs outside the import set:

```
Warning: 1 broken cross-reference(s) detected:
These links reference ADRs that were not included in the import.
You may need to manually fix these references.
```

Specific warnings show which ADR links where:
```
ADR 2 links to ADR 99 which is not in the import set
```

### 📋 Implementation Details

**Two-pass algorithm:**
1. **First pass:** Collect all ADRs and build renumber map
2. **Second pass:** Update links using HashMap lookup and write files

For each link:
- Check if target is in renumber map (O(1) lookup)
- If yes: update to new number
- If no: preserve original, add warning

### 🧪 Testing

Added 3 comprehensive tests:
- `test_import_renumber_with_internal_links`: Bidirectional links between ADRs
- `test_import_renumber_with_broken_links`: Links to external ADRs
- `test_import_renumber_complex_links`: Multiple ADRs with various patterns

All 308 library tests pass ✅

### 📝 Updated Messages

**Success message:**
```
Note: ADRs have been renumbered sequentially.
Internal cross-references have been updated automatically.
```

**With broken links:**
```
Warning: 2 broken cross-reference(s) detected:
These links reference ADRs that were not included in the import.
You may need to manually fix these references.
```

## Manual Testing

Tested with:
- ✅ Multiple ADRs with bidirectional links
- ✅ ADRs with gaps in numbering
- ✅ ADRs linking to external references
- ✅ Complex link patterns (multiple links per ADR)

All links renumbered correctly, broken links detected properly.

## Use Case

Merging ADR sets from different projects:
```bash
# Export from acquired project
cd ~/acquired-project
adrs export json --pretty > ../acquired-adrs.json

# Preview the merge
cd ~/main-project
adrs import json ../acquired-adrs.json --dry-run --append

# Import with automatic link fixing
adrs import json ../acquired-adrs.json --append
# ✅ All internal cross-references updated automatically
# ⚠️  Broken links to external ADRs detected and reported
```

## Breaking Changes

None - this enhances existing functionality.

## Related

- Completes #100 (Phase 1 + Phase 2)
- Depends on Phase 1 in base branch