### PR TITLE
chore: declare per-crate MSRV with a CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,26 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --all-targets --all-features
+
+  # Verify each crate still builds on its declared rust-version (MSRV), so a
+  # newer-toolchain feature can't silently raise it. Keep these versions in sync
+  # with the `rust-version` field in each crate's Cargo.toml.
+  msrv:
+    name: MSRV (${{ matrix.crate }} @ ${{ matrix.rust }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - crate: adrs-core
+            rust: "1.88"
+          - crate: adrs
+            rust: "1.90"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Check ${{ matrix.crate }} on ${{ matrix.rust }}
+        run: cargo check -p ${{ matrix.crate }} --all-features --locked

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -4,6 +4,8 @@ description = "Core library for managing Architecture Decision Records"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+# Library MSRV: edition 2024 (1.85) + let-chains (1.88). Verified in CI.
+rust-version = "1.88"
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/crates/adrs/Cargo.toml
+++ b/crates/adrs/Cargo.toml
@@ -4,6 +4,9 @@ description = "Command line tool for managing Architecture Decision Records"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+# CLI MSRV: higher than the library because tower-mcp (default `mcp` feature)
+# requires rustc 1.90. Verified in CI.
+rust-version = "1.90"
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Follows up the metadata work (#261), which deferred `rust-version` because it's dependency-driven and needs a guard.

## What

Per-crate MSRV, verified by building on the pinned toolchains:

| Crate | rust-version | Why |
|-------|-------------|-----|
| `adrs-core` | **1.88** | edition 2024 (1.85) + let-chains (1.88). Kept low so library consumers (e.g. embedding `adrs-core` without the CLI) aren't forced higher than necessary. |
| `adrs` | **1.90** | `tower-mcp` 0.9 (the default `mcp` feature) requires rustc 1.90. |

## Guard against drift

Added an `msrv` CI job (matrix over crate/version) that runs `cargo check -p <crate> --all-features --locked` on each declared toolchain. If a future change or a dependency MSRV bump raises the real floor, the matrix goes red instead of the field silently lying. The versions are duplicated in the workflow with a sync comment.

## Verification

- `cargo +1.88 check -p adrs-core --all-features --locked` ✅
- `cargo +1.90 check -p adrs --all-features --locked` ✅
- `ci.yml` parses as valid YAML