### PR TITLE
chore: release v0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -50,7 +50,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 axum = "0.8"
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.7.3" }
+adrs-core = { path = "crates/adrs-core", version = "0.7.4" }
 
 # Testing
 serial_test = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -48,7 +48,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.7.3" }
+adrs-core = { path = "crates/adrs-core", version = "0.7.4" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.4] - 2026-04-23
+
+### Bug Fixes
+
+- --ng flag now overrides template mode for existing repos
+- Accept string or list for frontmatter fields, report parse errors in doctor
+
+### Testing
+
+- Add tests for string-or-vec parsing and doctor parse error reporting
+
+
 ## [0.7.3] - 2026-03-04
 
 ### Bug Fixes

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.4] - 2026-06-06
+
+### Bug Fixes
+
+- --ng flag now overrides template mode for existing repos
+- Accept string or list for frontmatter fields, report parse errors in doctor
+- Resolve clippy 1.96 lints (sort_by_key, collapsible_match)
+- Serialize env-var tests to remove ADR_DIRECTORY race
+
+### Testing
+
+- Add tests for string-or-vec parsing and doctor parse error reporting
+- Add missing tests for template, export, cli, search, lint, config (closes #235, closes #236, closes #237, closes #238, closes #239, closes #241)
+
+
 ## [0.7.3] - 2026-03-04
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.4] - 2026-04-23
+
+### Bug Fixes
+
+- --ng flag now overrides template mode for existing repos
+
+### Features
+
+- Migrate MCP server from rmcp to tower-mcp
+- Upgrade tower-mcp from 0.1 to 0.9
+
+### Testing
+
+- Add tests for string-or-vec parsing and doctor parse error reporting
+- Add MCP server tests using in-process ChannelTransport client
+
+
 ## [0.7.3] - 2026-03-04
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.4] - 2026-06-06
+
+### Bug Fixes
+
+- --ng flag now overrides template mode for existing repos
+- Reject invalid status/link_type in MCP tools, add missing error path tests (closes #229, closes #240)
+
+### Documentation
+
+- Fix high-priority documentation inaccuracies
+
+### Features
+
+- Migrate MCP server from rmcp to tower-mcp
+- Upgrade tower-mcp from 0.1 to 0.9
+- Add format/variant/MADR fields and tags to MCP create_adr (closes #230, closes #234)
+- Add since/until/decider to list_adrs, status/case_sensitive/snippets to search_adrs, run_doctor and export_adrs tools (closes #231, closes #232, closes #233)
+
+### Testing
+
+- Add tests for string-or-vec parsing and doctor parse error reporting
+- Add MCP server tests using in-process ChannelTransport client
+- Add missing tests for template, export, cli, search, lint, config (closes #235, closes #236, closes #237, closes #238, closes #239, closes #241)
+
+
 ## [0.7.3] - 2026-03-04
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.7.3 -> 0.7.4 (✓ API compatible changes)
* `adrs`: 0.7.3 -> 0.7.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.7.4] - 2026-06-06

### Bug Fixes

- --ng flag now overrides template mode for existing repos
- Accept string or list for frontmatter fields, report parse errors in doctor
- Resolve clippy 1.96 lints (sort_by_key, collapsible_match)
- Serialize env-var tests to remove ADR_DIRECTORY race

### Testing

- Add tests for string-or-vec parsing and doctor parse error reporting
- Add missing tests for template, export, cli, search, lint, config (closes #235, closes #236, closes #237, closes #238, closes #239, closes #241)
</blockquote>

## `adrs`

<blockquote>

## [0.7.4] - 2026-06-06

### Bug Fixes

- --ng flag now overrides template mode for existing repos
- Reject invalid status/link_type in MCP tools, add missing error path tests (closes #229, closes #240)

### Documentation

- Fix high-priority documentation inaccuracies

### Features

- Migrate MCP server from rmcp to tower-mcp
- Upgrade tower-mcp from 0.1 to 0.9
- Add format/variant/MADR fields and tags to MCP create_adr (closes #230, closes #234)
- Add since/until/decider to list_adrs, status/case_sensitive/snippets to search_adrs, run_doctor and export_adrs tools (closes #231, closes #232, closes #233)

### Testing

- Add tests for string-or-vec parsing and doctor parse error reporting
- Add MCP server tests using in-process ChannelTransport client
- Add missing tests for template, export, cli, search, lint, config (closes #235, closes #236, closes #237, closes #238, closes #239, closes #241)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).