### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,11 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
+<<<<<<< Updated upstream
 version = "0.5.0"
+=======
+version = "0.6.0"
+>>>>>>> Stashed changes
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -27,7 +31,11 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
+<<<<<<< Updated upstream
 version = "0.5.0"
+=======
+version = "0.6.0"
+>>>>>>> Stashed changes
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,11 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
+<<<<<<< Updated upstream
 version = "0.5.0"
+=======
+version = "0.6.0"
+>>>>>>> Stashed changes
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -42,7 +46,11 @@ edit = "0.1"
 whoami = "1"
 
 # Internal
+<<<<<<< Updated upstream
 adrs-core = { path = "crates/adrs-core", version = "0.5.0" }
+=======
+adrs-core = { path = "crates/adrs-core", version = "0.6.0" }
+>>>>>>> Stashed changes
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+<<<<<<< Updated upstream
+=======
+## [0.6.0] - 2026-01-26
+
+### Bug Fixes
+
+- Init detects existing ADRs and skips initial ADR creation
+
+### Features
+
+- Add source_uri field to JSON-ADR spec for federation
+- Add template management commands
+- Add tags support for ADR categorization
+- Simplify link command with auto-derived reverse links
+
+
+## [0.5.1] - 2026-01-22
+
+### Features
+
+- Add status command to change ADR status
+
+
+>>>>>>> Stashed changes
 ## [0.5.0] - 2026-01-22
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+<<<<<<< Updated upstream
+=======
+## [0.6.0] - 2026-01-26
+
+### Bug Fixes
+
+- Init detects existing ADRs and skips initial ADR creation
+
+### Documentation
+
+- Improve CLI help discoverability with examples
+
+### Features
+
+- Add source_uri field to JSON-ADR spec for federation
+- Add filtering options to list command
+- Add search command for full-text search
+- Add template management commands
+- Add tags support for ADR categorization
+- Add --no-edit flag for non-interactive ADR creation
+- Simplify link command with auto-derived reverse links
+- Add shell completions command
+- Add MCP server for AI agent integration
+- Add MCP write operations (create, status, link)
+
+
+## [0.5.1] - 2026-01-22
+
+### Documentation
+
+- Refresh README for v0.5.0
+
+### Features
+
+- Add status command to change ADR status
+
+### Testing
+
+- Add integration tests for status command
+
+
+>>>>>>> Stashed changes
 ## [0.5.0] - 2026-01-22
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `adrs`: 0.5.1 -> 0.6.0

### ⚠ `adrs-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Adr.tags in /tmp/.tmpTKaGW4/adrs/crates/adrs-core/src/types.rs:47
  field JsonAdr.source_uri in /tmp/.tmpTKaGW4/adrs/crates/adrs-core/src/export.rs:54
  field JsonAdr.source_uri in /tmp/.tmpTKaGW4/adrs/crates/adrs-core/src/export.rs:54
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.6.0] - 2026-01-26

### Bug Fixes

- Init detects existing ADRs and skips initial ADR creation

### Features

- Add source_uri field to JSON-ADR spec for federation
- Add template management commands
- Add tags support for ADR categorization
- Simplify link command with auto-derived reverse links
</blockquote>

## `adrs`

<blockquote>

## [0.6.0] - 2026-01-26

### Bug Fixes

- Init detects existing ADRs and skips initial ADR creation

### Documentation

- Improve CLI help discoverability with examples

### Features

- Add source_uri field to JSON-ADR spec for federation
- Add filtering options to list command
- Add search command for full-text search
- Add template management commands
- Add tags support for ADR categorization
- Add --no-edit flag for non-interactive ADR creation
- Simplify link command with auto-derived reverse links
- Add shell completions command
- Add MCP server for AI agent integration
- Add MCP write operations (create, status, link)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).