### PR TITLE
fix: open actual ADR file in editor instead of temp file

### DIFF
--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -365,6 +365,10 @@ mod tests {
     #[test]
     fn test_lint_valid_nygard_adr() {
         // Create a temporary file with valid Nygard format
+        // NOTE: Uses simplified Decision text to avoid ADR014 false positive on "described"
+        // in mdbook-lint-rulesets <= 0.14.2. Update to actual ADR #0001 text (with
+        // "as described by Michael Nygard") once mdbook-lint-rulesets >= 0.15 is released
+        // with the word-boundary fix.
         let content = r#"# 1. Record architecture decisions
 
 Date: 2024-03-04

--- a/crates/adrs/src/commands/edit.rs
+++ b/crates/adrs/src/commands/edit.rs
@@ -9,10 +9,12 @@ pub fn edit(root: &Path, query: &str) -> Result<()> {
         Repository::open(root).context("ADR repository not found. Run 'adrs init' first.")?;
 
     let adr = repo.find(query).context("ADR not found")?;
-    let content = repo.read_content(&adr)?;
+    let path = adr
+        .path
+        .clone()
+        .unwrap_or_else(|| repo.adr_path().join(adr.filename()));
 
-    let edited = edit::edit(&content).context("Failed to open editor")?;
-    let path = repo.write_content(&adr, &edited)?;
+    edit::edit_file(&path).context("Failed to open editor")?;
 
     println!("{}", path.display());
     Ok(())

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -115,9 +115,7 @@ pub fn new(
 
     // Open in editor unless --no-edit was specified
     if !no_edit {
-        let content = repo.read_content(&adr)?;
-        let edited = edit::edit(&content).context("Failed to open editor")?;
-        repo.write_content(&adr, &edited)?;
+        edit::edit_file(&path).context("Failed to open editor")?;
     }
 
     println!("{}", path.display());


### PR DESCRIPTION
## Summary

- Replace `edit::edit(&content)` with `edit::edit_file(&path)` in both `adrs new` and `adrs edit` commands
- `$EDITOR` now opens the actual ADR file at its real path, not a temporary copy
- Matches behavior of `adr-tools` where the editor opens the real file directly

Fixes #196

## Test plan

- [x] All 364 lib tests pass
- [x] All 15 integration/corpus tests pass
- [x] Clippy clean, fmt clean
- [ ] Manual: `adrs new "test"` should show the real file path in editor title bar
- [ ] Manual: `adrs edit 1` should show the real file path in editor title bar