### PR TITLE
feat: upgrade tower-mcp from 0.1 to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,9 +2410,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.1.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba86ff2f8c73399d51d1d4780a82636c9ebeb06271d262273d04c67ccbfa11d2"
+checksum = "d8d2680ddb4e9e26260e5c37ed7ba5eb93030a9fc57428c004b0b15904c89b4b"
 dependencies = [
  "async-trait",
  "axum",
@@ -2426,13 +2426,25 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
+ "tower-mcp-types",
  "tower-service",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "tower-mcp-types"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f104da876114dc20c32cd82b3dabeaead05e449d02fb0945e5177fb96639ea"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ edit = "0.1"
 whoami = "1"
 
 # MCP server (optional feature)
-tower-mcp = { version = "0.1", features = ["http"] }
+tower-mcp = { version = "0.9", features = ["http"] }
 schemars = "1"
 tokio = { version = "1", features = ["full"] }
 

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -351,9 +351,28 @@ struct SuggestedTag {
 }
 
 // Macro to reduce boilerplate for tool registration.
-// Typed variant: handler receives a deserialized params struct.
 macro_rules! adr_tool {
-    ($state:expr, $name:expr, $desc:expr, $param:ty, $method:ident) => {
+    // Read-only tool with params.
+    (ro, $state:expr, $name:expr, $desc:expr, $param:ty, $method:ident) => {
+        ToolBuilder::new($name)
+            .description($desc)
+            .read_only()
+            .handler({
+                let state = $state.clone();
+                move |params: $param| {
+                    let state = state.clone();
+                    async move {
+                        match state.$method(params) {
+                            Ok(json) => Ok(CallToolResult::text(json)),
+                            Err(e) => Ok(CallToolResult::error(format!("Error: {e}"))),
+                        }
+                    }
+                }
+            })
+            .build()
+    };
+    // Write tool with params.
+    (rw, $state:expr, $name:expr, $desc:expr, $param:ty, $method:ident) => {
         ToolBuilder::new($name)
             .description($desc)
             .handler({
@@ -368,30 +387,36 @@ macro_rules! adr_tool {
                     }
                 }
             })
-            .build()?
+            .build()
     };
-    // Parameterless variant (for get_repository_info).
-    ($state:expr, $name:expr, $desc:expr, $method:ident) => {
-        ToolBuilder::new($name).description($desc).raw_handler({
-            let state = $state.clone();
-            move |_: serde_json::Value| {
-                let state = state.clone();
-                async move {
-                    match state.$method() {
-                        Ok(json) => Ok(CallToolResult::text(json)),
-                        Err(e) => Ok(CallToolResult::error(format!("Error: {e}"))),
+    // Read-only tool without params.
+    (ro, $state:expr, $name:expr, $desc:expr, $method:ident) => {
+        ToolBuilder::new($name)
+            .description($desc)
+            .read_only()
+            .no_params_handler({
+                let state = $state.clone();
+                move || {
+                    let state = state.clone();
+                    async move {
+                        match state.$method() {
+                            Ok(json) => Ok(CallToolResult::text(json)),
+                            Err(e) => Ok(CallToolResult::error(format!("Error: {e}"))),
+                        }
                     }
                 }
-            }
-        })?
+            })
+            .build()
     };
 }
 
 /// Build the MCP router with all ADR tools registered.
-fn build_router(root: PathBuf) -> Result<McpRouter> {
+fn build_router(root: PathBuf) -> McpRouter {
     let state = Arc::new(AdrState::new(root));
 
+    // Read-only tools
     let list_adrs = adr_tool!(
+        ro,
         state,
         "list_adrs",
         "List all Architecture Decision Records. Returns summary information for each ADR including number, title, status, and date. Optionally filter by status or tag.",
@@ -400,6 +425,7 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
     );
 
     let get_adr = adr_tool!(
+        ro,
         state,
         "get_adr",
         "Get the full content of an Architecture Decision Record by its number. Returns the complete ADR including title, status, content, and links.",
@@ -408,6 +434,7 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
     );
 
     let search_adrs = adr_tool!(
+        ro,
         state,
         "search_adrs",
         "Search Architecture Decision Records for matching text. Searches both titles and content by default. Use title_only=true to search only titles.",
@@ -415,47 +442,8 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
         search_adrs_impl
     );
 
-    let create_adr = adr_tool!(
-        state,
-        "create_adr",
-        "Create a new Architecture Decision Record. The ADR will be created with 'proposed' status and requires human review before acceptance. Returns the created ADR details including its number and file path.",
-        CreateAdrParams,
-        create_adr_impl
-    );
-
-    let update_status = adr_tool!(
-        state,
-        "update_status",
-        "Update the status of an existing ADR. Valid statuses: proposed, accepted, deprecated, superseded, rejected. For 'superseded', provide the superseded_by number. Note: Status changes should be reviewed by humans.",
-        UpdateStatusParams,
-        update_status_impl
-    );
-
-    let link_adrs = adr_tool!(
-        state,
-        "link_adrs",
-        "Create a bidirectional link between two ADRs. Link types: 'Supersedes', 'Amends', or 'Relates to'. The reverse link is automatically created on the target ADR.",
-        LinkAdrsParams,
-        link_adrs_impl
-    );
-
-    let update_content = adr_tool!(
-        state,
-        "update_content",
-        "Update the content sections (context, decision, consequences) of an existing ADR. Only provided fields are updated; omitted fields are preserved. Changes should be reviewed by humans.",
-        UpdateContentParams,
-        update_content_impl
-    );
-
-    let update_tags = adr_tool!(
-        state,
-        "update_tags",
-        "Add or replace tags on an ADR. Requires NextGen mode (YAML frontmatter). Use replace=true to replace all tags, or false/omit to append.",
-        UpdateTagsParams,
-        update_tags_impl
-    );
-
     let get_repository_info = adr_tool!(
+        ro,
         state,
         "get_repository_info",
         "Get information about the ADR repository including mode (compatible/nextgen), ADR count, and configuration.",
@@ -463,6 +451,7 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
     );
 
     let get_related_adrs = adr_tool!(
+        ro,
         state,
         "get_related_adrs",
         "Get all ADRs that are linked to or from a specific ADR. Returns both incoming and outgoing links with their types.",
@@ -471,6 +460,7 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
     );
 
     let validate_adr = adr_tool!(
+        ro,
         state,
         "validate_adr",
         "Validate a single ADR's structure and content. Checks for required sections (Context, Decision, Consequences), validates status, and reports any issues. Returns validation results with severity levels (error/warning).",
@@ -479,6 +469,7 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
     );
 
     let get_adr_sections = adr_tool!(
+        ro,
         state,
         "get_adr_sections",
         "Get an ADR with its content parsed into separate sections (context, decision, consequences). Returns structured data instead of raw markdown, making it easier to analyze specific sections independently.",
@@ -487,6 +478,7 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
     );
 
     let compare_adrs = adr_tool!(
+        ro,
         state,
         "compare_adrs",
         "Compare two ADRs and show the differences between them. Useful for understanding how decisions evolved, especially when one ADR supersedes another. Returns structural comparison of title, status, and content sections.",
@@ -494,15 +486,8 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
         compare_adrs_impl
     );
 
-    let bulk_update_status = adr_tool!(
-        state,
-        "bulk_update_status",
-        "Update the status of multiple ADRs in a single operation. Useful for batch accepting related ADRs or deprecating multiple outdated decisions. Returns detailed results for each ADR including any failures.",
-        BulkUpdateStatusParams,
-        bulk_update_status_impl
-    );
-
     let suggest_tags = adr_tool!(
+        ro,
         state,
         "suggest_tags",
         "Analyze an ADR's content and suggest relevant tags based on keywords and common architectural categories. Returns suggested tags with confidence scores and reasons. Requires NextGen mode for tags to be applied.",
@@ -510,35 +495,81 @@ fn build_router(root: PathBuf) -> Result<McpRouter> {
         suggest_tags_impl
     );
 
-    let router = McpRouter::new()
+    // Write tools
+    let create_adr = adr_tool!(
+        rw,
+        state,
+        "create_adr",
+        "Create a new Architecture Decision Record. The ADR will be created with 'proposed' status and requires human review before acceptance. Returns the created ADR details including its number and file path.",
+        CreateAdrParams,
+        create_adr_impl
+    );
+
+    let update_status = adr_tool!(
+        rw,
+        state,
+        "update_status",
+        "Update the status of an existing ADR. Valid statuses: proposed, accepted, deprecated, superseded, rejected. For 'superseded', provide the superseded_by number. Note: Status changes should be reviewed by humans.",
+        UpdateStatusParams,
+        update_status_impl
+    );
+
+    let link_adrs = adr_tool!(
+        rw,
+        state,
+        "link_adrs",
+        "Create a bidirectional link between two ADRs. Link types: 'Supersedes', 'Amends', or 'Relates to'. The reverse link is automatically created on the target ADR.",
+        LinkAdrsParams,
+        link_adrs_impl
+    );
+
+    let update_content = adr_tool!(
+        rw,
+        state,
+        "update_content",
+        "Update the content sections (context, decision, consequences) of an existing ADR. Only provided fields are updated; omitted fields are preserved. Changes should be reviewed by humans.",
+        UpdateContentParams,
+        update_content_impl
+    );
+
+    let update_tags = adr_tool!(
+        rw,
+        state,
+        "update_tags",
+        "Add or replace tags on an ADR. Requires NextGen mode (YAML frontmatter). Use replace=true to replace all tags, or false/omit to append.",
+        UpdateTagsParams,
+        update_tags_impl
+    );
+
+    let bulk_update_status = adr_tool!(
+        rw,
+        state,
+        "bulk_update_status",
+        "Update the status of multiple ADRs in a single operation. Useful for batch accepting related ADRs or deprecating multiple outdated decisions. Returns detailed results for each ADR including any failures.",
+        BulkUpdateStatusParams,
+        bulk_update_status_impl
+    );
+
+    McpRouter::new()
         .server_info("adrs", env!("CARGO_PKG_VERSION"))
-        .instructions(
-            "ADR (Architecture Decision Record) management server. \
-            Use list_adrs to see all decisions, get_adr to read a specific one, \
-            and search_adrs to find relevant decisions. For modifications: create_adr creates new ADRs \
-            (always as 'proposed' status for human review), update_status changes an ADR's status, \
-            link_adrs creates bidirectional links, update_content edits ADR sections, \
-            and update_tags manages ADR tags (NextGen mode only). \
-            Use get_repository_info to understand the repo configuration and get_related_adrs \
-            to explore ADR relationships. ADRs document important architectural decisions and their context."
-        )
+        .auto_instructions()
+        // Read tools
         .tool(list_adrs)
         .tool(get_adr)
         .tool(search_adrs)
-        .tool(create_adr)
-        .tool(update_status)
-        .tool(link_adrs)
-        .tool(update_content)
-        .tool(update_tags)
         .tool(get_repository_info)
         .tool(get_related_adrs)
         .tool(validate_adr)
         .tool(get_adr_sections)
         .tool(compare_adrs)
+        .tool(suggest_tags)
+        // Write tools
+        .tool(create_adr)
+        .tool(update_status)
+        .tool(link_adrs)
+        .tool(update_content)
+        .tool(update_tags)
         .tool(bulk_update_status)
-        .tool(suggest_tags);
-
-    Ok(router)
 }
 
 // Business logic implementations (unchanged).
@@ -1357,7 +1388,7 @@ impl AdrState {
 pub async fn serve_stdio(root: PathBuf) -> Result<()> {
     use tower_mcp::StdioTransport;
 
-    let router = build_router(root)?;
+    let router = build_router(root);
     let mut transport = StdioTransport::new(router);
     transport.run().await?;
     Ok(())
@@ -1368,7 +1399,7 @@ pub async fn serve_stdio(root: PathBuf) -> Result<()> {
 pub async fn serve_http(root: PathBuf, addr: std::net::SocketAddr) -> Result<()> {
     use tower_mcp::HttpTransport;
 
-    let router = build_router(root)?;
+    let router = build_router(root);
 
     eprintln!("MCP server listening on http://{}/mcp", addr);
 

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -214,7 +214,7 @@ pub struct SuggestTagsParams {
 
 // Response types
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct AdrSummary {
     number: u32,
     title: String,
@@ -223,7 +223,7 @@ struct AdrSummary {
     tags: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct AdrDetail {
     number: u32,
     title: String,
@@ -234,14 +234,14 @@ struct AdrDetail {
     links: Vec<LinkInfo>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct LinkInfo {
     kind: String,
     target: u32,
     description: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct ValidationResult {
     number: u32,
     title: String,
@@ -250,27 +250,27 @@ struct ValidationResult {
     sections: SectionStatus,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct ValidationIssue {
     severity: String,
     message: String,
     section: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct SectionStatus {
     context: SectionInfo,
     decision: SectionInfo,
     consequences: SectionInfo,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct SectionInfo {
     present: bool,
     empty: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct AdrSections {
     number: u32,
     title: String,
@@ -283,21 +283,21 @@ struct AdrSections {
     links: Vec<LinkInfo>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct CompareResult {
     source: AdrBrief,
     target: AdrBrief,
     differences: Differences,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct AdrBrief {
     number: u32,
     title: String,
     status: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct Differences {
     title_changed: bool,
     status_changed: bool,
@@ -306,7 +306,7 @@ struct Differences {
     consequences: SectionDiff,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct SectionDiff {
     changed: bool,
     source_empty: bool,
@@ -315,27 +315,27 @@ struct SectionDiff {
     target_length: usize,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct BulkUpdateResult {
     updated: Vec<UpdatedAdr>,
     failed: Vec<FailedAdr>,
     summary: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct UpdatedAdr {
     number: u32,
     old_status: String,
     new_status: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct FailedAdr {
     number: u32,
     error: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct SuggestTagsResult {
     number: u32,
     title: String,
@@ -343,7 +343,7 @@ struct SuggestTagsResult {
     suggested_tags: Vec<SuggestedTag>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct SuggestedTag {
     tag: String,
     confidence: f32,
@@ -1407,4 +1407,429 @@ pub async fn serve_http(root: PathBuf, addr: std::net::SocketAddr) -> Result<()>
     transport.serve(&addr.to_string()).await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tower_mcp::client::{ChannelTransport, McpClient};
+
+    /// Helper: create an initialized MCP client connected to a temp ADR repo.
+    async fn setup_client(ng: bool) -> (McpClient, tempfile::TempDir) {
+        let temp = tempfile::tempdir().unwrap();
+        adrs_core::Repository::init(temp.path(), None, ng).unwrap();
+        let router = build_router(temp.path().to_path_buf());
+        let transport = ChannelTransport::new(router);
+        let client = McpClient::connect(transport).await.unwrap();
+        client.initialize("test-client", "1.0.0").await.unwrap();
+        (client, temp)
+    }
+
+    #[tokio::test]
+    async fn test_initialize_returns_server_info() {
+        let (client, _tmp) = setup_client(false).await;
+        let info = client.server_info().unwrap();
+        assert_eq!(info.server_info.name, "adrs");
+        assert!(info.capabilities.tools.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_list_tools_returns_all_15() {
+        let (client, _tmp) = setup_client(false).await;
+        let tools = client.list_all_tools().await.unwrap();
+        assert_eq!(tools.len(), 15, "expected 15 tools, got {}", tools.len());
+
+        let names: Vec<_> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"list_adrs"));
+        assert!(names.contains(&"get_adr"));
+        assert!(names.contains(&"search_adrs"));
+        assert!(names.contains(&"create_adr"));
+        assert!(names.contains(&"update_status"));
+        assert!(names.contains(&"link_adrs"));
+        assert!(names.contains(&"update_content"));
+        assert!(names.contains(&"update_tags"));
+        assert!(names.contains(&"get_repository_info"));
+        assert!(names.contains(&"get_related_adrs"));
+        assert!(names.contains(&"validate_adr"));
+        assert!(names.contains(&"get_adr_sections"));
+        assert!(names.contains(&"compare_adrs"));
+        assert!(names.contains(&"bulk_update_status"));
+        assert!(names.contains(&"suggest_tags"));
+    }
+
+    #[tokio::test]
+    async fn test_read_only_tools_have_annotation() {
+        let (client, _tmp) = setup_client(false).await;
+        let tools = client.list_all_tools().await.unwrap();
+
+        let read_only_names = [
+            "list_adrs",
+            "get_adr",
+            "search_adrs",
+            "get_repository_info",
+            "get_related_adrs",
+            "validate_adr",
+            "get_adr_sections",
+            "compare_adrs",
+            "suggest_tags",
+        ];
+
+        for name in read_only_names {
+            let tool = tools
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("tool {name} not found"));
+            let annotations = tool
+                .annotations
+                .as_ref()
+                .unwrap_or_else(|| panic!("tool {name} has no annotations"));
+            assert!(
+                annotations.read_only_hint,
+                "tool {name} should be read-only"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_adrs_returns_initial_adr() {
+        let (client, _tmp) = setup_client(false).await;
+        let result = client.call_tool_text("list_adrs", json!({})).await.unwrap();
+
+        let adrs: Vec<AdrSummary> = serde_json::from_str(&result).unwrap();
+        assert_eq!(adrs.len(), 1);
+        assert_eq!(adrs[0].number, 1);
+        assert_eq!(adrs[0].status, "Accepted");
+    }
+
+    #[tokio::test]
+    async fn test_get_adr_returns_content() {
+        let (client, _tmp) = setup_client(false).await;
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 1}))
+            .await
+            .unwrap();
+
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+        assert_eq!(adr.number, 1);
+        assert!(!adr.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_create_adr_and_get() {
+        let (client, _tmp) = setup_client(false).await;
+
+        // Create a new ADR
+        let result = client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use PostgreSQL",
+                    "context": "We need a database.",
+                    "decision": "Use PostgreSQL.",
+                    "consequences": "Need DBA skills."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let created: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(created["number"], 2);
+        assert_eq!(created["status"], "Proposed");
+
+        // Retrieve it back
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+        assert_eq!(adr.title, "Use PostgreSQL");
+    }
+
+    #[tokio::test]
+    async fn test_search_adrs() {
+        let (client, _tmp) = setup_client(false).await;
+
+        // Create an ADR with searchable content
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({"title": "Adopt Kubernetes for deployment"}),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("search_adrs", json!({"query": "Kubernetes"}))
+            .await
+            .unwrap();
+
+        let matches: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        assert!(!matches.is_empty(), "search should find Kubernetes ADR");
+        assert!(
+            matches
+                .iter()
+                .any(|m| m["title"].as_str().unwrap().contains("Kubernetes"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_status() {
+        let (client, _tmp) = setup_client(false).await;
+
+        client
+            .call_tool_text("create_adr", json!({"title": "Use Redis"}))
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("update_status", json!({"number": 2, "status": "accepted"}))
+            .await
+            .unwrap();
+
+        let updated: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(updated["new_status"], "Accepted");
+
+        // Verify via get
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+        assert_eq!(adr.status, "Accepted");
+    }
+
+    #[tokio::test]
+    async fn test_link_adrs() {
+        let (client, _tmp) = setup_client(false).await;
+
+        client
+            .call_tool_text("create_adr", json!({"title": "Use MySQL"}))
+            .await
+            .unwrap();
+        client
+            .call_tool_text("create_adr", json!({"title": "Use PostgreSQL"}))
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text(
+                "link_adrs",
+                json!({"source": 3, "target": 2, "link_type": "Supersedes"}),
+            )
+            .await
+            .unwrap();
+        assert!(result.contains("Supersedes"));
+
+        // Verify the link via get_related_adrs
+        let result = client
+            .call_tool_text("get_related_adrs", json!({"number": 3}))
+            .await
+            .unwrap();
+        let related: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let links = related["related"].as_array().unwrap();
+        assert!(
+            links.iter().any(|l| l["direction"] == "outgoing"),
+            "expected outgoing link"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_content() {
+        let (client, _tmp) = setup_client(false).await;
+
+        client
+            .call_tool_text("create_adr", json!({"title": "Use Docker"}))
+            .await
+            .unwrap();
+
+        client
+            .call_tool_text(
+                "update_content",
+                json!({
+                    "number": 2,
+                    "context": "We need containerization.",
+                    "decision": "Use Docker."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("get_adr_sections", json!({"number": 2}))
+            .await
+            .unwrap();
+        let sections: AdrSections = serde_json::from_str(&result).unwrap();
+        assert!(sections.context.contains("containerization"));
+        assert!(sections.decision.contains("Docker"));
+    }
+
+    #[tokio::test]
+    async fn test_update_tags_ng_mode() {
+        let (client, _tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text("create_adr", json!({"title": "Use gRPC"}))
+            .await
+            .unwrap();
+
+        client
+            .call_tool_text(
+                "update_tags",
+                json!({"number": 2, "tags": ["api", "networking"]}),
+            )
+            .await
+            .unwrap();
+
+        // Verify tags via list with filter
+        let result = client
+            .call_tool_text("list_adrs", json!({"tag": "api"}))
+            .await
+            .unwrap();
+        let adrs: Vec<AdrSummary> = serde_json::from_str(&result).unwrap();
+        assert!(adrs.iter().any(|a| a.number == 2));
+    }
+
+    #[tokio::test]
+    async fn test_get_repository_info() {
+        let (client, _tmp) = setup_client(true).await;
+        let result = client
+            .call_tool_text("get_repository_info", json!({}))
+            .await
+            .unwrap();
+
+        let info: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(info["mode"], "nextgen");
+        assert!(info["adr_count"].as_u64().unwrap() >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_validate_adr() {
+        let (client, _tmp) = setup_client(false).await;
+        let result = client
+            .call_tool_text("validate_adr", json!({"number": 1}))
+            .await
+            .unwrap();
+
+        let validation: ValidationResult = serde_json::from_str(&result).unwrap();
+        assert_eq!(validation.number, 1);
+    }
+
+    #[tokio::test]
+    async fn test_compare_adrs() {
+        let (client, _tmp) = setup_client(false).await;
+
+        client
+            .call_tool_text("create_adr", json!({"title": "Use REST"}))
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("compare_adrs", json!({"source": 1, "target": 2}))
+            .await
+            .unwrap();
+
+        let cmp: CompareResult = serde_json::from_str(&result).unwrap();
+        assert_eq!(cmp.source.number, 1);
+        assert_eq!(cmp.target.number, 2);
+        assert!(cmp.differences.title_changed);
+    }
+
+    #[tokio::test]
+    async fn test_bulk_update_status() {
+        let (client, _tmp) = setup_client(false).await;
+
+        client
+            .call_tool_text("create_adr", json!({"title": "ADR A"}))
+            .await
+            .unwrap();
+        client
+            .call_tool_text("create_adr", json!({"title": "ADR B"}))
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text(
+                "bulk_update_status",
+                json!({"numbers": [2, 3], "status": "accepted"}),
+            )
+            .await
+            .unwrap();
+
+        let bulk: BulkUpdateResult = serde_json::from_str(&result).unwrap();
+        assert_eq!(bulk.updated.len(), 2);
+        assert!(bulk.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_suggest_tags() {
+        let (client, _tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use PostgreSQL for database",
+                    "context": "We need a relational database for storing user data and API records.",
+                    "decision": "Use PostgreSQL as the primary database."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("suggest_tags", json!({"number": 2}))
+            .await
+            .unwrap();
+
+        let suggestions: SuggestTagsResult = serde_json::from_str(&result).unwrap();
+        assert_eq!(suggestions.number, 2);
+        assert!(!suggestions.suggested_tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_adrs_filter_by_status() {
+        let (client, _tmp) = setup_client(false).await;
+
+        client
+            .call_tool_text("create_adr", json!({"title": "Proposed ADR"}))
+            .await
+            .unwrap();
+
+        // Filter for accepted (only the init ADR)
+        let result = client
+            .call_tool_text("list_adrs", json!({"status": "accepted"}))
+            .await
+            .unwrap();
+        let adrs: Vec<AdrSummary> = serde_json::from_str(&result).unwrap();
+        assert_eq!(adrs.len(), 1);
+        assert_eq!(adrs[0].number, 1);
+
+        // Filter for proposed (only the new one)
+        let result = client
+            .call_tool_text("list_adrs", json!({"status": "proposed"}))
+            .await
+            .unwrap();
+        let adrs: Vec<AdrSummary> = serde_json::from_str(&result).unwrap();
+        assert_eq!(adrs.len(), 1);
+        assert_eq!(adrs[0].number, 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_nonexistent_adr_returns_error() {
+        let (client, _tmp) = setup_client(false).await;
+        let result = client
+            .call_tool("get_adr", json!({"number": 999}))
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn test_ping() {
+        let (client, _tmp) = setup_client(false).await;
+        client.ping().await.unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

- Bump `tower-mcp` from 0.1 to 0.9 (follow-up to #171)
- Add `read_only()` tool annotations to all read-only tools (9 of 15)
- Use `auto_instructions()` to generate server instructions from tool descriptions, replacing the hand-written instructions block
- Use `no_params_handler()` for `get_repository_info` (replaces removed `raw_handler`)
- `build_router()` is now infallible (tower-mcp 0.9 made `ToolBuilder::build()` infallible)

Key improvements from the upgrade:
- MCP protocol version updated to 2025-11-25
- Clients see `[read-only]` annotations in auto-generated instructions
- Simpler macro (`ro`/`rw` variants instead of fallible `?` handling)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] 378 lib tests pass
- [x] 64 CLI tests pass
- [x] 26 scenario tests pass
- [x] 15 integration tests pass
- [x] MCP server smoke test (initialize handshake verified)