### PR TITLE
chore: release v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -42,7 +42,7 @@ edit = "0.1"
 whoami = "1"
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.5.0" }
+adrs-core = { path = "crates/adrs-core", version = "0.5.1" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-01-25
+
+### Features
+
+- Add status command to change ADR status
+- Add JSON-ADR export support
+- Add custom_sections field to JSON-ADR for extensibility
+- Add MADR-inspired fields to JSON-ADR spec
+- Add export --dir and import json commands
+- Add --dry-run and --append flags to import command
+- Add automatic cross-reference renumbering (Phase 2 of #100)
+- Add lint command and integrate mdbook-lint ADR rules ([#98](https://github.com/joshrotenberg/adrs/pull/98))
+
+### Miscellaneous
+
+- Use published mdbook-lint crates (0.13.7)
+
+
 ## [0.5.0] - 2026-01-22
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-01-25
+
+### Documentation
+
+- Refresh README for v0.5.0
+
+### Features
+
+- Add status command to change ADR status
+- Add JSON-ADR export support
+- Add export --dir and import json commands
+- Add --dry-run and --append flags to import command
+- Add automatic cross-reference renumbering (Phase 2 of #100)
+- Add lint command and integrate mdbook-lint ADR rules ([#98](https://github.com/joshrotenberg/adrs/pull/98))
+
+### Refactoring
+
+- Simplify to just doctor command, remove separate lint
+
+### Testing
+
+- Add integration tests for status command
+
+
 ## [0.5.0] - 2026-01-22
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `adrs`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.5.1] - 2026-01-25

### Features

- Add status command to change ADR status
- Add JSON-ADR export support
- Add custom_sections field to JSON-ADR for extensibility
- Add MADR-inspired fields to JSON-ADR spec
- Add export --dir and import json commands
- Add --dry-run and --append flags to import command
- Add automatic cross-reference renumbering (Phase 2 of #100)
- Add lint command and integrate mdbook-lint ADR rules ([#98](https://github.com/joshrotenberg/adrs/pull/98))

### Miscellaneous

- Use published mdbook-lint crates (0.13.7)
</blockquote>

## `adrs`

<blockquote>

## [0.5.1] - 2026-01-25

### Documentation

- Refresh README for v0.5.0

### Features

- Add status command to change ADR status
- Add JSON-ADR export support
- Add export --dir and import json commands
- Add --dry-run and --append flags to import command
- Add automatic cross-reference renumbering (Phase 2 of #100)
- Add lint command and integrate mdbook-lint ADR rules ([#98](https://github.com/joshrotenberg/adrs/pull/98))

### Refactoring

- Simplify to just doctor command, remove separate lint

### Testing

- Add integration tests for status command
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).