### PR TITLE
chore: add workflow_dispatch trigger to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary
- Adds manual trigger capability to release-plz workflow
- Useful when release PRs need to be regenerated after conflicts

## Test plan
- Merge this PR
- Use `gh workflow run Release-plz` to trigger fresh release PR