### PR TITLE
chore(deps): bump mdbook-lint 0.14.3 -> 0.14.4 (closes #273)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6b8640488ad03e21ec1f5bb9f25dc5781eab5b985dbcd0f83ba8d3ead00017"
+checksum = "6010706660419253f53f2f17b3e44da380147cd547be89cc1bd04ee7813cb599"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1230,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87d6caf57dfde20440d4bd97abec181efda276083ec8e50e35e62a7672f83f4"
+checksum = "df5a8e0fa15b8ce5b4fed691592d2e93372cdcd4e342cd18950ae44d82528010"
 dependencies = [
  "anyhow",
  "comrak",

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -28,8 +28,8 @@ fuzzy-matcher.workspace = true
 regex.workspace = true
 
 # Linting (mdbook-lint integration)
-mdbook-lint-core = "0.14.3"
-mdbook-lint-rulesets = { version = "0.14.3", default-features = false, features = ["adr"] }
+mdbook-lint-core = "0.14.4"
+mdbook-lint-rulesets = { version = "0.14.4", default-features = false, features = ["adr"] }
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
## Summary

Bump `mdbook-lint-core` and `mdbook-lint-rulesets` from `0.14.3` to `0.14.4` in `crates/adrs-core/Cargo.toml`. Regenerate `Cargo.lock`.

This is a trivial patch bump. `0.14.4` still pins `comrak ^0.21` (syntect enabled), so this does **not** clear advisories #259 or #260 (bincode / yaml-rust) -- those remain in `audit.toml` pending an upstream comrak bump.

## Plan

1. Update `mdbook-lint-core` version to `0.14.4` in `crates/adrs-core/Cargo.toml`
2. Update `mdbook-lint-rulesets` version to `0.14.4` in `crates/adrs-core/Cargo.toml`
3. Run `cargo update` to regenerate `Cargo.lock`
4. Verify: `cargo build --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `cargo test --all-features`
5. Commit both `Cargo.toml` and `Cargo.lock`

## Constraints

- Do NOT claim this clears advisories #259 or #260
- Commit `Cargo.lock` alongside the `Cargo.toml` change

Closes #273.