### PR TITLE
ci: run CI on all PRs so required checks always report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "book/**"
-      - "**.md"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "book/**"
-      - "**.md"
+# Note: no paths-ignore. CI runs on every PR so the required status checks
+# (Format, Clippy, Test) always report -- a paths-filtered workflow leaves
+# required checks "expected" forever and blocks docs-only PRs from merging.
+# See issue #243.
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Part of #243 (required status checks on `main`).

## Why

Enabling required status checks (`Format`, `Clippy`, `Test`) interacts badly with the workflow's `paths-ignore` (`docs/**`, `book/**`, `**.md`): for a docs-only PR, CI never runs, so the required checks stay in an "expected" state forever and the PR can never merge. We saw this shape already — the earlier docs PRs only ran the `plan` job.

## Change

Remove `paths-ignore` from the CI workflow so `Format`/`Clippy`/`Test` run on every PR and always report. Docs-only PRs now also run the Rust checks (fast, and they pass), which is the cost of having reliable required checks.

Branch protection (the required-checks settings themselves) is applied separately via the GitHub API as the second half of #243.

## Verification

- `ci.yml` parses as valid YAML.