### PR TITLE
feat: simplify link command with auto-derived reverse links

### DIFF
--- a/crates/adrs-core/src/types.rs
+++ b/crates/adrs-core/src/types.rs
@@ -282,6 +282,31 @@ impl std::str::FromStr for LinkKind {
     }
 }
 
+impl LinkKind {
+    /// Get the reverse link kind.
+    ///
+    /// For predefined link types, returns the opposite direction.
+    /// For custom types, returns the same type (symmetric relation).
+    ///
+    /// # Examples
+    /// ```
+    /// use adrs_core::LinkKind;
+    /// assert_eq!(LinkKind::Supersedes.reverse(), LinkKind::SupersededBy);
+    /// assert_eq!(LinkKind::AmendedBy.reverse(), LinkKind::Amends);
+    /// assert_eq!(LinkKind::RelatesTo.reverse(), LinkKind::RelatesTo);
+    /// ```
+    pub fn reverse(&self) -> Self {
+        match self {
+            Self::Supersedes => Self::SupersededBy,
+            Self::SupersededBy => Self::Supersedes,
+            Self::Amends => Self::AmendedBy,
+            Self::AmendedBy => Self::Amends,
+            Self::RelatesTo => Self::RelatesTo,
+            Self::Custom(s) => Self::Custom(s.clone()),
+        }
+    }
+}
+
 /// Convert a title to a URL-safe slug.
 ///
 /// Only ASCII alphanumeric characters are preserved; everything else becomes a dash.
@@ -585,6 +610,19 @@ mod tests {
                 .unwrap()
                 .trim(),
             "supersededby"
+        );
+    }
+
+    #[test]
+    fn test_link_kind_reverse() {
+        assert_eq!(LinkKind::Supersedes.reverse(), LinkKind::SupersededBy);
+        assert_eq!(LinkKind::SupersededBy.reverse(), LinkKind::Supersedes);
+        assert_eq!(LinkKind::Amends.reverse(), LinkKind::AmendedBy);
+        assert_eq!(LinkKind::AmendedBy.reverse(), LinkKind::Amends);
+        assert_eq!(LinkKind::RelatesTo.reverse(), LinkKind::RelatesTo);
+        assert_eq!(
+            LinkKind::Custom("Extends".into()).reverse(),
+            LinkKind::Custom("Extends".into())
         );
     }
 

--- a/crates/adrs/src/commands/link.rs
+++ b/crates/adrs/src/commands/link.rs
@@ -9,13 +9,16 @@ pub fn link(
     source: u32,
     link_kind: &str,
     target: u32,
-    reverse_kind: &str,
+    reverse_kind: Option<&str>,
 ) -> Result<()> {
     let repo =
         Repository::open(root).context("ADR repository not found. Run 'adrs init' first.")?;
 
     let source_kind: LinkKind = link_kind.parse().unwrap_or(LinkKind::RelatesTo);
-    let target_kind: LinkKind = reverse_kind.parse().unwrap_or(LinkKind::RelatesTo);
+    let target_kind: LinkKind = match reverse_kind {
+        Some(kind) => kind.parse().unwrap_or(LinkKind::RelatesTo),
+        None => source_kind.reverse(),
+    };
 
     repo.link(source, target, source_kind, target_kind)?;
 

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -30,7 +30,7 @@ EXAMPLES:
   adrs init                                      Initialize repository
   adrs new --format madr \"Use PostgreSQL\"       Create MADR-format ADR
   adrs new --supersedes 2 \"Use MySQL instead\"   Supersede an ADR
-  adrs link 3 \"Amends\" 1 \"Amended by\"           Link two ADRs
+  adrs link 3 Amends 1                          Link two ADRs (auto-derives reverse)
   adrs generate toc > doc/adr/README.md         Generate table of contents
 
 DOCUMENTATION: https://joshrotenberg.github.io/adrs-book/")]
@@ -142,14 +142,14 @@ enum Commands {
         /// Source ADR number
         source: u32,
 
-        /// Link description (e.g., "Amends")
+        /// Link description (e.g., "Amends", "Supersedes", "Relates to")
         link: String,
 
         /// Target ADR number
         target: u32,
 
-        /// Reverse link description (e.g., "Amended by")
-        reverse_link: String,
+        /// Reverse link description (auto-derived if omitted)
+        reverse_link: Option<String>,
     },
 
     /// Change an ADR's status
@@ -379,7 +379,13 @@ fn main() -> Result<()> {
             reverse_link,
         } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
-            commands::link(&discovered.root, source, &link, target, &reverse_link)
+            commands::link(
+                &discovered.root,
+                source,
+                &link,
+                target,
+                reverse_link.as_deref(),
+            )
         }
         Commands::Status { adr, status, by } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;


### PR DESCRIPTION
## Summary
- Add `LinkKind::reverse()` method to auto-derive the opposite link direction
- Make `reverse_link` argument optional in the link command
- Simplify common linking from `adrs link 3 "Amends" 1 "Amended by"` to `adrs link 3 Amends 1`

## Changes
- **adrs-core/types.rs**: Added `reverse()` method with mappings:
  - Supersedes <-> Superseded by
  - Amends <-> Amended by
  - Relates to (symmetric)
  - Custom types (symmetric)
- **adrs/commands/link.rs**: Use `reverse()` when reverse_kind is not provided
- **adrs/main.rs**: Made `reverse_link` optional, updated help text
- **tests/scenarios.rs**: Added test for simplified syntax

## Test plan
- [x] Unit test for `LinkKind::reverse()` method
- [x] Doc test examples
- [x] Integration test `scenario_link_simplified_syntax`
- [x] Existing `scenario_link_decisions` test (full syntax) still passes

Closes #125