### PR TITLE
chore: release v0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.7.4" }
+adrs-core = { path = "crates/adrs-core", version = "0.7.5" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.5] - 2026-06-08
+
+### Bug Fixes
+
+- MADR bare template no longer emits unparseable null YAML
+
+### Documentation
+
+- Expand adrs-core crate-level documentation
+
+### Features
+
+- Polish adrs-core for external library use
+
+### Miscellaneous
+
+- Complete crate metadata (docs, homepage, keywords, categories)
+- Declare per-crate MSRV with a CI guard
+
+
 ## [0.7.4] - 2026-06-06
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.5] - 2026-06-08
+
+### Features
+
+- Add --template flag to adrs new for custom template files (closes #122)
+
+### Miscellaneous
+
+- Complete crate metadata (docs, homepage, keywords, categories)
+- Declare per-crate MSRV with a CI guard
+
+
 ## [0.7.4] - 2026-06-06
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.7.4 -> 0.7.5 (✓ API compatible changes)
* `adrs`: 0.7.4 -> 0.7.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.7.5] - 2026-06-08

### Bug Fixes

- MADR bare template no longer emits unparseable null YAML

### Documentation

- Expand adrs-core crate-level documentation

### Features

- Polish adrs-core for external library use

### Miscellaneous

- Complete crate metadata (docs, homepage, keywords, categories)
- Declare per-crate MSRV with a CI guard
</blockquote>

## `adrs`

<blockquote>

## [0.7.5] - 2026-06-08

### Features

- Add --template flag to adrs new for custom template files (closes #122)

### Miscellaneous

- Complete crate metadata (docs, homepage, keywords, categories)
- Declare per-crate MSRV with a CI guard
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).