### PR TITLE
feat: add search command for full-text search

### DIFF
--- a/crates/adrs/src/commands/mod.rs
+++ b/crates/adrs/src/commands/mod.rs
@@ -10,6 +10,7 @@ mod init;
 mod link;
 mod list;
 mod new;
+mod search;
 mod status;
 
 pub use config::config_with_discovery;
@@ -22,4 +23,5 @@ pub use init::init;
 pub use link::link;
 pub use list::list;
 pub use new::new;
+pub use search::search;
 pub use status::status;

--- a/crates/adrs/src/commands/search.rs
+++ b/crates/adrs/src/commands/search.rs
@@ -1,0 +1,191 @@
+//! Search ADRs command.
+
+use adrs_core::{Adr, AdrStatus, Repository};
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Search ADRs for matching content.
+pub fn search(
+    root: &Path,
+    query: &str,
+    title_only: bool,
+    status_filter: Option<String>,
+    case_sensitive: bool,
+) -> Result<()> {
+    let repo =
+        Repository::open(root).context("ADR repository not found. Run 'adrs init' first.")?;
+
+    let adrs = repo.list()?;
+
+    // Parse status filter
+    let status_filter: Option<AdrStatus> = status_filter.map(|s| s.parse().unwrap());
+
+    // Prepare query for matching
+    let query_normalized = if case_sensitive {
+        query.to_string()
+    } else {
+        query.to_lowercase()
+    };
+
+    let mut found_any = false;
+
+    for adr in adrs {
+        // Apply status filter
+        if let Some(ref filter_status) = status_filter
+            && !status_matches(&adr.status, filter_status)
+        {
+            continue;
+        }
+
+        // Search for matches
+        let matches = find_matches(&adr, &query_normalized, title_only, case_sensitive);
+
+        if !matches.is_empty() {
+            found_any = true;
+            print_result(&adr, &matches, query);
+        }
+    }
+
+    if !found_any {
+        println!("No matches found for '{}'", query);
+    }
+
+    Ok(())
+}
+
+/// Find matches in an ADR.
+fn find_matches(
+    adr: &Adr,
+    query: &str,
+    title_only: bool,
+    case_sensitive: bool,
+) -> Vec<SearchMatch> {
+    let mut matches = Vec::new();
+
+    // Check title
+    if contains_match(&adr.title, query, case_sensitive) {
+        matches.push(SearchMatch {
+            section: "Title".to_string(),
+            snippet: adr.title.clone(),
+        });
+    }
+
+    if title_only {
+        return matches;
+    }
+
+    // Check context
+    if contains_match(&adr.context, query, case_sensitive) {
+        matches.push(SearchMatch {
+            section: "Context".to_string(),
+            snippet: extract_snippet(&adr.context, query, case_sensitive),
+        });
+    }
+
+    // Check decision
+    if contains_match(&adr.decision, query, case_sensitive) {
+        matches.push(SearchMatch {
+            section: "Decision".to_string(),
+            snippet: extract_snippet(&adr.decision, query, case_sensitive),
+        });
+    }
+
+    // Check consequences
+    if contains_match(&adr.consequences, query, case_sensitive) {
+        matches.push(SearchMatch {
+            section: "Consequences".to_string(),
+            snippet: extract_snippet(&adr.consequences, query, case_sensitive),
+        });
+    }
+
+    matches
+}
+
+/// Check if text contains the query.
+fn contains_match(text: &str, query: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        text.contains(query)
+    } else {
+        text.to_lowercase().contains(query)
+    }
+}
+
+/// Extract a snippet around the match.
+fn extract_snippet(text: &str, query: &str, case_sensitive: bool) -> String {
+    let text_search = if case_sensitive {
+        text.to_string()
+    } else {
+        text.to_lowercase()
+    };
+
+    if let Some(pos) = text_search.find(query) {
+        // Get some context around the match
+        let start = pos.saturating_sub(40);
+        let end = (pos + query.len() + 40).min(text.len());
+
+        // Find word boundaries
+        let start = text[..start]
+            .rfind(char::is_whitespace)
+            .map(|p| p + 1)
+            .unwrap_or(start);
+        let end = text[end..]
+            .find(char::is_whitespace)
+            .map(|p| end + p)
+            .unwrap_or(end);
+
+        let mut snippet = text[start..end].to_string();
+
+        // Add ellipsis if truncated
+        if start > 0 {
+            snippet = format!("...{}", snippet);
+        }
+        if end < text.len() {
+            snippet = format!("{}...", snippet);
+        }
+
+        // Replace newlines with spaces for cleaner output
+        snippet.replace('\n', " ")
+    } else {
+        // Fallback: first 80 chars
+        let preview: String = text.chars().take(80).collect();
+        if text.len() > 80 {
+            format!("{}...", preview)
+        } else {
+            preview
+        }
+    }
+}
+
+/// Print a search result.
+fn print_result(adr: &Adr, matches: &[SearchMatch], _query: &str) {
+    println!("{}. {}", adr.number, adr.title);
+
+    for m in matches {
+        if m.section != "Title" {
+            println!("   {}: {}", m.section, m.snippet);
+        }
+    }
+
+    println!();
+}
+
+/// A match found in an ADR.
+struct SearchMatch {
+    section: String,
+    snippet: String,
+}
+
+/// Check if two statuses match (case-insensitive).
+fn status_matches(adr_status: &AdrStatus, filter_status: &AdrStatus) -> bool {
+    match (adr_status, filter_status) {
+        (AdrStatus::Proposed, AdrStatus::Proposed) => true,
+        (AdrStatus::Accepted, AdrStatus::Accepted) => true,
+        (AdrStatus::Deprecated, AdrStatus::Deprecated) => true,
+        (AdrStatus::Superseded, AdrStatus::Superseded) => true,
+        (AdrStatus::Custom(a), AdrStatus::Custom(b)) => a.to_lowercase() == b.to_lowercase(),
+        (AdrStatus::Custom(s), standard) | (standard, AdrStatus::Custom(s)) => {
+            s.to_lowercase() == standard.to_string().to_lowercase()
+        }
+        _ => false,
+    }
+}

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -111,6 +111,24 @@ enum Commands {
         long: bool,
     },
 
