### PR TITLE
fix: accept string or list for frontmatter fields, report parse errors in doctor

### DIFF
--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -315,10 +315,41 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
 }
 
 /// Run all checks: per-file lint + repository-level checks.
+///
+/// Also reports files that look like ADRs (digit-prefixed `.md` files in the
+/// ADR directory) but could not be parsed (e.g., invalid YAML frontmatter).
 pub fn check_all(repo: &Repository) -> Result<LintReport> {
-    let mut report = lint_all(repo)?;
+    let mut report = LintReport::new();
+
+    // Use list_with_errors to capture parse failures
+    let (adrs, parse_errors) = repo.list_with_errors()?;
+
+    // Report parse errors as lint issues
+    for (path, error) in &parse_errors {
+        report.add(Issue {
+            rule_id: "parse-error".to_string(),
+            rule_name: "adr-parse-error".to_string(),
+            severity: IssueSeverity::Error,
+            message: format!("Failed to parse ADR: {error}"),
+            path: Some(path.clone()),
+            line: None,
+            column: None,
+            adr_number: None,
+            related_adrs: Vec::new(),
+        });
+    }
+
+    // Run per-file lint on successfully parsed ADRs
+    for adr in &adrs {
+        let adr_report = lint_adr(adr)?;
+        report.issues.extend(adr_report.issues);
+    }
+
+    // Run repository-level checks (these still use repo.list() internally,
+    // which is fine — they only need successfully parsed ADRs)
     let repo_report = check_repository(repo)?;
     report.issues.extend(repo_report.issues);
+
     report.sort();
     Ok(report)
 }

--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -482,4 +482,62 @@ Some consequences.
             "Expected ADR002 (missing status) violation"
         );
     }
+
+    #[test]
+    fn test_check_all_reports_parse_errors() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        // Write an ADR with invalid YAML (bad date)
+        let bad_content =
+            "---\nnumber: 2\nstatus: accepted\ndate: not-a-date\n---\n\n# 2. Bad Date\n";
+        std::fs::write(repo.adr_path().join("0002-bad-date.md"), bad_content).unwrap();
+
+        let report = check_all(&repo).unwrap();
+
+        let parse_errors: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "parse-error")
+            .collect();
+
+        assert_eq!(parse_errors.len(), 1, "should report 1 parse error");
+        assert_eq!(parse_errors[0].severity, IssueSeverity::Error);
+        assert!(
+            parse_errors[0]
+                .path
+                .as_ref()
+                .unwrap()
+                .to_string_lossy()
+                .contains("0002-bad-date.md")
+        );
+    }
+
+    #[test]
+    fn test_check_all_no_parse_errors_for_string_decision_makers() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        // Issue #216: decision-makers as string should not cause a parse error
+        let content = "---\nnumber: 2\nstatus: accepted\ndate: 2026-03-18\ndecision-makers: alice\n---\n\n# 2. Test\n\n## Context\n\nContext.\n\n## Decision\n\nDecision.\n\n## Consequences\n\nConsequences.\n";
+        std::fs::write(repo.adr_path().join("0002-test.md"), content).unwrap();
+
+        let report = check_all(&repo).unwrap();
+
+        let parse_errors: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "parse-error")
+            .collect();
+
+        assert!(
+            parse_errors.is_empty(),
+            "string decision-makers should not cause parse error, got: {:?}",
+            parse_errors.iter().map(|i| &i.message).collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -194,6 +194,45 @@ impl Repository {
         Ok(adrs)
     }
 
+    /// List all ADRs, also returning parse errors for files that look like ADRs
+    /// but failed to parse.
+    ///
+    /// This is used by the `doctor` command to report files that could not be
+    /// parsed (e.g., invalid frontmatter).
+    #[allow(clippy::type_complexity)]
+    pub fn list_with_errors(&self) -> Result<(Vec<Adr>, Vec<(PathBuf, crate::Error)>)> {
+        let adr_path = self.adr_path();
+        if !adr_path.exists() {
+            return Err(Error::AdrDirNotFound);
+        }
+
+        let mut adrs = Vec::new();
+        let mut errors = Vec::new();
+
+        let candidates: Vec<_> = WalkDir::new(&adr_path)
+            .max_depth(1)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path().extension().is_some_and(|ext| ext == "md")
+                    && e.path()
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.chars().next().is_some_and(|c| c.is_ascii_digit()))
+            })
+            .collect();
+
+        for entry in candidates {
+            match self.parser.parse_file(entry.path()) {
+                Ok(adr) => adrs.push(adr),
+                Err(e) => errors.push((entry.path().to_path_buf(), e)),
+            }
+        }
+
+        adrs.sort_by_key(|a| a.number);
+        Ok((adrs, errors))
+    }
+
     /// Get the next available ADR number.
     pub fn next_number(&self) -> Result<u32> {
         let adrs = self.list()?;

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -1853,4 +1853,75 @@ Context.
         // Body preserved
         assert!(result.contains("## Context\n\nContext."));
     }
