### PR TITLE
docs: fix high-priority documentation inaccuracies

### DIFF
--- a/book/src/commands/init.md
+++ b/book/src/commands/init.md
@@ -86,15 +86,13 @@ date: 2024-01-15
 ...
 ```
 
-## Error Handling
+## Re-initialization
 
-If the repository is already initialized (`.adr-dir` exists), the command will fail:
-
-```
-Error: ADR repository already initialized
-```
-
-To reinitialize, remove the `.adr-dir` file first.
+`adrs init` is idempotent: running it again in an already-initialized
+repository succeeds. It rewrites the configuration (for example, to change the
+ADR directory or switch modes) and preserves existing ADRs. The initial
+"Record architecture decisions" ADR is only created when the repository has no
+ADRs yet, so re-initializing will not add a duplicate.
 
 ## Related
 

--- a/book/src/commands/new.md
+++ b/book/src/commands/new.md
@@ -88,10 +88,16 @@ Common link types:
 - `Extends` / `Extended by`
 - `Relates to` / `Relates to`
 
-### Multiple Links
+### Adding More Links
+
+`--link` accepts a single link when creating an ADR (format
+`TARGET:KIND:REVERSE_KIND`). To attach additional links, create the ADR first
+and then use [`adrs link`](./link.md), whose arguments are
+`SOURCE LINK TARGET [REVERSE_LINK]`:
 
 ```sh
-adrs new --link "2:Amends:Amended by" --link "3:Extends:Extended by" "Combined decision"
+adrs new --link "2:Amends:Amended by" "Combined decision"
+adrs link 4 Extends 3 "Extended by"   # ADR 4 extends ADR 3
 ```
 
 ### NextGen Mode with MADR

--- a/book/src/mcp.md
+++ b/book/src/mcp.md
@@ -167,8 +167,8 @@ Validate an ADR's structure and content.
 Compare two ADRs side by side.
 
 **Parameters:**
-- `adr1` (required): First ADR number
-- `adr2` (required): Second ADR number
+- `source` (required): First ADR number
+- `target` (required): Second ADR number
 
 **Returns:** Structural comparison of title, status, and content sections.
 

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -316,15 +316,18 @@ FISH:
         shell: ShellArg,
     },
 
-    /// Start MCP server for AI agent integration (requires --features mcp)
+    /// Start MCP server for AI agent integration (included by default)
     #[cfg(feature = "mcp")]
     #[command(after_long_help = "\
 Starts an MCP (Model Context Protocol) server on stdio for AI agent integration.
 
-TOOLS PROVIDED:
-  list_adrs     List all ADRs with optional status/tag filters
-  get_adr       Get full content of an ADR by number
-  search_adrs   Search ADRs for matching text
+TOOLS PROVIDED (15):
+  Read-only:
+    list_adrs, get_adr, search_adrs, get_repository_info, get_related_adrs,
+    validate_adr, get_adr_sections, compare_adrs, suggest_tags
+  Write:
+    create_adr, update_status, update_content, update_tags, link_adrs,
+    bulk_update_status
 
 USAGE WITH CLAUDE:
   Add to your Claude Desktop config (claude_desktop_config.json):


### PR DESCRIPTION
Implements the high-priority documentation findings from the audit (H5–H8).

## Changes

- **`book/src/commands/init.md` (#223)** — documented that `adrs init` is idempotent (rewrites config, preserves ADRs) instead of falsely claiming it errors on re-init.
- **`book/src/commands/new.md` (#224)** — the "Multiple Links" example used `--link` twice, but `--link` is `Option<String>` so the second silently overwrote the first. Replaced with a single `--link` plus a follow-up `adrs link`, using the correct `SOURCE LINK TARGET [REVERSE_LINK]` argument order (verified against `adrs link --help`).
- **`crates/adrs/src/main.rs` (#225)** — the `mcp` subcommand help said "requires --features mcp" (MCP is default since 0.6.1) and listed only 3 tools; now says "included by default" and lists all 15 (grouped read-only/write).
- **`book/src/mcp.md` (#226)** — `compare_adrs` parameters corrected from `adr1`/`adr2` to the actual `source`/`target`.

## Verification

- `cargo fmt --all --check` clean
- `cargo run -p adrs -- mcp --help` renders the corrected help with all 15 tools
- `mdbook build` succeeds

## Note on CI

The `Clippy` check will fail until **#221** merges — this branch is based on `main`, which still has the clippy 1.96 lint regression in `adrs-core` (the exact issue #221 fixes). It is unrelated to this diff; `cargo run` compiles cleanly here. Rebasing after #221 merges will clear it.

Closes #223
Closes #224
Closes #225
Closes #226