### PR TITLE
feat: add shell completions command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "clap",
+ "clap_complete",
  "edit",
  "predicates",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ regex = "1"
 # CLI only
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "string"] }
+clap_complete = "4"
 edit = "0.1"
 whoami = "1"
 

--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 adrs-core.workspace = true
 anyhow.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 edit.workspace = true
 serde_json = "1"
 time.workspace = true


### PR DESCRIPTION
## Summary
- Add `adrs completions` subcommand using `clap_complete`
- Support for Bash, Zsh, Fish, PowerShell, and Elvish shells
- Include shell-specific setup instructions in help

## Usage
```bash
# Generate completions
adrs completions bash > ~/.bash_completion.d/adrs
adrs completions zsh > ~/.zfunc/_adrs
adrs completions fish > ~/.config/fish/completions/adrs.fish
adrs completions powershell > _adrs.ps1
```

## Help Output
```
$ adrs completions --help
Generate shell completions

Usage: adrs completions <SHELL>

Arguments:
  <SHELL>  Shell to generate completions for
           [possible values: bash, zsh, fish, powershell, elvish]

EXAMPLES:
  adrs completions bash > ~/.bash_completion.d/adrs
  adrs completions zsh > ~/.zfunc/_adrs
  ...
```

## Test plan
- [x] All existing tests pass
- [x] Verified bash completions generate correctly
- [x] Verified help output includes setup instructions

Part of #124 (Phase 3)