### PR TITLE
chore: release v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -50,7 +50,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 axum = "0.8"
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.7.2" }
+adrs-core = { path = "crates/adrs-core", version = "0.7.3" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.3] - 2026-03-04
+
+### Bug Fixes
+
+- Open actual ADR file in editor instead of temp file
+- Bump mdbook-lint-rulesets to 0.14.3
+
+
 ## [0.7.2] - 2026-02-26
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.3] - 2026-03-04
+
+### Bug Fixes
+
+- Open actual ADR file in editor instead of temp file
+
+
 ## [0.7.2] - 2026-02-26
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `adrs`: 0.7.2 -> 0.7.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.7.3] - 2026-03-04

### Bug Fixes

- Open actual ADR file in editor instead of temp file
- Bump mdbook-lint-rulesets to 0.14.3
</blockquote>

## `adrs`

<blockquote>

## [0.7.3] - 2026-03-04

### Bug Fixes

- Open actual ADR file in editor instead of temp file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).