### PR TITLE
fix: MADR bare template emits unparseable null YAML

### DIFF
--- a/crates/adrs-core/src/template.rs
+++ b/crates/adrs-core/src/template.rs
@@ -537,13 +537,15 @@ number: {{ number }}
 title: {{ title }}
 status: {{ status | lower }}
 date: {{ date }}
-decision-makers:
-consulted:
-informed:
-{% if tags %}tags:
+{% if decision_makers %}decision-makers:
+{% for dm in decision_makers %}  - {{ dm }}
+{% endfor %}{% endif %}{% if consulted %}consulted:
+{% for c in consulted %}  - {{ c }}
+{% endfor %}{% endif %}{% if informed %}informed:
+{% for i in informed %}  - {{ i }}
+{% endfor %}{% endif %}{% if tags %}tags:
 {% for tag in tags %}  - {{ tag }}
-{% endfor %}{% else %}tags:
-{% endif %}---
+{% endfor %}{% endif %}---
 
 # {{ title }}
 
@@ -740,6 +742,40 @@ mod tests {
         assert!(output.contains("## Status"));
         assert!(output.contains("Accepted"));
         assert!(!output.starts_with("---")); // No frontmatter in compatible mode
+    }
+
+    #[test]
+    fn test_madr_bare_roundtrips_when_empty() {
+        // Regression for #264: the bare MADR template emitted null-valued
+        // metadata keys that the parser rejected, silently dropping the ADR.
+        let template = Template::builtin_with_variant(TemplateFormat::Madr, TemplateVariant::Bare);
+        let adr = Adr::new(2, "Bare MADR decision");
+        let config = Config::default();
+        let output = template.render(&adr, &config, &no_link_titles()).unwrap();
+
+        // Empty metadata keys are omitted entirely, not emitted as null.
+        assert!(!output.contains("decision-makers:"));
+
+        // And the rendered file parses back cleanly.
+        let parsed = crate::Parser::new().parse(&output).unwrap();
+        assert_eq!(parsed.title, "Bare MADR decision");
+        assert!(parsed.decision_makers.is_empty());
+        assert!(parsed.tags.is_empty());
+    }
+
+    #[test]
+    fn test_madr_bare_renders_decision_makers() {
+        // The old bare template ignored decision-makers entirely; confirm they
+        // now render and round-trip (relevant to MCP create_adr with MADR).
+        let template = Template::builtin_with_variant(TemplateFormat::Madr, TemplateVariant::Bare);
+        let mut adr = Adr::new(2, "With deciders");
+        adr.decision_makers = vec!["alice".to_string(), "bob".to_string()];
+        let config = Config::default();
+        let output = template.render(&adr, &config, &no_link_titles()).unwrap();
+
+        assert!(output.contains("decision-makers:"));
+        let parsed = crate::Parser::new().parse(&output).unwrap();
+        assert_eq!(parsed.decision_makers, vec!["alice", "bob"]);
     }
 
     #[test]
@@ -1183,12 +1219,13 @@ mod tests {
         let config = Config::default();
         let output = template.render(&adr, &config, &no_link_titles()).unwrap();
 
-        // MADR bare has frontmatter with empty fields (matches official adr-template-bare.md)
+        // MADR bare has frontmatter; empty metadata keys are omitted rather
+        // than emitted as null YAML (which the parser rejects -- see #264).
         assert!(output.starts_with("---"));
         assert!(output.contains("status:"));
-        assert!(output.contains("decision-makers:"));
-        assert!(output.contains("consulted:"));
-        assert!(output.contains("informed:"));
+        assert!(!output.contains("decision-makers:"));
+        assert!(!output.contains("consulted:"));
+        assert!(!output.contains("informed:"));
         assert!(output.contains("# MADR Bare"));
         // Should have ALL sections (empty)
         assert!(output.contains("## Decision Drivers"));

--- a/crates/adrs-core/src/types.rs
+++ b/crates/adrs-core/src/types.rs
@@ -361,9 +361,12 @@ mod string_or_vec {
             Vec(Vec<String>),
         }
 
-        match StringOrVec::deserialize(deserializer)? {
-            StringOrVec::String(s) => Ok(vec![s]),
-            StringOrVec::Vec(v) => Ok(v),
+        // Accept a missing/null value (a `field:` line with nothing after it)
+        // as an empty list, in addition to a bare string or a YAML sequence.
+        match Option::<StringOrVec>::deserialize(deserializer)? {
+            None => Ok(Vec::new()),
+            Some(StringOrVec::String(s)) => Ok(vec![s]),
+            Some(StringOrVec::Vec(v)) => Ok(v),
         }
     }
 }
@@ -886,6 +889,27 @@ number: 1
 title: Test
 date: 2024-09-15
 status: accepted
+"#;
+        let adr: Adr = serde_yaml::from_str(yaml).unwrap();
+        assert!(adr.decision_makers.is_empty());
+        assert!(adr.consulted.is_empty());
+        assert!(adr.informed.is_empty());
+        assert!(adr.tags.is_empty());
+    }
+
+    #[test]
+    fn test_string_or_vec_fields_null_value() {
+        // The MADR bare template historically emitted `field:` with no value
+        // (YAML null). Those must deserialize to empty lists, not error (#264).
+        let yaml = r#"
+number: 1
+title: Test
+date: 2024-09-15
+status: accepted
+decision-makers:
+consulted:
+informed:
+tags:
 "#;
         let adr: Adr = serde_yaml::from_str(yaml).unwrap();
         assert!(adr.decision_makers.is_empty());


### PR DESCRIPTION
## Problem

Creating an ADR with the MADR `bare` variant produced frontmatter with null-valued metadata keys:

```yaml
decision-makers:
consulted:
informed:
tags:
```

The `StringOrVec` deserializer (from #216) rejected null, so the file failed its own round-trip: `adrs list` silently dropped it and `adrs doctor` reported `YAML error: data did not match any variant of untagged enum StringOrVec`.

## Fix

- **Template** — align the bare MADR frontmatter with the full MADR template's conditional form. Empty metadata keys are omitted entirely; `decision-makers`/`consulted`/`informed` now render when provided (the bare template previously *ignored* them, which also silently affected MCP `create_adr` with `variant=bare`).
- **Parser** — make `StringOrVec` tolerate a null value (treat as empty list), so any existing/external file with this shape round-trips too.

## Tests

- `test_string_or_vec_fields_null_value` — null fields deserialize to empty vecs
- `test_madr_bare_roundtrips_when_empty` — bare MADR renders + parses back clean
- `test_madr_bare_renders_decision_makers` — bare MADR now renders passed deciders
- Updated the stale `test_madr_bare_template` assertion

Verified end-to-end: a bare MADR ADR now appears in `adrs list` with clean frontmatter. Full suite + clippy green.

Closes #264