### PR TITLE
docs: fix library.md examples for repo.link() args and health checks API

### DIFF
--- a/book/src/library.md
+++ b/book/src/library.md
@@ -94,8 +94,8 @@ fn main() -> anyhow::Result<()> {
     
     repo.link(
         3,                          // source
-        LinkKind::Amends,           // link type
         1,                          // target
+        LinkKind::Amends,           // link type
         LinkKind::AmendedBy,        // reverse link type
     )?;
     
@@ -232,24 +232,25 @@ None significant.
 ## Health Checks
 
 ```rust
-use adrs_core::{Repository, doctor_check};
+use adrs_core::{Repository, check_all};
+use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
     let repo = Repository::open(Path::new("."))?;
-    let report = doctor_check(&repo)?;
-    
-    for diagnostic in &report.diagnostics {
-        println!("[{:?}] {}: {}", 
-            diagnostic.severity,
-            diagnostic.check,
-            diagnostic.message
+    let report = check_all(&repo)?;
+
+    for issue in &report.issues {
+        println!("[{}] {}: {}",
+            issue.severity,
+            issue.rule_name,
+            issue.message
         );
     }
-    
+
     if report.has_errors() {
         std::process::exit(1);
     }
-    
+
     Ok(())
 }
 ```


### PR DESCRIPTION
## Plan

Fix two broken examples in `book/src/library.md`:

### #227 -- `repo.link()` argument order

The "Linking ADRs" example passes a `LinkKind` where a `u32` target is expected.
The actual signature is `link(source: u32, target: u32, source_kind: LinkKind, target_kind: LinkKind)`.
Fix the call to pass the u32 args before the LinkKind args.

### #228 -- Health Checks uses deprecated `doctor_check`

The "Health Checks" example imports and calls `adrs_core::doctor_check`, which is
`#[deprecated(since = "0.6.0", note = "Use lint module instead")]`.
Replace with the current `adrs_core::check_all` / `lint::LintReport` API.

## Verification

- `mdbook build` from `book/` passes
- Examples cross-checked against the real API in `crates/adrs-core/src/repository.rs`
  and `crates/adrs-core/src/lint.rs`

Closes #227, closes #228.