### PR TITLE
feat: add template management commands

### DIFF
--- a/crates/adrs-core/src/template.rs
+++ b/crates/adrs-core/src/template.rs
@@ -103,6 +103,16 @@ impl Template {
         }
     }
 
+    /// Get the template content.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Get the template name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// Load a template from a file.
     pub fn from_file(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path)?;

--- a/crates/adrs/src/commands/mod.rs
+++ b/crates/adrs/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod link;
 mod list;
 mod new;
 mod status;
+mod template;
 
 pub use config::config_with_discovery;
 pub use doctor::doctor;
@@ -23,3 +24,4 @@ pub use link::link;
 pub use list::list;
 pub use new::new;
 pub use status::status;
+pub use template::{list as template_list, show as template_show};

--- a/crates/adrs/src/commands/template.rs
+++ b/crates/adrs/src/commands/template.rs
@@ -1,0 +1,70 @@
+//! Template management commands.
+
+use adrs_core::{Template, TemplateFormat, TemplateVariant};
+use anyhow::Result;
+
+/// List available templates.
+pub fn list() -> Result<()> {
+    println!("Built-in templates:");
+    println!("  nygard     Classic adr-tools format (default)");
+    println!("  madr       MADR 4.0.0 with structured metadata");
+    println!();
+    println!("Variants:");
+    println!("  full           All sections with guidance text (default)");
+    println!("  minimal        Core sections only, with guidance text");
+    println!("  bare           All sections, but empty (no guidance)");
+    println!("  bare-minimal   Core sections only, empty (no guidance)");
+    println!();
+    println!("Usage:");
+    println!("  adrs new --format madr --variant minimal \"Title\"");
+    println!("  adrs template show madr --variant bare");
+
+    Ok(())
+}
+
+/// Show a template's content.
+pub fn show(format: &str, variant: Option<&str>) -> Result<()> {
+    let template_format: TemplateFormat = format
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Unknown format '{}'. Use 'nygard' or 'madr'.", format))?;
+
+    let template_variant: TemplateVariant = variant
+        .map(|v| {
+            v.parse().map_err(|_| {
+                anyhow::anyhow!(
+                    "Unknown variant '{}'. Use 'full', 'minimal', 'bare', or 'bare-minimal'.",
+                    v
+                )
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    let template = Template::builtin_with_variant(template_format, template_variant);
+
+    println!("# {} ({} variant)", template_format, template_variant);
+    println!();
+    println!("Template variables:");
+    println!("  {{{{ number }}}}       ADR number");
+    println!("  {{{{ title }}}}        ADR title");
+    println!("  {{{{ date }}}}         Creation date (YYYY-MM-DD)");
+    println!("  {{{{ status }}}}       Status (proposed, accepted, etc.)");
+    println!("  {{{{ context }}}}      Context section content");
+    println!("  {{{{ decision }}}}     Decision section content");
+    println!("  {{{{ consequences }}}} Consequences section content");
+    println!("  {{{{ links }}}}        Array of links to other ADRs");
+    println!("  {{{{ is_ng }}}}        True if using next-gen mode");
+    println!();
+    if matches!(template_format, TemplateFormat::Madr) {
+        println!("MADR-specific variables:");
+        println!("  {{{{ decision_makers }}}} Array of decision makers");
+        println!("  {{{{ consulted }}}}       Array of consulted parties");
+        println!("  {{{{ informed }}}}        Array of informed parties");
+        println!();
+    }
+    println!("---");
+    println!();
+    print!("{}", template.content());
+
+    Ok(())
+}

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -162,6 +162,12 @@ enum Commands {
         #[command(subcommand)]
         command: ImportCommands,
     },
+
+    /// Manage ADR templates
+    Template {
+        #[command(subcommand)]
+        command: TemplateCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -265,6 +271,22 @@ enum ImportCommands {
         /// Use next-gen mode with YAML frontmatter
         #[arg(long)]
         ng: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum TemplateCommands {
+    /// List available templates
+    List,
+
+    /// Show a template's content
+    Show {
+        /// Template format: nygard, madr
+        format: String,
+
+        /// Template variant: full, minimal, bare, bare-minimal
+        #[arg(short, long, value_name = "VARIANT")]
+        variant: Option<String>,
     },
 }
 
@@ -417,6 +439,12 @@ fn main() -> Result<()> {
                         ng,
                     )
                 }
+            }
+        },
+        Commands::Template { command } => match command {
+            TemplateCommands::List => commands::template_list(),
+            TemplateCommands::Show { format, variant } => {
+                commands::template_show(&format, variant.as_deref())
             }
         },
     }


### PR DESCRIPTION
## Summary

Add commands to list and preview ADR templates:

- `adrs template list` - Show available templates (nygard, madr) and variants (full, minimal, bare, bare-minimal)
- `adrs template show <format>` - Preview template content with variable documentation
- `adrs template show <format> --variant <variant>` - Show specific template variant

## Usage

```bash
# List available templates
adrs template list

# Show default nygard template
adrs template show nygard

# Show MADR minimal template
adrs template show madr --variant minimal

# Show bare template (all sections, no guidance text)
adrs template show nygard --variant bare
```

## Example Output

```
$ adrs template list
Built-in templates:
  nygard     Classic adr-tools format (default)
  madr       MADR 4.0.0 with structured metadata

Variants:
  full           All sections with guidance text (default)
  minimal        Core sections only, with guidance text
  bare           All sections, but empty (no guidance)
  bare-minimal   Core sections only, empty (no guidance)
```

## Test plan

- [x] All existing tests pass (372 tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `adrs template list` shows available templates
- [x] `adrs template show nygard` shows nygard template
- [x] `adrs template show madr --variant minimal` shows MADR minimal

Closes #90