### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -50,7 +50,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 axum = "0.8"
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.6.1" }
+adrs-core = { path = "crates/adrs-core", version = "0.6.2" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.2] - 2026-02-11
+
+### Bug Fixes
+
+- Honor adrs.toml template fields and accept "nextgen" mode
+- Wire custom template config, validate empty adr_dir, add tests
+- Resolve security audit failures and update dependencies
+
+
 ## [0.6.1] - 2026-01-27
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.2] - 2026-02-11
+
+### Bug Fixes
+
+- Honor adrs.toml template fields and accept "nextgen" mode
+- Wire custom template config, validate empty adr_dir, add tests
+- Resolve security audit failures and update dependencies
+
+### Testing
+
+- Add scenario test for config-driven template selection
+
+
 ## [0.6.1] - 2026-01-27
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `adrs`: 0.6.1 -> 0.6.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.6.2] - 2026-02-11

### Bug Fixes

- Honor adrs.toml template fields and accept "nextgen" mode
- Wire custom template config, validate empty adr_dir, add tests
- Resolve security audit failures and update dependencies
</blockquote>

## `adrs`

<blockquote>

## [0.6.2] - 2026-02-11

### Bug Fixes

- Honor adrs.toml template fields and accept "nextgen" mode
- Wire custom template config, validate empty adr_dir, add tests
- Resolve security audit failures and update dependencies

### Testing

- Add scenario test for config-driven template selection
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).