### PR TITLE
feat: polish adrs-core for external library use

### DIFF
--- a/crates/adrs-core/examples/create_and_list.rs
+++ b/crates/adrs-core/examples/create_and_list.rs
@@ -1,0 +1,22 @@
+//! Create an ADR repository, add a decision, and list all records.
+//!
+//! Run with: `cargo run -p adrs-core --example create_and_list`
+
+use adrs_core::Repository;
+
+fn main() -> adrs_core::Result<()> {
+    // Use a throwaway directory so the example is self-contained.
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let repo = Repository::init(tmp.path(), None, false)?;
+
+    // `init` seeds ADR 0001 ("Record architecture decisions").
+    let (adr, path) = repo.new_adr("Use PostgreSQL for persistence")?;
+    println!("Created ADR {:04} at {}", adr.number, path.display());
+
+    println!("\nAll ADRs:");
+    for adr in repo.list()? {
+        println!("  {:04}  {}  [{}]", adr.number, adr.title, adr.status);
+    }
+
+    Ok(())
+}

--- a/crates/adrs-core/examples/export_json.rs
+++ b/crates/adrs-core/examples/export_json.rs
@@ -1,0 +1,20 @@
+//! Export a repository to the JSON-ADR format.
+//!
+//! JSON-ADR is a machine-readable representation of a decision log -- handy for
+//! feeding ADRs to other tools or to AI agents that reason over them.
+//!
+//! Run with: `cargo run -p adrs-core --example export_json`
+
+use adrs_core::{Repository, export_repository};
+
+fn main() -> adrs_core::Result<()> {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let repo = Repository::init(tmp.path(), None, false)?;
+    repo.new_adr("Use gRPC for service-to-service calls")?;
+
+    let export = export_repository(&repo)?;
+    let json = serde_json::to_string_pretty(&export).expect("serialize JSON-ADR");
+    println!("{json}");
+
+    Ok(())
+}

