### PR TITLE
fix: handle existing release in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
-      - name: Create GitHub Release
+      - name: Create or Update GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
@@ -276,7 +276,14 @@ jobs:
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          # Check if release already exists (created by dist host --steps=create)
+          if gh release view "${{ needs.plan.outputs.tag }}" > /dev/null 2>&1; then
+            echo "Release already exists, uploading artifacts..."
+            gh release upload "${{ needs.plan.outputs.tag }}" artifacts/* --clobber
+          else
+            echo "Creating new release..."
+            gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          fi
 
   publish-homebrew-formula:
     needs:


### PR DESCRIPTION
## Problem

The release workflow was intermittently failing with:
```
a release with the same tag name already exists: v0.5.1
```

## Root Cause

The `release.yml` workflow has two places that create releases:

1. `plan` job runs `dist host --steps=create` which creates the GitHub release
2. `host` job runs `gh release create` which tries to create it again

When `dist` successfully creates the release in step 1, step 2 fails because the release already exists.

## Fix

Check if the release exists before trying to create it. If it exists, use `gh release upload --clobber` to add artifacts to the existing release instead of failing.

```yaml
if gh release view "$TAG" > /dev/null 2>&1; then
  gh release upload "$TAG" artifacts/* --clobber
else
  gh release create "$TAG" ...
fi
```