### PR TITLE
feat: add --no-edit flag for non-interactive ADR creation

### DIFF
--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -15,6 +15,7 @@ pub fn new(
     variant: Option<String>,
     status: Option<String>,
     tags: Option<Vec<String>>,
+    no_edit: bool,
 ) -> Result<()> {
     // Parse template format if specified
     let template_format = if let Some(ref fmt) = format {
@@ -85,10 +86,12 @@ pub fn new(
         }
     }
 
-    // Open in editor
-    let content = repo.read_content(&adr)?;
-    let edited = edit::edit(&content).context("Failed to open editor")?;
-    repo.write_content(&adr, &edited)?;
+    // Open in editor unless --no-edit was specified
+    if !no_edit {
+        let content = repo.read_content(&adr)?;
+        let edited = edit::edit(&content).context("Failed to open editor")?;
+        repo.write_content(&adr, &edited)?;
+    }
 
     println!("{}", path.display());
     Ok(())

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -84,6 +84,10 @@ enum Commands {
         /// Tags for categorization (comma-separated, requires --ng)
         #[arg(short = 't', long, value_name = "TAGS", value_delimiter = ',')]
         tags: Option<Vec<String>>,
+
+        /// Create ADR without opening editor (for scripting/CI)
+        #[arg(long)]
+        no_edit: bool,
     },
 
     /// Edit an existing ADR
@@ -334,6 +338,7 @@ fn main() -> Result<()> {
             variant,
             status,
             tags,
+            no_edit,
         } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
             commands::new(
@@ -346,6 +351,7 @@ fn main() -> Result<()> {
                 variant,
                 status,
                 tags,
+                no_edit,
             )
         }
         Commands::Edit { adr } => {


### PR DESCRIPTION
## Summary

Add `--no-edit` flag to the `new` command that creates an ADR without opening an editor. The ADR is created with the template defaults.

## Use Cases

- **CI/CD pipelines** - Automated ADR creation
- **AI assistants** - Claude Code, Cursor, etc. writing ADRs programmatically (no TTY)
- **Scripting** - Bulk creation or migration scripts
- **MCP server** - Prerequisite for #94

## Usage

```bash
# Create ADR without opening editor
adrs new --no-edit "My Decision"

# Combine with other options
adrs new --no-edit --format madr "Use PostgreSQL"
adrs new --no-edit --status accepted "Already decided"
adrs --ng new --no-edit --tags security,api "Auth approach"
```

## Test plan

- [x] All existing tests pass (316 tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `adrs new --no-edit "Test"` creates file without opening editor
- [x] `adrs new --help` shows new flag

Closes #120