### PR TITLE
feat: add source_uri field to JSON-ADR spec for federation

### DIFF
--- a/crates/adrs/src/commands/export.rs
+++ b/crates/adrs/src/commands/export.rs
@@ -1,6 +1,6 @@
 //! Export commands.
 
-use adrs_core::{Repository, export_adr, export_directory, export_repository};
+use adrs_core::{JsonAdr, Repository, export_adr, export_directory, export_repository};
 use anyhow::{Context, Result};
 use std::path::Path;
 
@@ -8,11 +8,18 @@ use std::path::Path;
 ///
 /// If `dir` is provided, exports from that directory without requiring an adrs repository.
 /// Otherwise, exports from the repository at `root`.
+///
+/// Options:
+/// - `metadata_only`: If true, excludes content fields (context, decision, consequences)
+///   and sets source_uri based on base_url.
+/// - `base_url`: Base URL for constructing source_uri values.
 pub fn export_json(
     root: &Path,
     adr_number: Option<u32>,
     dir: Option<&Path>,
     pretty: bool,
+    metadata_only: bool,
+    base_url: Option<String>,
 ) -> Result<()> {
     let json = if let Some(dir_path) = dir {
         // Export from arbitrary directory (no repo required)
@@ -20,10 +27,16 @@ pub fn export_json(
             anyhow::bail!("Cannot specify both --dir and an ADR number");
         }
 
-        let export = export_directory(dir_path).context(format!(
+        let mut export = export_directory(dir_path).context(format!(
             "Failed to export from directory: {}",
             dir_path.display()
         ))?;
+
+        if metadata_only || base_url.is_some() {
+            for adr in &mut export.adrs {
+                apply_metadata_options(adr, metadata_only, &base_url);
+            }
+        }
 
         if pretty {
             serde_json::to_string_pretty(&export)?
@@ -39,7 +52,11 @@ pub fn export_json(
             let adr = repo
                 .get(number)
                 .context(format!("ADR {} not found", number))?;
-            let json_adr = export_adr(&adr);
+            let mut json_adr = export_adr(&adr);
+
+            if metadata_only || base_url.is_some() {
+                apply_metadata_options(&mut json_adr, metadata_only, &base_url);
+            }
 
             if pretty {
                 serde_json::to_string_pretty(&json_adr)?
@@ -48,7 +65,13 @@ pub fn export_json(
             }
         } else {
             // Export all ADRs
-            let export = export_repository(&repo)?;
+            let mut export = export_repository(&repo)?;
+
+            if metadata_only || base_url.is_some() {
+                for adr in &mut export.adrs {
+                    apply_metadata_options(adr, metadata_only, &base_url);
+                }
+            }
 
             if pretty {
                 serde_json::to_string_pretty(&export)?
@@ -60,4 +83,33 @@ pub fn export_json(
 
     println!("{}", json);
     Ok(())
+}
+
+/// Apply metadata-only options to a JSON ADR.
+fn apply_metadata_options(adr: &mut JsonAdr, metadata_only: bool, base_url: &Option<String>) {
+    // Set source_uri from base_url and path
+    if let Some(base) = base_url
+        && let Some(path) = &adr.path
+    {
+        // Extract just the filename from the path
+        let filename = std::path::Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(path);
+
+        // Construct the full URI
+        let base_trimmed = base.trim_end_matches('/');
+        adr.source_uri = Some(format!("{}/{}", base_trimmed, filename));
+    }
+
+    // Clear content fields if metadata_only
+    if metadata_only {
+        adr.context = None;
+        adr.decision = None;
+        adr.consequences = None;
+        adr.confirmation = None;
+        adr.decision_drivers.clear();
+        adr.considered_options.clear();
+        adr.custom_sections.clear();
+    }
 }

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -207,6 +207,14 @@ enum ExportCommands {
         /// Pretty-print the JSON output
         #[arg(short, long)]
         pretty: bool,
+
+        /// Export metadata only (excludes content, includes source_uri)
+        #[arg(long)]
+        metadata_only: bool,
+
+        /// Base URL for source_uri (e.g., https://github.com/org/repo/blob/main/doc/adr)
+        #[arg(long, value_name = "URL")]
+        base_url: Option<String>,
     },
 }
 
@@ -319,14 +327,34 @@ fn main() -> Result<()> {
             }
         }
         Commands::Export { command } => match command {
-            ExportCommands::Json { adr, dir, pretty } => {
+            ExportCommands::Json {
+                adr,
+                dir,
+                pretty,
+                metadata_only,
+                base_url,
+            } => {
                 if let Some(ref dir_path) = dir {
                     // Export from arbitrary directory - no repo needed
-                    commands::export_json(&start_dir, adr, Some(dir_path), pretty)
+                    commands::export_json(
+                        &start_dir,
+                        adr,
+                        Some(dir_path),
+                        pretty,
+                        metadata_only,
+                        base_url,
+                    )
                 } else {
                     // Export from repository
                     let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
-                    commands::export_json(&discovered.root, adr, None, pretty)
+                    commands::export_json(
+                        &discovered.root,
+                        adr,
+                        None,
+                        pretty,
+                        metadata_only,
+                        base_url,
+                    )
                 }
             }
         },

--- a/schema/json-adr/v1.json
+++ b/schema/json-adr/v1.json
@@ -93,6 +93,11 @@
           "items": { "type": "string" },
           "description": "Categorization labels"
         },
+        "source_uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to the source ADR file (for federation/reference)"
+        },
         "context": {
           "type": "string",
           "description": "Background and problem statement"


### PR DESCRIPTION
## Summary

Adds an optional `source_uri` field to the JSON-ADR spec to enable federation and lightweight indexing of ADRs across repositories.

- Add `source_uri` field to `JsonAdr` struct
- Add `--metadata-only` CLI flag to export metadata without content fields
- Add `--base-url` CLI flag to construct source_uri from base URL + filename
- Update JSON-ADR schema with source_uri field definition
- Add tests for new functionality

## Use Cases

1. **Organization-wide ADR index**: Create a lightweight catalog of ADRs across multiple repos without duplicating content
2. **Federation**: Reference ADRs from other projects without copying
3. **Reduced payload**: For large exports, consumers can fetch content on demand

## Examples

Export with metadata only (no content, includes source_uri):
```bash
adrs export json --metadata-only --base-url "https://github.com/org/repo/blob/main/doc/adr" --pretty
```

Export with source_uri but keep all content (useful for caching/snapshots):
```bash
adrs export json --base-url "https://github.com/org/repo/blob/main/doc/adr" --pretty
```

## Output Example

```json
{
  "number": 1,
  "title": "Use PostgreSQL",
  "status": "Accepted",
  "date": "2024-01-15",
  "source_uri": "https://github.com/org/repo/blob/main/doc/adr/0001-use-postgresql.md",
  "path": "doc/adr/0001-use-postgresql.md"
}
```

Closes #99