--- a/crates/adrs-core/examples/link_adrs.rs
+++ b/crates/adrs-core/examples/link_adrs.rs
@@ -1,0 +1,31 @@
+//! Create two ADRs and connect them with a typed, bidirectional link.
+//!
+//! Run with: `cargo run -p adrs-core --example link_adrs`
+
+use adrs_core::{LinkKind, Repository};
+
+fn main() -> adrs_core::Result<()> {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let repo = Repository::init(tmp.path(), None, false)?;
+
+    let (amending, _) = repo.new_adr("Adopt event sourcing")?;
+    let (amended, _) = repo.new_adr("Use a single relational database")?;
+
+    // `amending` amends `amended`. The reverse ("Amended by") link is written
+    // to the target automatically.
+    repo.link(
+        amending.number,
+        amended.number,
+        LinkKind::Amends,
+        LinkKind::AmendedBy,
+    )?;
+
+    for adr in repo.list()? {
+        println!("{:04}  {}", adr.number, adr.title);
+        for link in &adr.links {
+            println!("    {:?} -> {:04}", link.kind, link.target);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/adrs-core/examples/lint_repository.rs
+++ b/crates/adrs-core/examples/lint_repository.rs
@@ -1,0 +1,30 @@
+//! Run health checks over a repository and report any issues.
+//!
+//! `check_all` combines per-ADR linting with repository-wide checks (broken
+//! links, duplicate numbers, numbering gaps, ...).
+//!
+//! Run with: `cargo run -p adrs-core --example lint_repository`
+
+use adrs_core::{Repository, check_all};
+
+fn main() -> adrs_core::Result<()> {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let repo = Repository::init(tmp.path(), None, false)?;
+    repo.new_adr("Use gRPC for service-to-service calls")?;
+
+    // `check_all` returns a report; a healthy repository yields an empty list.
+    let report = check_all(&repo)?;
+    if report.issues.is_empty() {
+        println!("No issues found.");
+    } else {
+        println!("Found {} issue(s):", report.issues.len());
+        for issue in &report.issues {
+            println!(
+                "  [{:?}] {}: {}",
+                issue.severity, issue.rule_name, issue.message
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/adrs-core/src/error.rs
+++ b/crates/adrs-core/src/error.rs
@@ -22,7 +22,12 @@ pub enum Error {
 
     /// Multiple ADRs matched a query.
     #[error("Multiple ADRs match '{query}': {matches:?}")]
-    AmbiguousAdr { query: String, matches: Vec<String> },
+    AmbiguousAdr {
+        /// The query string that matched more than one ADR.
+        query: String,
+        /// Human-readable identifiers of the ADRs that matched.
+        matches: Vec<String>,
+    },
 
     /// Invalid ADR number.
     #[error("Invalid ADR number: {0}")]
@@ -30,11 +35,21 @@ pub enum Error {
 
     /// Invalid ADR format (parsing failed).
     #[error("Invalid ADR format in {path}: {reason}")]
-    InvalidFormat { path: PathBuf, reason: String },
+    InvalidFormat {
+        /// Path to the ADR file that failed to parse.
+        path: PathBuf,
+        /// Why parsing failed.
+        reason: String,
+    },
 
     /// Missing required field in ADR.
     #[error("Missing required field '{field}' in {path}")]
-    MissingField { path: PathBuf, field: String },
+    MissingField {
+        /// Path to the ADR file missing the field.
+        path: PathBuf,
+        /// Name of the required field that was missing.
+        field: String,
+    },
 
     /// Invalid status value.
     #[error("Invalid status: {0}")]

--- a/crates/adrs-core/src/export.rs
+++ b/crates/adrs-core/src/export.rs
@@ -331,9 +331,23 @@ pub struct ImportResult {
 /// This function scans a directory for markdown files that look like ADRs
 /// (files matching `NNNN-*.md` pattern) and parses them. Unlike `export_repository`,
 /// this does not require an initialized adrs repository.
+///
+/// Files that look like ADRs but fail to parse are skipped. Use
+/// [`export_directory_with_warnings`] if you need to surface those parse
+/// failures to the caller rather than silently dropping them.
 pub fn export_directory(dir: &Path) -> Result<JsonAdrBulkExport> {
+    export_directory_with_warnings(dir).map(|(export, _warnings)| export)
+}
+
+/// Like [`export_directory`], but also returns a human-readable warning for
+/// every file that looked like an ADR but failed to parse.
+///
+/// This is the library-friendly variant: it never writes to stderr, leaving the
+/// caller in control of how (or whether) to surface skipped files.
+pub fn export_directory_with_warnings(dir: &Path) -> Result<(JsonAdrBulkExport, Vec<String>)> {
     let parser = Parser::new();
     let mut adrs = Vec::new();
+    let mut warnings = Vec::new();
 
     // Scan for markdown files
     if dir.is_dir() {
@@ -357,16 +371,18 @@ pub fn export_directory(dir: &Path) -> Result<JsonAdrBulkExport> {
             let path = entry.path();
             match parser.parse_file(&path) {
                 Ok(adr) => adrs.push(JsonAdr::from(&adr)),
-                Err(e) => {
-                    // Log warning but continue with other files
-                    eprintln!("Warning: Failed to parse {}: {}", path.display(), e);
-                }
+                // Collect the warning instead of printing; the caller decides
+                // whether and how to surface skipped files.
+                Err(e) => warnings.push(format!("Failed to parse {}: {}", path.display(), e)),
             }
         }
     }
 
     let adr_dir = dir.display().to_string();
-    Ok(JsonAdrBulkExport::new(adrs).with_repository(None, adr_dir))
+    Ok((
+        JsonAdrBulkExport::new(adrs).with_repository(None, adr_dir),
+        warnings,
+    ))
 }
 
 /// Convert a JsonAdr back to an Adr for rendering.

--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -1,18 +1,51 @@
 //! # adrs-core
 //!
-//! Core library for managing Architecture Decision Records (ADRs).
+//! The engine behind the [`adrs`] command-line tool: a standalone library for
+//! creating, reading, linking, validating, and exporting Architecture Decision
+//! Records (ADRs).
 //!
-//! This library provides the foundational types and operations for working with ADRs,
-//! including parsing, creating, linking, and querying decision records.
+//! Depend on `adrs-core` directly when you want to manage ADRs from your own
+//! program -- a build tool, an editor integration, or an AI agent -- instead of
+//! shelling out to the CLI. The CLI is a thin layer over this crate, so anything
+//! `adrs` does is available here as a normal Rust API.
+//!
+//! [`adrs`]: https://crates.io/crates/adrs
+//!
+//! ## Key types
+//!
+//! - [`Repository`] -- the main entry point. Open or initialize a directory of
+//!   ADRs, then [`list`](Repository::list), [`new_adr`](Repository::new_adr),
+//!   [`link`](Repository::link), [`supersede`](Repository::supersede), and
+//!   [`set_status`](Repository::set_status).
+//! - [`Adr`] -- a single decision record: number, title, [`AdrStatus`], body
+//!   sections, [`AdrLink`]s, tags, and MADR metadata (deciders, consulted,
+//!   informed).
+//! - [`AdrStatus`] and [`LinkKind`] -- typed status values and link
+//!   relationships (e.g. `Supersedes` / `SupersededBy`).
+//! - [`Config`] and [`discover`] -- repository configuration and upward
+//!   directory discovery (find the ADR directory from a nested path).
+//! - [`Parser`] -- parse an ADR from markdown, in either legacy (adr-tools) or
+//!   YAML-frontmatter form.
+//! - The [`export`] module -- convert ADRs to and from the **JSON-ADR**
+//!   interchange format, handy for feeding a decision log to other tools or to
+//!   an AI agent that reasons over it.
+//! - The [`lint`] module -- repository health checks via [`check_all`]:
+//!   broken links, duplicate numbers, numbering gaps, and missing fields.
+//! - [`Error`] and [`Result`] -- the library's error type, built on `thiserror`.
 //!
 //! ## Modes
 //!
-//! The library supports two modes:
+//! ADRs can be stored in two on-disk formats:
 //!
-//! - **Compatible mode** (default): Writes markdown-only format compatible with adr-tools,
-//!   but can read both legacy and next-gen formats.
-//! - **Next-gen mode**: Uses YAML frontmatter for structured metadata, enabling richer
-//!   features like typed links and better validation.
+//! - **Compatible mode** (default): markdown-only, interoperable with
+//!   [adr-tools]. Reads both legacy and next-gen files; writes legacy.
+//! - **Next-gen mode**: YAML frontmatter for structured metadata, enabling
+//!   richer features like typed links, tags, and stronger validation.
+//!
+//! The mode is chosen at [`Repository::init`] time (the `ng` argument) or via
+//! [`Config`], and the parser transparently reads either format.
+//!
+//! [adr-tools]: https://github.com/npryce/adr-tools
 //!
 //! ## Quick start
 //!
@@ -35,8 +68,18 @@
 //! # }
 //! ```
 //!
-//! See the [`examples`](https://github.com/joshrotenberg/adrs/tree/main/crates/adrs-core/examples)
-//! directory for more, including linking ADRs, exporting to JSON-ADR, and linting.
+//! ## Exporting to JSON-ADR
+//!
+//! [`export_repository`] converts an open [`Repository`] to the JSON-ADR format.
+//! For a plain directory that isn't an initialized adrs repository, use
+//! [`export_directory`] (or [`export_directory_with_warnings`] to also receive a
+//! message for every file that failed to parse, rather than skipping silently).
+//!
+//! ## More examples
+//!
+//! The [`examples`](https://github.com/joshrotenberg/adrs/tree/main/crates/adrs-core/examples)
+//! directory has runnable programs: `create_and_list`, `link_adrs`,
+//! `export_json`, and `lint_repository`.
 
 mod config;
 pub mod doctor;

--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -13,6 +13,30 @@
 //!   but can read both legacy and next-gen formats.
 //! - **Next-gen mode**: Uses YAML frontmatter for structured metadata, enabling richer
 //!   features like typed links and better validation.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use adrs_core::Repository;
+//!
+//! # fn main() -> adrs_core::Result<()> {
+//! # let tmp = tempfile::tempdir().unwrap();
+//! // Initialize a repository (compatible mode).
+//! let repo = Repository::init(tmp.path(), None, false)?;
+//!
+//! // Create a decision record.
+//! let (adr, _path) = repo.new_adr("Use PostgreSQL for persistence")?;
+//! assert_eq!(adr.title, "Use PostgreSQL for persistence");
+//!
+//! // List all ADRs (`init` seeds the first one).
+//! let all = repo.list()?;
+//! assert!(all.len() >= 2);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! See the [`examples`](https://github.com/joshrotenberg/adrs/tree/main/crates/adrs-core/examples)
+//! directory for more, including linking ADRs, exporting to JSON-ADR, and linting.
 
 mod config;
 pub mod doctor;
@@ -29,7 +53,7 @@ pub use error::{Error, Result};
 pub use export::{
     ConsideredOption, ImportOptions, ImportResult, JSON_ADR_SCHEMA, JSON_ADR_VERSION, JsonAdr,
     JsonAdrBulkExport, JsonAdrLink, JsonAdrSingle, RepositoryInfo, ToolInfo, export_adr,
-    export_directory, export_repository, import_to_directory,
+    export_directory, export_directory_with_warnings, export_repository, import_to_directory,
 };
 pub use lint::{Issue, IssueSeverity, LintReport, check_all, check_repository, lint_adr, lint_all};
 pub use parse::Parser;


### PR DESCRIPTION
Makes `adrs-core` comfortable to depend on directly — prompted by an external user building an agentic framework on top of ADRs who'd integrate the library rather than shell out to the CLI.

## Changes

1. **Fix a stderr leak (library correctness).** `export_directory` called `eprintln!` on unparseable files — a library shouldn't write to the host's stderr. It now delegates to a new `export_directory_with_warnings(dir) -> Result<(JsonAdrBulkExport, Vec<String>)>` that returns the warnings, leaving the caller in control. `export_directory` keeps its signature (non-breaking) and simply drops the warnings. Mirrors the existing `list` / `list_with_errors` convention.
2. **Docs.** Documented the previously-undocumented `Error` struct-variant fields (`AmbiguousAdr`, `InvalidFormat`, `MissingField`), clearing the `missing_docs` gaps.
3. **Crate-level example.** Added a tested usage doctest to `lib.rs` (renders at the top of docs.rs).
4. **`examples/`.** `create_and_list`, `link_adrs`, `export_json` (JSON-ADR is the natural integration point for tools/agents), and `lint_repository`. All compile under `--all-targets` and run.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings` clean
- `cargo test --doc -p adrs-core` — new doctest passes
- All four examples run (`cargo run -p adrs-core --example <name>`)
- Full suite green

## Deferred

The deprecated `doctor` module (since 0.6.0) is still `pub`. Removing it is a clean-library win but a breaking change — better bundled into 0.8 with the MSRV work.