### PR TITLE
feat: add filtering options to list command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "time",
  "whoami",
 ]
 

--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 clap.workspace = true
 edit.workspace = true
 serde_json = "1"
+time.workspace = true
 whoami.workspace = true
 
 [dev-dependencies]

--- a/crates/adrs/src/commands/list.rs
+++ b/crates/adrs/src/commands/list.rs
@@ -1,21 +1,327 @@
 //! List ADRs command.
 
-use adrs_core::Repository;
+use adrs_core::{Adr, AdrStatus, Repository};
 use anyhow::{Context, Result};
 use std::path::Path;
+use time::Date;
 
-pub fn list(root: &Path) -> Result<()> {
+/// List ADRs with optional filtering.
+pub fn list(
+    root: &Path,
+    status_filter: Option<String>,
+    since: Option<String>,
+    until: Option<String>,
+    decider: Option<String>,
+    long_format: bool,
+) -> Result<()> {
     let repo =
         Repository::open(root).context("ADR repository not found. Run 'adrs init' first.")?;
 
     let adrs = repo.list()?;
-    for adr in adrs {
-        if let Some(path) = &adr.path {
-            println!("{}", path.display());
+
+    // Parse date filters
+    let since_date = parse_date_filter(&since)?;
+    let until_date = parse_date_filter(&until)?;
+
+    // Parse status filter
+    let status_filter: Option<AdrStatus> = status_filter.map(|s| s.parse().unwrap());
+
+    // Filter ADRs
+    let filtered: Vec<&Adr> = adrs
+        .iter()
+        .filter(|adr| matches_filters(adr, &status_filter, &since_date, &until_date, &decider))
+        .collect();
+
+    // Output
+    for adr in filtered {
+        if long_format {
+            print_long_format(adr);
         } else {
-            println!("{}", adr.filename());
+            print_short_format(adr);
         }
     }
 
     Ok(())
+}
+
+/// Parse a date string in YYYY-MM-DD format.
+fn parse_date_filter(date_str: &Option<String>) -> Result<Option<Date>> {
+    match date_str {
+        Some(s) => {
+            let date = Date::parse(s, &time::format_description::well_known::Iso8601::DATE)
+                .with_context(|| format!("Invalid date format: '{}'. Use YYYY-MM-DD.", s))?;
+            Ok(Some(date))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Check if an ADR matches all the provided filters.
+fn matches_filters(
+    adr: &Adr,
+    status_filter: &Option<AdrStatus>,
+    since_date: &Option<Date>,
+    until_date: &Option<Date>,
+    decider: &Option<String>,
+) -> bool {
+    // Status filter (case-insensitive match)
+    if let Some(filter_status) = status_filter
+        && !status_matches(&adr.status, filter_status)
+    {
+        return false;
+    }
+
+    // Since date filter
+    if let Some(since) = since_date
+        && adr.date < *since
+    {
+        return false;
+    }
+
+    // Until date filter
+    if let Some(until) = until_date
+        && adr.date > *until
+    {
+        return false;
+    }
+
+    // Decider filter (case-insensitive substring match)
+    if let Some(decider_name) = decider {
+        let decider_lower = decider_name.to_lowercase();
+        let has_decider = adr
+            .decision_makers
+            .iter()
+            .any(|dm| dm.to_lowercase().contains(&decider_lower));
+        if !has_decider {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Check if two statuses match (case-insensitive).
+fn status_matches(adr_status: &AdrStatus, filter_status: &AdrStatus) -> bool {
+    match (adr_status, filter_status) {
+        (AdrStatus::Proposed, AdrStatus::Proposed) => true,
+        (AdrStatus::Accepted, AdrStatus::Accepted) => true,
+        (AdrStatus::Deprecated, AdrStatus::Deprecated) => true,
+        (AdrStatus::Superseded, AdrStatus::Superseded) => true,
+        (AdrStatus::Custom(a), AdrStatus::Custom(b)) => a.to_lowercase() == b.to_lowercase(),
+        // Allow matching custom status against standard ones by name
+        (AdrStatus::Custom(s), standard) | (standard, AdrStatus::Custom(s)) => {
+            s.to_lowercase() == standard.to_string().to_lowercase()
+        }
+        _ => false,
+    }
+}
+
+/// Print ADR in short format (just the path).
+fn print_short_format(adr: &Adr) {
+    if let Some(path) = &adr.path {
+        println!("{}", path.display());
+    } else {
+        println!("{}", adr.filename());
+    }
+}
+
+/// Print ADR in long format (number, status, date, title).
+fn print_long_format(adr: &Adr) {
+    let date = adr
+        .date
+        .format(&time::format_description::well_known::Iso8601::DATE)
+        .unwrap_or_default();
+
+    println!(
+        "{:4}  {:12}  {}  {}",
+        adr.number, adr.status, date, adr.title
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::Month;
+
+    fn create_test_adr(number: u32, status: AdrStatus, date: Date) -> Adr {
+        let mut adr = Adr::new(number, format!("Test ADR {}", number));
+        adr.status = status;
+        adr.date = date;
+        adr
+    }
+
+    #[test]
+    fn test_status_matches_same() {
+        assert!(status_matches(&AdrStatus::Accepted, &AdrStatus::Accepted));
+        assert!(status_matches(&AdrStatus::Proposed, &AdrStatus::Proposed));
+        assert!(status_matches(
+            &AdrStatus::Deprecated,
+            &AdrStatus::Deprecated
+        ));
+        assert!(status_matches(
+            &AdrStatus::Superseded,
+            &AdrStatus::Superseded
+        ));
+    }
+
+    #[test]
+    fn test_status_matches_different() {
+        assert!(!status_matches(&AdrStatus::Accepted, &AdrStatus::Proposed));
+        assert!(!status_matches(
+            &AdrStatus::Proposed,
+            &AdrStatus::Deprecated
+        ));
+    }
+
+    #[test]
+    fn test_status_matches_custom() {
+        assert!(status_matches(
+            &AdrStatus::Custom("Draft".to_string()),
+            &AdrStatus::Custom("draft".to_string())
+        ));
+        assert!(status_matches(
+            &AdrStatus::Custom("DRAFT".to_string()),
+            &AdrStatus::Custom("draft".to_string())
+        ));
+    }
+
+    #[test]
+    fn test_matches_filters_status() {
+        let date = Date::from_calendar_date(2024, Month::January, 15).unwrap();
+        let adr = create_test_adr(1, AdrStatus::Accepted, date);
+
+        assert!(matches_filters(
+            &adr,
+            &Some(AdrStatus::Accepted),
+            &None,
+            &None,
+            &None
+        ));
+        assert!(!matches_filters(
+            &adr,
+            &Some(AdrStatus::Proposed),
+            &None,
+            &None,
+            &None
+        ));
+    }
+
+    #[test]
+    fn test_matches_filters_since() {
+        let date = Date::from_calendar_date(2024, Month::June, 15).unwrap();
+        let adr = create_test_adr(1, AdrStatus::Accepted, date);
+
+        let before = Date::from_calendar_date(2024, Month::January, 1).unwrap();
+        let after = Date::from_calendar_date(2024, Month::December, 1).unwrap();
+
+        assert!(matches_filters(&adr, &None, &Some(before), &None, &None));
+        assert!(!matches_filters(&adr, &None, &Some(after), &None, &None));
+    }
+
+    #[test]
+    fn test_matches_filters_until() {
+        let date = Date::from_calendar_date(2024, Month::June, 15).unwrap();
+        let adr = create_test_adr(1, AdrStatus::Accepted, date);
+
+        let before = Date::from_calendar_date(2024, Month::January, 1).unwrap();
+        let after = Date::from_calendar_date(2024, Month::December, 1).unwrap();
+
+        assert!(matches_filters(&adr, &None, &None, &Some(after), &None));
+        assert!(!matches_filters(&adr, &None, &None, &Some(before), &None));
+    }
+
+    #[test]
+    fn test_matches_filters_decider() {
+        let date = Date::from_calendar_date(2024, Month::January, 15).unwrap();
+        let mut adr = create_test_adr(1, AdrStatus::Accepted, date);
+        adr.decision_makers = vec!["Alice Smith".to_string(), "Bob Jones".to_string()];
+
+        assert!(matches_filters(
+            &adr,
+            &None,
+            &None,
+            &None,
+            &Some("alice".to_string())
+        ));
+        assert!(matches_filters(
+            &adr,
+            &None,
+            &None,
+            &None,
+            &Some("Smith".to_string())
+        ));
+        assert!(matches_filters(
+            &adr,
+            &None,
+            &None,
+            &None,
+            &Some("bob".to_string())
+        ));
+        assert!(!matches_filters(
+            &adr,
+            &None,
+            &None,
+            &None,
+            &Some("charlie".to_string())
+        ));
+    }
+
+    #[test]
+    fn test_matches_filters_combined() {
+        let date = Date::from_calendar_date(2024, Month::June, 15).unwrap();
+        let mut adr = create_test_adr(1, AdrStatus::Accepted, date);
+        adr.decision_makers = vec!["Alice".to_string()];
+
+        let since = Date::from_calendar_date(2024, Month::January, 1).unwrap();
+        let until = Date::from_calendar_date(2024, Month::December, 1).unwrap();
+
+        // All filters match
+        assert!(matches_filters(
+            &adr,
+            &Some(AdrStatus::Accepted),
+            &Some(since),
+            &Some(until),
+            &Some("Alice".to_string())
+        ));
+
+        // Status doesn't match
+        assert!(!matches_filters(
+            &adr,
+            &Some(AdrStatus::Proposed),
+            &Some(since),
+            &Some(until),
+            &Some("Alice".to_string())
+        ));
+
+        // Decider doesn't match
+        assert!(!matches_filters(
+            &adr,
+            &Some(AdrStatus::Accepted),
+            &Some(since),
+            &Some(until),
+            &Some("Bob".to_string())
+        ));
+    }
+
+    #[test]
+    fn test_parse_date_filter_valid() {
+        let result = parse_date_filter(&Some("2024-01-15".to_string())).unwrap();
+        assert!(result.is_some());
+        let date = result.unwrap();
+        assert_eq!(date.year(), 2024);
+        assert_eq!(date.month(), Month::January);
+        assert_eq!(date.day(), 15);
+    }
+
+    #[test]
+    fn test_parse_date_filter_none() {
+        let result = parse_date_filter(&None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_date_filter_invalid() {
+        let result = parse_date_filter(&Some("not-a-date".to_string()));
+        assert!(result.is_err());
+    }
 }

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -89,7 +89,27 @@ enum Commands {
     },
 
     /// List all ADRs
-    List,
+    List {
+        /// Filter by status (e.g., proposed, accepted, deprecated, superseded)
+        #[arg(short, long, value_name = "STATUS")]
+        status: Option<String>,
+
+        /// Filter by date (show ADRs from this date onwards, YYYY-MM-DD)
+        #[arg(long, value_name = "DATE")]
+        since: Option<String>,
+
+        /// Filter by date (show ADRs up to this date, YYYY-MM-DD)
+        #[arg(long, value_name = "DATE")]
+        until: Option<String>,
+
+        /// Filter by decision maker (MADR format)
+        #[arg(long, value_name = "NAME")]
+        decider: Option<String>,
+
+        /// Show detailed output (number, status, date, title)
+        #[arg(short = 'l', long)]
+        long: bool,
+    },
 
     /// Link two ADRs together
     Link {
@@ -282,9 +302,15 @@ fn main() -> Result<()> {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
             commands::edit(&discovered.root, &adr)
         }
-        Commands::List => {
+        Commands::List {
+            status,
+            since,
+            until,
+            decider,
+            long,
+        } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
-            commands::list(&discovered.root)
+            commands::list(&discovered.root, status, since, until, decider, long)
         }
         Commands::Link {
             source,


### PR DESCRIPTION
## Summary

Adds filtering capabilities to `adrs list` command:
- `--status <STATUS>`: Filter by status (proposed, accepted, deprecated, superseded)
- `--since <DATE>`: Filter by date (show ADRs from this date onwards, YYYY-MM-DD)
- `--until <DATE>`: Filter by date (show ADRs up to this date, YYYY-MM-DD)
- `--decider <NAME>`: Filter by decision maker (MADR format, case-insensitive substring match)
- `-l/--long`: Show detailed output (number, status, date, title)

Multiple filters can be combined and are AND'd together.

## Examples

```bash
# Show all accepted ADRs
adrs list --status accepted

# Show ADRs needing review
adrs list --status proposed -l

# Show ADRs from 2024 onwards
adrs list --since 2024-01-01 -l

# Show ADRs decided by Alice
adrs list --decider alice -l

# Combined filters
adrs list --status accepted --since 2024-01-01 --decider "Alice Smith" -l
```

## Output Example

```
   1  Accepted  2026-01-26  Record architecture decisions
   2  Accepted  2026-01-26  Use PostgreSQL for persistence
   3  Proposed  2026-01-26  Use Rust for backend services
```

## Notes

- Tag filtering (`--tag`) is deferred until tag support is implemented (#84)
- Works with both legacy and NextGen format ADRs
- Decider filter uses case-insensitive substring matching

Closes #83