+    /// Search ADRs for matching content
+    Search {
+        /// Search query
+        query: String,
+
+        /// Search titles only
+        #[arg(short = 't', long)]
+        title: bool,
+
+        /// Filter by status
+        #[arg(short, long, value_name = "STATUS")]
+        status: Option<String>,
+
+        /// Case-sensitive search
+        #[arg(short = 'c', long)]
+        case_sensitive: bool,
+    },
+
     /// Link two ADRs together
     Link {
         /// Source ADR number
@@ -311,6 +329,15 @@ fn main() -> Result<()> {
         } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
             commands::list(&discovered.root, status, since, until, decider, long)
+        }
+        Commands::Search {
+            query,
+            title,
+            status,
+            case_sensitive,
+        } => {
+            let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+            commands::search(&discovered.root, &query, title, status, case_sensitive)
         }
         Commands::Link {
             source,


### PR DESCRIPTION
## Summary

Add command to search ADRs by content across title, context, decision, and consequences sections.

## Usage

```bash
# Search all content
adrs search "database"

# Search titles only
adrs search "security" --title

# Combine with status filter
adrs search "OAuth" --status accepted

# Case-sensitive search
adrs search "API" --case-sensitive
```

## Example Output

```
$ adrs search "architecture"
1. Record architecture decisions
   Decision: We will use Architecture Decision Records, as [described by Michael...

4. Library-first architecture

$ adrs search "rust" --status accepted
2. Rewrite it in Rust
   Decision: Rewrite the original `adr-tools` in Rust.

3. Use mdBook for documentation
   Decision: ...will have an [mdBook](https://github.com/rust-lang/mdBook) based documentation site.
```

## Features

- Search across title, context, decision, and consequences sections
- `--title` flag for title-only search
- `--status` filter to combine with search
- `--case-sensitive` flag for case-sensitive matching
- Shows matching snippets with context around the search term

## Test plan

- [x] All existing tests pass (372 tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `adrs search "query"` searches all ADR content
- [x] `adrs search "query" --title` searches titles only
- [x] `adrs search "query" --status accepted` combines filters

Closes #87