+
+    // ========== list_with_errors Tests ==========
+
+    #[test]
+    fn test_list_with_errors_all_valid() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        repo.new_adr("Valid ADR").unwrap();
+
+        let (adrs, errors) = repo.list_with_errors().unwrap();
+        assert_eq!(adrs.len(), 2); // init ADR + new one
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_list_with_errors_captures_invalid_frontmatter() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        // Write a file with invalid YAML frontmatter (bad date format)
+        let bad_content =
+            "---\nnumber: 2\nstatus: accepted\ndate: not-a-date\n---\n\n# 2. Bad ADR\n";
+        fs::write(repo.adr_path().join("0002-bad-adr.md"), bad_content).unwrap();
+
+        let (adrs, errors) = repo.list_with_errors().unwrap();
+        assert_eq!(adrs.len(), 1); // Only the init ADR
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].0.to_string_lossy().contains("0002-bad-adr.md"));
+    }
+
+    #[test]
+    fn test_list_with_errors_mixed_valid_and_invalid() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        // Valid ADR
+        repo.new_adr("Good ADR").unwrap();
+
+        // Invalid ADR (completely broken YAML)
+        let bad_content = "---\n: :\n---\n\n# 3. Broken\n";
+        fs::write(repo.adr_path().join("0003-broken.md"), bad_content).unwrap();
+
+        let (adrs, errors) = repo.list_with_errors().unwrap();
+        assert_eq!(adrs.len(), 2); // init + good
+        assert_eq!(errors.len(), 1); // broken
+    }
+
+    #[test]
+    fn test_list_with_errors_string_decision_makers_is_valid() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        // This is the exact case from issue #216
+        let content = r#"---
+number: 2
+status: accepted
+date: 2026-03-18
+decision-makers: mschoettle
+---
+
+# 2. Use Markdown Architectural Decision Records
+"#;
+        fs::write(repo.adr_path().join("0002-use-markdown-adrs.md"), content).unwrap();
+
+        let (adrs, errors) = repo.list_with_errors().unwrap();
+        assert!(errors.is_empty(), "string decision-makers should parse");
+        assert_eq!(adrs.len(), 2);
+
+        let adr = adrs.iter().find(|a| a.number == 2).unwrap();
+        assert_eq!(adr.decision_makers, vec!["mschoettle"]);
+    }
 }

--- a/crates/adrs-core/src/types.rs
+++ b/crates/adrs-core/src/types.rs
@@ -29,22 +29,35 @@ pub struct Adr {
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",
-        rename = "decision-makers"
+        rename = "decision-makers",
+        deserialize_with = "string_or_vec::deserialize"
     )]
     pub decision_makers: Vec<String>,
 
     /// People consulted for input (MADR 4.0.0).
     /// Two-way communication - their opinions are sought.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "string_or_vec::deserialize"
+    )]
     pub consulted: Vec<String>,
 
     /// People kept informed (MADR 4.0.0).
     /// One-way communication - they are kept up-to-date.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "string_or_vec::deserialize"
+    )]
     pub informed: Vec<String>,
 
     /// Tags for categorization.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "string_or_vec::deserialize"
+    )]
     pub tags: Vec<String>,
 
     /// The context section (why this decision was needed).
@@ -322,6 +335,37 @@ fn slug(title: &str) -> String {
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("-")
+}
+
+/// Flexible deserialization for fields that accept either a single string or a list.
+///
+/// In MADR frontmatter, fields like `decision-makers` can be written as either:
+/// ```yaml
+/// decision-makers: alice        # single string
+/// decision-makers:              # list
+///   - alice
+///   - bob
+/// ```
+/// This module handles both forms, always deserializing into `Vec<String>`.
+mod string_or_vec {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrVec {
+            String(String),
+            Vec(Vec<String>),
+        }
+
+        match StringOrVec::deserialize(deserializer)? {
+            StringOrVec::String(s) => Ok(vec![s]),
+            StringOrVec::Vec(v) => Ok(v),
+        }
+    }
 }
 
 /// Custom date serialization format (YYYY-MM-DD).
@@ -760,5 +804,93 @@ informed:
         assert_eq!(adr.decision_makers, vec!["Alice", "Bob"]);
         assert_eq!(adr.consulted, vec!["Carol"]);
         assert_eq!(adr.informed, vec!["Dave"]);
