### PR TITLE
fix: bump mdbook-lint-rulesets to 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0361428cd991916c3d0a463c35ef08873bc6c19b4df20d08c9dc13d44845ac13"
+checksum = "1c6b8640488ad03e21ec1f5bb9f25dc5781eab5b985dbcd0f83ba8d3ead00017"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1261,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0e48fe6453170bae3bd066b6f240143edb162abf3097cc7f4e0d9066eb6c5e"
+checksum = "f87d6caf57dfde20440d4bd97abec181efda276083ec8e50e35e62a7672f83f4"
 dependencies = [
  "anyhow",
  "comrak",

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -22,8 +22,8 @@ fuzzy-matcher.workspace = true
 regex.workspace = true
 
 # Linting (mdbook-lint integration)
-mdbook-lint-core = "0.14.2"
-mdbook-lint-rulesets = { version = "0.14.2", default-features = false, features = ["adr"] }
+mdbook-lint-core = "0.14.3"
+mdbook-lint-rulesets = { version = "0.14.3", default-features = false, features = ["adr"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -364,11 +364,8 @@ mod tests {
 
     #[test]
     fn test_lint_valid_nygard_adr() {
-        // Create a temporary file with valid Nygard format
-        // NOTE: Uses simplified Decision text to avoid ADR014 false positive on "described"
-        // in mdbook-lint-rulesets <= 0.14.2. Update to actual ADR #0001 text (with
-        // "as described by Michael Nygard") once mdbook-lint-rulesets >= 0.15 is released
-        // with the word-boundary fix.
+        // Uses the actual ADR #0001 text produced by `adrs init`. The word "described"
+        // previously triggered an ADR014 false positive (fixed in mdbook-lint-rulesets 0.14.3).
         let content = r#"# 1. Record architecture decisions
 
 Date: 2024-03-04
@@ -383,11 +380,11 @@ We need to record the architectural decisions made on this project.
 
 ## Decision
 
-We will use Architecture Decision Records.
+We will use Architecture Decision Records, as described by Michael Nygard in his article "Documenting Architecture Decisions".
 
 ## Consequences
 
-See Michael Nygard's article for details.
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's adr-tools.
 "#;
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir


### PR DESCRIPTION
## Summary

- Bump `mdbook-lint-core` and `mdbook-lint-rulesets` from 0.14.2 to 0.14.3
- Updates lint test to use the actual ADR #0001 text (with "as described by Michael Nygard") now that the ADR014 false positive is fixed upstream
- Picks up fixes for:
  - **ADR014**: Word-boundary placeholder matching (no more false positive on "described")
  - **ADR010**: Bare filename link recognition (`0003-use-mysql.md` format)

Relates to #197, #198

## Test plan

- [x] All 364 lib tests pass (including updated lint test with real ADR #0001 text)
- [x] All 15 integration/corpus tests pass
- [x] Clippy clean, fmt clean