### PR TITLE
docs: fix orphaned root changelog and stale doc references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,10 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+This is a Cargo workspace. Changelogs are maintained per crate and updated
+automatically by [release-plz](https://release-plz.dev/):
 
-## [Unreleased]
+- [`adrs`](crates/adrs/CHANGELOG.md) -- the CLI binary
+- [`adrs-core`](crates/adrs-core/CHANGELOG.md) -- the core library
 
-### Bug Fixes
-
-- Align MADR templates with official adr/madr repository
-
-### Features
-
-- Add doctor command for repository health checks
-- Add Docker image support
-## [0.4.0] - 2026-01-22
-
-### Documentation
-
-- Add ADRs for v2 rewrite decisions
-
-### Features
-
-- Rework CI and add Windows binary support
-- V2 rewrite with library-first architecture
-- Add MADR 4.0.0 support
-- Add template variants (full, minimal, bare)
-
-### Miscellaneous
-
-- Set up release-plz for automated releases
-
-### Testing
-
-- Add comprehensive test suite for adrs-core
-- Add CLI integration tests
-
+See the [GitHub Releases](https://github.com/joshrotenberg/adrs/releases) page
+for tagged releases with prebuilt binaries and installers.

--- a/book/src/commands/export.md
+++ b/book/src/commands/export.md
@@ -31,7 +31,7 @@ adrs export json -d path/to/adrs  # Export from directory (no repo needed)
   "generated_at": "2024-01-15T10:30:00Z",
   "tool": {
     "name": "adrs",
-    "version": "0.7.1"
+    "version": "0.7.4"
   },
   "repository": {
     "adr_directory": "doc/adr"

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -113,4 +113,4 @@ adrs/
 
 - Update the mdbook in `book/` for user-facing changes
 - Add doc comments to public APIs
-- Update CHANGELOG.md (handled by release-plz)
+- Per-crate changelogs (`crates/adrs/CHANGELOG.md`, `crates/adrs-core/CHANGELOG.md`) are handled by release-plz; no manual edits needed


### PR DESCRIPTION
Part of a documentation-drift cleanup from a full project audit.

## Changes

- **Root `CHANGELOG.md`** was orphaned: frozen at v0.4.0 with a wrong `[Unreleased]` section (listing the doctor command and Docker support as unreleased, though both shipped long ago). release-plz maintains per-crate changelogs (`crates/adrs/CHANGELOG.md`, `crates/adrs-core/CHANGELOG.md`), so the root file is now a short pointer to those plus the GitHub Releases page.
- **`book/src/contributing.md`**: the "Update CHANGELOG.md" guidance pointed at the orphaned root file. Corrected to reference the per-crate changelogs release-plz actually updates.
- **`book/src/commands/export.md`**: bumped the stale `0.7.1` example tool version.

## Verification

- `mdbook build` succeeds.

No code changes.