### PR TITLE
feat: enable MCP server by default

### DIFF
--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -13,7 +13,7 @@ name = "adrs"
 path = "src/main.rs"
 
 [features]
-default = []
+default = ["mcp"]
 mcp = ["rmcp", "schemars", "tokio"]
 mcp-http = ["mcp", "tokio-util", "axum"]
 


### PR DESCRIPTION
## Summary
- Enable MCP (Model Context Protocol) server feature by default
- AI agents can now interact with ADR repositories out of the box
- No rebuild required for MCP functionality

## Tradeoffs
| Metric | Without MCP | With MCP | Change |
|--------|-------------|----------|--------|
| Binary size | 6.4 MB | 8.9 MB | +2.5 MB (+39%) |
| Dependencies | ~402 | ~600 | +~200 |

## Rationale
The MCP feature is a key differentiator for this tool. Keeping it opt-in means most users will never discover or try it. The binary size increase is acceptable for a CLI tool, and users who need a minimal build can still use `--no-default-features`.

## Test plan
- [x] `cargo test --lib --all-features` passes
- [x] `cargo test --test '*' --all-features` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `adrs mcp --help` works without explicit feature flag

Closes #164