### PR TITLE
chore: complete crate metadata (docs, homepage, keywords, categories)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/adrs"
-homepage = "https://github.com/joshrotenberg/adrs"
-documentation = "https://github.com/joshrotenberg/adrs"
+homepage = "https://joshrotenberg.com/adrs/"
 
 [workspace.dependencies]
 # Core

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io Version](https://img.shields.io/crates/v/adrs)](https://crates.io/crates/adrs)
 [![crates.io](https://img.shields.io/crates/d/adrs.svg)](https://crates.io/crates/adrs)
+[![docs.rs](https://img.shields.io/docsrs/adrs-core)](https://docs.rs/adrs-core)
 [![CI](https://github.com/joshrotenberg/adrs/workflows/CI/badge.svg)](https://github.com/joshrotenberg/adrs/actions?query=workflow%3ACI)
 [![dependency status](https://deps.rs/repo/github/joshrotenberg/adrs/status.svg)](https://deps.rs/repo/github/joshrotenberg/adrs)
 

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -6,6 +6,11 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/adrs-core"
+readme = "../../README.md"
+keywords = ["adr", "architecture", "decision-records", "madr", "library"]
+categories = ["development-tools"]
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -6,7 +6,11 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://joshrotenberg.com/adrs/"
 readme = "../../README.md"
+keywords = ["adr", "architecture", "decision-records", "madr", "cli"]
+categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]
 name = "adrs"


### PR DESCRIPTION
## Problem

The workspace `[workspace.package]` defined `documentation` and `homepage`, but **neither crate opted into inheriting them** (no `documentation.workspace = true` etc.), so on crates.io both crates showed `documentation: None`, `homepage: None`, `keywords: []`, `categories: []`. The `documentation` value was also just the GitHub repo, not real docs.

## Changes (metadata only)

- **`documentation`** — set per-crate: `adrs` → the book (`https://joshrotenberg.com/adrs/`), `adrs-core` → `https://docs.rs/adrs-core`.
- **`homepage`** — changed from the repo to the book and actually inherited by both crates (`homepage.workspace = true`).
- **`keywords` / `categories`** — added to both crates (categories verified against the crates.io API: `command-line-utilities`, `development-tools`).
- **`adrs-core`** — added `readme = "../../README.md"` so the library has a rendered crates.io page.
- **README** — added a `docs.rs` badge alongside the existing crates.io/CI/deps badges.

No version fields touched (release-plz owns those).

## Verification

- `cargo check --all-features` clean.
- Category slugs confirmed valid via the crates.io API.
- Keyword rules checked by hand (≤5 per crate, lowercase, ≤20 chars). `cargo publish --dry-run` is blocked by policy in this environment, so the next release's publish step is the final gate.

## Deferred: MSRV

`rust-version` was intentionally left out. It's dependency-driven — `tower-mcp@0.9.1` requires **rustc 1.90** (the let-chains in `adrs-core` only need 1.88) — and it'll drift as deps bump, so it deserves its own PR with a verified value and an MSRV CI job to prevent silent drift.