### PR TITLE
fix: init detects existing ADRs and skips initial ADR creation

### DIFF
--- a/crates/adrs/src/commands/init.rs
+++ b/crates/adrs/src/commands/init.rs
@@ -13,6 +13,19 @@ pub fn init(root: &Path, directory: PathBuf, ng: bool) -> Result<()> {
         )
     })?;
 
-    println!("{}", repo.adr_path().display());
+    // Check how many ADRs exist
+    let adr_count = repo.list().map(|adrs| adrs.len()).unwrap_or(0);
+
+    if adr_count > 1 {
+        // More than just the initial ADR means we found existing ADRs
+        println!(
+            "{} ({} existing ADRs found)",
+            repo.adr_path().display(),
+            adr_count
+        );
+    } else {
+        println!("{}", repo.adr_path().display());
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

When running `adrs init` on a directory that already contains ADR files, the command now:
- Succeeds instead of erroring with "ADR directory already exists"
- Skips creating the "Record architecture decisions" initial ADR
- Shows how many existing ADRs were found

## Use Cases

- Migrating existing ADR directories to use adrs tooling
- Re-initializing a repository after config changes
- Setting up adrs on a project that manually created ADRs

## Examples

```bash
# Directory with existing ADRs
$ adrs init docs/adr
/path/to/docs/adr (2 existing ADRs found)

# Fresh directory (unchanged behavior)
$ adrs init doc/adr
/path/to/doc/adr
```

## Implementation

- `Repository::init` now checks for existing ADR files before deciding whether to create the initial ADR
- Added `count_existing_adrs()` helper that matches `NNNN-*.md` pattern
- CLI shows count of existing ADRs when found

## Test plan

- [x] All existing tests pass (317 tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Added test: `test_init_repository_already_exists_skips_initial_adr`
- [x] Added test: `test_init_with_existing_adrs_skips_initial`
- [x] Manual test: init on directory with existing ADRs shows count
- [x] Manual test: fresh init still creates initial ADR

Closes #121