### PR TITLE
fix: --ng flag now overrides template mode for existing repos

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -157,6 +157,12 @@ impl Repository {
         self
     }
 
+    /// Override the configuration mode.
+    pub fn with_mode(mut self, mode: ConfigMode) -> Self {
+        self.config.mode = mode;
+        self
+    }
+
     /// Set a custom template.
     pub fn with_custom_template(mut self, template: Template) -> Self {
         self.template_engine = self.template_engine.with_custom_template(template);
@@ -1224,6 +1230,43 @@ mod tests {
 
         let content = repo.read_content(&adr).unwrap();
         assert!(content.contains("Modified"));
+    }
+
+    // ========== Mode Override Tests ==========
+
+    #[test]
+    fn test_with_mode_overrides_compatible_to_ng() {
+        let temp = TempDir::new().unwrap();
+        // Init in compatible mode
+        let repo = Repository::init(temp.path(), None, false)
+            .unwrap()
+            .with_mode(ConfigMode::NextGen);
+
+        let (_, path) = repo.new_adr("Mode Override Test").unwrap();
+        let content = fs::read_to_string(path).unwrap();
+
+        assert!(
+            content.starts_with("---\n"),
+            "with_mode(NextGen) on compatible repo should produce YAML frontmatter. Got:\n{content}"
+        );
+        assert!(content.contains("status: proposed"));
+    }
+
+    #[test]
+    fn test_with_mode_ng_to_compatible() {
+        let temp = TempDir::new().unwrap();
+        // Init in ng mode, then override to compatible
+        let repo = Repository::init(temp.path(), None, true)
+            .unwrap()
+            .with_mode(ConfigMode::Compatible);
+
+        let (_, path) = repo.new_adr("Downgrade Mode Test").unwrap();
+        let content = fs::read_to_string(path).unwrap();
+
+        assert!(
+            !content.starts_with("---\n"),
+            "with_mode(Compatible) on ng repo should NOT produce YAML frontmatter. Got:\n{content}"
+        );
     }
 
     // ========== Template Configuration Tests ==========

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -1,7 +1,7 @@
 //! New ADR command.
 
 use adrs_core::{
-    AdrStatus, Config, LinkKind, Repository, Template, TemplateFormat, TemplateVariant,
+    AdrStatus, Config, ConfigMode, LinkKind, Repository, Template, TemplateFormat, TemplateVariant,
 };
 use anyhow::{Context, Result};
 use std::path::Path;
@@ -53,6 +53,11 @@ pub fn new(
         .context("ADR repository not found. Run 'adrs init' first.")?
         .with_template_format(template_format)
         .with_template_variant(template_variant);
+
+    // Override mode if --ng flag is passed
+    if ng {
+        repo = repo.with_mode(ConfigMode::NextGen);
+    }
 
     // Load custom template from config if set (and no format/variant CLI override)
     if format.is_none()

--- a/crates/adrs/tests/scenarios.rs
+++ b/crates/adrs/tests/scenarios.rs
@@ -1016,6 +1016,151 @@ fn scenario_config_ng_mode_enables_tags() {
     temp.close().unwrap();
 }
 
+// ============================================================================
+// Scenario: --ng Flag Overrides Compatible Mode (Issue #204)
+// ============================================================================
+
+/// User has a compatible-mode repo but uses --ng flag to create an ADR with
+/// YAML frontmatter. This was broken: --ng only affected tag validation,
+/// not template rendering.
+#[test]
+fn scenario_ng_flag_overrides_compatible_mode() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Step 1: Initialize in compatible mode (no --ng)
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Verify compatible mode (no adrs.toml, just .adr-dir)
+    let first_adr = temp.child("doc/adr/0001-record-architecture-decisions.md");
+    let content = fs::read_to_string(first_adr.path()).unwrap();
+    assert!(
+        !content.starts_with("---"),
+        "Compatible mode init should not have frontmatter"
+    );
+
+    // Step 2: Create ADR with --ng flag
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "new", "--no-edit", "Use PostgreSQL for persistence"])
+        .assert()
+        .success();
+
+    // Step 3: Verify the new ADR has YAML frontmatter
+    let ng_adr = temp.child("doc/adr/0002-use-postgresql-for-persistence.md");
+    let content = fs::read_to_string(ng_adr.path()).unwrap();
+    assert!(
+        content.starts_with("---\n"),
+        "--ng flag should produce YAML frontmatter. Got:\n{content}"
+    );
+    assert!(
+        content.contains("status: proposed"),
+        "Frontmatter should contain status field"
+    );
+
+    temp.close().unwrap();
+}
+
+/// User has a compatible-mode repo and uses --ng flag with tags.
+#[test]
+fn scenario_ng_flag_with_tags_on_compatible_repo() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Initialize in compatible mode
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Create ADR with --ng flag AND tags
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "--ng",
+            "new",
+            "--no-edit",
+            "-t",
+            "database,infrastructure",
+            "Use PostgreSQL",
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(temp.path().join("doc/adr/0002-use-postgresql.md")).unwrap();
+    assert!(
+        content.starts_with("---\n"),
+        "--ng flag should produce YAML frontmatter"
+    );
+    assert!(content.contains("tags:"), "Should have tags in frontmatter");
+    assert!(content.contains("database"), "Should contain database tag");
+    assert!(
+        content.contains("infrastructure"),
+        "Should contain infrastructure tag"
+    );
+
+    temp.close().unwrap();
+}
+
+/// User has a compatible-mode repo and uses --ng flag with supersede.
+#[test]
+fn scenario_ng_flag_supersede_on_compatible_repo() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Initialize in compatible mode and create an ADR
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "Use MySQL"])
+        .env("EDITOR", "true")
+        .assert()
+        .success();
+
+    // Supersede with --ng flag
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "--ng",
+            "new",
+            "--no-edit",
+            "--supersedes",
+            "2",
+            "Use PostgreSQL instead",
+        ])
+        .assert()
+        .success();
+
+    // New ADR should have frontmatter
+    let new_adr = temp.child("doc/adr/0003-use-postgresql-instead.md");
+    let content = fs::read_to_string(new_adr.path()).unwrap();
+    assert!(
+        content.starts_with("---\n"),
+        "Superseding ADR with --ng should have frontmatter. Got:\n{content}"
+    );
+
+    // Old ADR should still be compatible format (no frontmatter) but updated
+    let old_adr = temp.child("doc/adr/0002-use-mysql.md");
+    let old_content = fs::read_to_string(old_adr.path()).unwrap();
+    assert!(
+        !old_content.starts_with("---"),
+        "Old compatible-mode ADR should remain without frontmatter"
+    );
+    assert!(
+        old_content.contains("Superseded"),
+        "Old ADR should be marked superseded"
+    );
+
+    temp.close().unwrap();
+}
+
 /// Config mode = "ng" with the alias "nextgen" also works for tags.
 #[test]
 fn scenario_config_nextgen_alias_enables_tags() {


### PR DESCRIPTION
## Summary

- Fixes #204: `--ng` flag didn't override template rendering mode for existing compatible-mode repositories
- Added `Repository::with_mode()` method to allow overriding the config mode
- Called `with_mode(ConfigMode::NextGen)` in the `new` command when `--ng` is passed

The root cause was that `--ng` only affected tag validation (`is_ng` check), but the template engine still read `config.is_next_gen()` which reflected the persisted config, not the CLI flag.

## Test plan

- [x] Unit test: `test_with_mode_overrides_compatible_to_ng` - verifies `with_mode` produces frontmatter on compatible repo
- [x] Unit test: `test_with_mode_ng_to_compatible` - verifies reverse override also works
- [x] Scenario: `scenario_ng_flag_overrides_compatible_mode` - exact reproduction from the issue
- [x] Scenario: `scenario_ng_flag_with_tags_on_compatible_repo` - `--ng` + tags on compatible repo
- [x] Scenario: `scenario_ng_flag_supersede_on_compatible_repo` - `--ng` + supersede preserves old ADR format
- [x] All existing tests pass (366 lib, 24 scenario, 15 integration)