+    }
+
+    // ========== String-or-Vec Deserialization Tests ==========
+
+    #[test]
+    fn test_decision_makers_as_string() {
+        let yaml = r#"
+number: 1
+title: Test
+date: 2024-09-15
+status: accepted
+decision-makers: alice
+"#;
+        let adr: Adr = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(adr.decision_makers, vec!["alice"]);
+    }
+
+    #[test]
+    fn test_consulted_as_string() {
+        let yaml = r#"
+number: 1
+title: Test
+date: 2024-09-15
+status: accepted
+consulted: bob
+"#;
+        let adr: Adr = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(adr.consulted, vec!["bob"]);
+    }
+
+    #[test]
+    fn test_informed_as_string() {
+        let yaml = r#"
+number: 1
+title: Test
+date: 2024-09-15
+status: accepted
+informed: carol
+"#;
+        let adr: Adr = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(adr.informed, vec!["carol"]);
+    }
+
+    #[test]
+    fn test_tags_as_string() {
+        let yaml = r#"
+number: 1
+title: Test
+date: 2024-09-15
+status: accepted
+tags: architecture
+"#;
+        let adr: Adr = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(adr.tags, vec!["architecture"]);
+    }
+
+    #[test]
+    fn test_string_or_vec_fields_still_accept_lists() {
+        let yaml = r#"
+number: 1
+title: Test
+date: 2024-09-15
+status: accepted
+decision-makers:
+  - alice
+  - bob
+tags:
+  - arch
+  - security
+"#;
+        let adr: Adr = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(adr.decision_makers, vec!["alice", "bob"]);
+        assert_eq!(adr.tags, vec!["arch", "security"]);
+    }
+
+    #[test]
+    fn test_string_or_vec_fields_default_when_absent() {
+        let yaml = r#"
+number: 1
+title: Test
+date: 2024-09-15
+status: accepted
+"#;
+        let adr: Adr = serde_yaml::from_str(yaml).unwrap();
+        assert!(adr.decision_makers.is_empty());
+        assert!(adr.consulted.is_empty());
+        assert!(adr.informed.is_empty());
+        assert!(adr.tags.is_empty());
     }
 }

--- a/crates/adrs/tests/scenarios.rs
+++ b/crates/adrs/tests/scenarios.rs
@@ -4,6 +4,7 @@
 //! catching integration issues that unit tests might miss.
 
 use assert_cmd::{Command, cargo_bin_cmd};
+use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
 use std::fs;
@@ -1300,6 +1301,93 @@ fn scenario_config_ng_multiple_tagged_adrs() {
         .success()
         .stdout(predicate::str::contains("0003-auth-design.md"))
         .stdout(predicate::str::contains("0002-use-postgresql.md").not());
+
+    temp.close().unwrap();
+}
+
+// ============================================================================
+// Scenario: String-valued frontmatter fields (issue #216)
+// ============================================================================
+
+/// User writes decision-makers as a plain string instead of a YAML list.
+/// The ADR should still appear in list and doctor should not report parse errors.
+#[test]
+fn scenario_string_decision_makers_visible_in_list() {
+    let temp = TempDir::new().unwrap();
+
+    // Init with --ng for frontmatter mode
+    adrs()
+        .current_dir(temp.path())
+        .args(["init", "--ng"])
+        .assert()
+        .success();
+
+    // Write an ADR with decision-makers as a plain string (the reporter's case)
+    let content = r#"---
+number: 2
+status: accepted
+date: 2026-03-18
+decision-makers: mschoettle
+---
+
+# 2. Use Markdown Architectural Decision Records
+
+## Context
+
+We need to record decisions.
+
+## Decision
+
+Use MADR format.
+
+## Consequences
+
+Decisions are recorded.
+"#;
+    let adr_dir = temp.path().join("doc/adr");
+    fs::write(adr_dir.join("0002-use-markdown-adrs.md"), content).unwrap();
+
+    // list should show this ADR
+    adrs()
+        .current_dir(temp.path())
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0002-use-markdown-adrs.md"));
+
+    // doctor should not report parse-error (other lint rules may still fire)
+    adrs()
+        .current_dir(temp.path())
+        .args(["doctor"])
+        .assert()
+        .stdout(predicate::str::contains("parse-error").not());
+
+    temp.close().unwrap();
+}
+
+/// Doctor reports files with completely unparseable YAML frontmatter.
+#[test]
+fn scenario_doctor_reports_invalid_frontmatter() {
+    let temp = TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["init", "--ng"])
+        .assert()
+        .success();
+
+    // Write an ADR with completely broken YAML that fails our parser
+    let content = "---\n: :\n---\n\n# 2. Broken\n";
+    let adr_dir = temp.path().join("doc/adr");
+    fs::write(adr_dir.join("0002-broken.md"), content).unwrap();
+
+    // doctor should report the parse error
+    adrs()
+        .current_dir(temp.path())
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("parse-error"));
 
     temp.close().unwrap();
 }


### PR DESCRIPTION
## Summary

- YAML frontmatter fields (`decision-makers`, `consulted`, `informed`, `tags`) now accept both a single string and a list. Previously, `decision-makers: alice` caused a deserialization error that silently dropped the ADR from `list` and `doctor` output.
- `adrs doctor` now reports parse errors for files that look like ADRs (digit-prefixed `.md` files) but fail to parse, instead of silently ignoring them.

Closes #216

## Test plan

- [x] New unit tests for string-or-vec deserialization (6 tests)
- [x] All 372 lib tests pass
- [x] All 15 integration tests pass
- [x] clippy and fmt clean