### PR TITLE
ci: bump GitHub Actions off Node 20 (checkout, docker, pages-deploy, release-plz)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,7 +17,7 @@ jobs:
     name: Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -21,7 +21,7 @@ jobs:
           toolchain: stable
       - run: (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
       - run: cd book && mdbook build
-      - uses: JamesIves/github-pages-deploy-action@4.1.7
+      - uses: JamesIves/github-pages-deploy-action@v4.8.0
         if: github.event_name == 'release'
         with:
           branch: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write # To push a branch
       pull-requests: write # To create a PR from that branch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -30,7 +30,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -67,7 +67,7 @@ jobs:
           - crate: adrs
             rust: "1.90"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,11 +26,11 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -48,7 +48,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
         env:
           # Use COMMITTER_TOKEN (PAT) so tag pushes trigger the Release workflow
           # GITHUB_TOKEN actions don't trigger other workflows (security feature)


### PR DESCRIPTION
GitHub is removing Node 20 action support on 2026-09-16. This bumps all hand-maintained workflows' actions to current Node-24 majors (and fixes one relocation), based on the dependency audit.

## Changes
- **`actions/checkout`** v4 → v5 (ci, audit, book, docker, release-plz)
- **`docker.yml`**: `setup-buildx-action` v3→v4, `login-action` v3→v4, `metadata-action` v5→v6, `build-push-action` v6→v7 (all were Node 20)
- **`book.yml`**: `JamesIves/github-pages-deploy-action` `4.1.7` → `v4.8.0` (4.1.7 was **Node 12**, removed by GitHub back in 2023)
- **`release-plz.yml`**: `MarcoIeni/release-plz-action` → relocated `release-plz/action@v0.5`

All action versions verified against each repo's latest release; all five workflows pass YAML validation.

## Out of scope
`release.yml` is **cargo-dist-generated** and still uses Node-20 artifact actions — handled separately by upgrading cargo-dist (filed as its own issue/PR), since hand-edits there get regenerated away.

Other actions checked and fine: `Swatinem/rust-cache@v2` (Node 24), `dtolnay/rust-toolchain` (composite), `rustsec/audit-check@v2` (no v3 exists).