### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.7.0"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -50,7 +50,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 axum = "0.8"
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.6.2" }
+adrs-core = { path = "crates/adrs-core", version = "0.7.0" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2026-02-20
+
+### Bug Fixes
+
+- Generate functional supersedes/superseded-by markdown links
+
+### Styling
+
+- Run cargo fmt
+
+
 ## [0.6.2] - 2026-02-11
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2026-02-20
+
+### Bug Fixes
+
+- Generate functional supersedes/superseded-by markdown links
+- Honor config mode=ng for tags in `new` command ([#181](https://github.com/joshrotenberg/adrs/pull/181))
+
+### Styling
+
+- Run cargo fmt
+- Run cargo fmt
+
+
 ## [0.6.2] - 2026-02-11
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `adrs`: 0.6.2 -> 0.7.0

### ⚠ `adrs-core` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  adrs_core::Template::render now takes 3 parameters instead of 2, in /tmp/.tmpJY0x7m/adrs/crates/adrs-core/src/template.rs:164
  adrs_core::TemplateEngine::render now takes 3 parameters instead of 2, in /tmp/.tmpJY0x7m/adrs/crates/adrs-core/src/template.rs:291
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.7.0] - 2026-02-20

### Bug Fixes

- Generate functional supersedes/superseded-by markdown links

### Styling

- Run cargo fmt
</blockquote>

## `adrs`

<blockquote>

## [0.7.0] - 2026-02-20

### Bug Fixes

- Generate functional supersedes/superseded-by markdown links
- Honor config mode=ng for tags in `new` command ([#181](https://github.com/joshrotenberg/adrs/pull/181))

### Styling

- Run cargo fmt
- Run cargo fmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).