### PR TITLE
chore(deps): pulldown-cmark 0.13 + remove dead pulldown-cmark-to-cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,8 +40,7 @@ dependencies = [
  "mdbook-lint-rulesets",
  "minijinja",
  "proptest",
- "pulldown-cmark 0.12.2",
- "pulldown-cmark-to-cmark",
+ "pulldown-cmark 0.13.4",
  "regex",
  "serde",
  "serde_json",
@@ -1580,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1602,15 +1601,6 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pulldown-cmark-to-cmark"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b27c0d365d60ff3e085007911d73419e5664de48155d558ebfa84d117a5109"
-dependencies = [
- "pulldown-cmark 0.12.2",
-]
 
 [[package]]
 name = "quick-error"
@@ -2410,9 +2400,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d2680ddb4e9e26260e5c37ed7ba5eb93030a9fc57428c004b0b15904c89b4b"
+checksum = "497c31b3fe4747f7223020932006b1aa8f077e5dfb3642b2dae2d1001ed06a3c"
 dependencies = [
  "async-trait",
  "axum",
@@ -2437,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "tower-mcp-types"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f104da876114dc20c32cd82b3dabeaead05e449d02fb0945e5177fb96639ea"
+checksum = "c0d0e783ebb50f9449cc26b1ac5f82318efa042d474662304e9d45c95b8960e9"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ serde_yaml = "0.9"
 toml = "0.8"
 
 # Markdown
-pulldown-cmark = "0.12"
-pulldown-cmark-to-cmark = "17"
+pulldown-cmark = "0.13"
 
 # Templates
 minijinja = { version = "2", features = ["loader"] }

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -21,7 +21,6 @@ serde_json = "1"
 serde_yaml.workspace = true
 toml.workspace = true
 pulldown-cmark.workspace = true
-pulldown-cmark-to-cmark.workspace = true
 minijinja.workspace = true
 walkdir.workspace = true
 time.workspace = true


### PR DESCRIPTION
From the dependency audit.

- **Remove `pulldown-cmark-to-cmark`** (was `"17"`) — declared in `Cargo.toml` and `crates/adrs-core/Cargo.toml` but with **zero usages** in any `.rs` file (dead since the v2 rewrite). Confirmed gone from the dep tree.
- **Bump `pulldown-cmark` 0.12 → 0.13** — compiles cleanly; no `Tag`/`TagEnd`/`Event` API changes needed for `parse.rs`.

`cargo clippy --all-targets --all-features -D warnings` and `cargo test --all-features` green.

Closes #269