### PR TITLE
fix: trim extra newline before frontmatter closing separator

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -482,6 +482,7 @@ impl Repository {
             yaml_block
         };
 
+        let yaml_block = yaml_block.trim_end_matches('\n');
         Ok(format!("---\n{}{}", yaml_block, after_yaml))
     }
 
@@ -1706,6 +1707,38 @@ Decision.
         assert!(result.contains("links:"));
         assert!(result.contains("target: 1"));
         assert!(result.contains("kind: amends"));
+        // No extra blank line before closing ---
+        assert!(
+            !result.contains("\n\n---"),
+            "Should not have extra blank line before closing ---: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_set_status_no_extra_newline_before_separator() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = "---\nnumber: 2\ntitle: Test\ndate: 2026-01-15\nstatus: proposed\n---\n\n## Context\n\nContext.\n";
+        let adr_path = repo.adr_path().join("0002-test.md");
+        fs::write(&adr_path, content).unwrap();
+
+        repo.set_status(2, AdrStatus::Accepted, None).unwrap();
+
+        let result = fs::read_to_string(&adr_path).unwrap();
+        assert!(result.contains("status: accepted"));
+        // Frontmatter should close cleanly without extra blank line (#192)
+        assert!(
+            result.contains("\n---\n"),
+            "Should have clean closing separator: {:?}",
+            result
+        );
+        assert!(
+            !result.contains("\n\n---"),
+            "Should not have extra blank line before closing ---: {:?}",
+            result
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #192

## Summary

- When `update_frontmatter_metadata` reconstructs a file, `yaml_block` ended with `\n` and `after_yaml` started with `\n---\n`, producing a blank line before the closing `---`
- Trim trailing newlines from the yaml block before reconstruction to eliminate the extra blank line

## Test plan

- [x] Added `test_set_status_no_extra_newline_before_separator` targeting this exact bug
- [x] Added `\n\n---` assertion to existing `test_set_status_frontmatter_with_existing_links`
- [x] All 364 lib tests pass
- [x] All 15 integration tests pass
- [x] clippy/fmt clean