### PR TITLE
fix: resolve clippy 1.96 lints blocking release CI

### DIFF
--- a/crates/adrs-core/src/doctor.rs
+++ b/crates/adrs-core/src/doctor.rs
@@ -156,7 +156,7 @@ pub fn check(repo: &Repository) -> Result<DoctorReport> {
     // Sort diagnostics by severity (errors first)
     report
         .diagnostics
-        .sort_by(|a, b| b.severity.cmp(&a.severity));
+        .sort_by_key(|d| std::cmp::Reverse(d.severity));
 
     Ok(report)
 }

--- a/crates/adrs-core/src/parse.rs
+++ b/crates/adrs-core/src/parse.rs
@@ -240,10 +240,8 @@ impl Parser {
                         section_content.push_str(&text);
                     }
                 }
-                Event::SoftBreak | Event::HardBreak => {
-                    if !in_heading {
-                        section_content.push('\n');
-                    }
+                Event::SoftBreak | Event::HardBreak if !in_heading => {
+                    section_content.push('\n');
                 }
                 _ => {}
             }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -266,7 +266,7 @@ impl Repository {
             })
             .collect();
 
-        matches.sort_by(|a, b| b.1.cmp(&a.1));
+        matches.sort_by_key(|m| std::cmp::Reverse(m.1));
 
         match matches.len() {
             0 => Err(Error::AdrNotFound(query.to_string())),


### PR DESCRIPTION
## Problem

The open release PR #212 (v0.7.4) is blocked by a failing Clippy job. A newer clippy (1.96) introduced lints that fail under `-D warnings`:

- `crates/adrs-core/src/doctor.rs:157` — `unnecessary_sort_by`
- `crates/adrs-core/src/repository.rs:269` — `unnecessary_sort_by`
- `crates/adrs-core/src/parse.rs:244` — `collapsible_match`

All other CI jobs (Format, Audit, Test on macOS/Linux/Windows) pass.

## Fix

- `doctor.rs` / `repository.rs`: replace `sort_by(|a, b| b.x.cmp(&a.x))` with `sort_by_key(|m| std::cmp::Reverse(m.x))` (descending sort preserved).
- `parse.rs`: fold the inner `if !in_heading` into a match guard on the `SoftBreak | HardBreak` arm.

Pure lint cleanup, no behavior change.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test --lib --all-features` — 378 passed

Once merged, release-plz will rebase #212 and its Clippy job should go green.