### PR TITLE
fix: draft incomplete releases when artifact build fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,6 +331,31 @@ jobs:
           done
           git push
 
+  # Custom job (manual addition; ci is in dist allow-dirty): the `plan` job runs
+  # `dist host --steps=create`, which publishes the GitHub Release before any
+  # artifacts are built. If an artifact build then fails, `host` is skipped but
+  # the empty release stays public. Convert it to a draft so an incomplete
+  # release is never visible. See issue #242 (root cause of #217).
+  cleanup-on-failure:
+    needs:
+      - plan
+      - build-local-artifacts
+      - build-global-artifacts
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-local-artifacts.result == 'failure' || needs.build-global-artifacts.result == 'failure') }}
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Convert incomplete release to draft
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          if [ -n "$TAG" ] && gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft
+            echo "::warning::Artifact build failed; release $TAG converted to draft to avoid publishing an incomplete release. Re-run the failed job, then undraft."
+          else
+            echo "No release found for tag '$TAG'; nothing to clean up."
+          fi
+
   announce:
     needs:
       - plan


### PR DESCRIPTION
## Problem

The `plan` job in `release.yml` runs `dist host --steps=create`, which publishes the GitHub Release **before** any artifacts are built. With `build-local-artifacts` using `fail-fast: false`, a single platform build failure causes the `host` (upload) job to be skipped — but the empty release is already public.

This is the confirmed **root cause of #217**: v0.7.3 shipped with only source artifacts (no installers, no `.sha256`) because the Windows build failed on the first attempt; the release sat empty until a manual re-run 18 days later.

## Fix

Add a `cleanup-on-failure` job that runs when any artifact build fails (and we're publishing). It converts the release to a draft via `gh release edit --draft`, so an incomplete release is never publicly visible. Recovery is then: re-run the failed job, then undraft.

- Uses the existing top-level `permissions: contents: write` and `GITHUB_TOKEN`.
- `ci` is in dist's `allow-dirty`, so this manual edit to the generated workflow is tolerated. (A future `dist generate-ci` would drop it — noted as a follow-up in the release runbook issue #246.)

## Verification

- `release.yml` parses as valid YAML.
- Job condition triggers only on `publishing == 'true'` and a `failure` result from local/global artifact builds; the existing `host` gate (success/skipped only) is unchanged.

Closes #242
Closes #217