### PR TITLE
feat: add --template flag to adrs new for custom template files (closes #122)

### DIFF
--- a/book/src/commands/new.md
+++ b/book/src/commands/new.md
@@ -20,6 +20,7 @@ adrs new [OPTIONS] <TITLE>
 |--------|-------------|
 | `-f, --format <FORMAT>` | Template format: `nygard` or `madr` (default: `nygard`) |
 | `-v, --variant <VARIANT>` | Template variant: `full`, `minimal`, or `bare` (default: `full`) |
+| `--template <PATH>` | Path to a custom template file (overrides `--format`/`--variant` and config) |
 | `--status <STATUS>` | Initial status (default: `Proposed`) |
 | `-s, --supersedes <N>` | ADR number this supersedes |
 | `-l, --link <LINK>` | Link to another ADR |
@@ -60,6 +61,18 @@ adrs new --variant minimal "Use PostgreSQL for persistence"
 ```sh
 adrs new --status Accepted "Use PostgreSQL for persistence"
 ```
+
+### Custom Template File
+
+Use a custom template file for this ADR:
+
+```sh
+adrs new --template ./templates/security-adr.md "Security Design Decision"
+```
+
+The `--template` flag takes precedence over `--format`/`--variant` and the
+`[templates] custom` setting in `adrs.toml`. See
+[Templates](../templates.md) for the template variable reference.
 
 ### Superseding an ADR
 

--- a/book/src/templates.md
+++ b/book/src/templates.md
@@ -100,6 +100,25 @@ Chosen option: "", because ...
 
 Create custom templates using [Jinja2](https://jinja.palletsprojects.com/) syntax.
 
+### Specifying a Custom Template
+
+Custom templates can be set in two ways:
+
+1. **Per-invocation via CLI flag** -- highest precedence, overrides config and built-in formats:
+
+   ```sh
+   adrs new --template ./templates/security-adr.md "My Decision"
+   ```
+
+2. **Project-wide via `adrs.toml`** -- applied when no CLI `--format`/`--variant`/`--template` is given:
+
+   ```toml
+   [templates]
+   custom = "templates/my-template.md"
+   ```
+
+Precedence: `--template` CLI flag > `[templates] custom` in config > `--format`/`--variant`.
+
 ### Template Variables
 
 | Variable | Description | Example |

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -4,7 +4,7 @@ use adrs_core::{
     AdrStatus, Config, ConfigMode, LinkKind, Repository, Template, TemplateFormat, TemplateVariant,
 };
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[allow(clippy::too_many_arguments)]
 pub fn new(
@@ -15,6 +15,7 @@ pub fn new(
     link: Option<String>,
     format: Option<String>,
     variant: Option<String>,
+    template: Option<PathBuf>,
     status: Option<String>,
     tags: Option<Vec<String>>,
     no_edit: bool,
@@ -59,17 +60,25 @@ pub fn new(
         repo = repo.with_mode(ConfigMode::NextGen);
     }
 
-    // Load custom template from config if set (and no format/variant CLI override)
-    if format.is_none()
+    // Apply custom template: CLI --template > config custom > built-in format/variant
+    if let Some(ref cli_path) = template {
+        // CLI flag takes highest precedence
+        let tmpl = Template::from_file(cli_path).context(format!(
+            "Failed to load custom template from {}: check the path is correct",
+            cli_path.display()
+        ))?;
+        repo = repo.with_custom_template(tmpl);
+    } else if format.is_none()
         && variant.is_none()
         && let Some(ref custom_path) = config.templates.custom
     {
+        // Config custom path applies when no CLI format/variant override is given
         let full_path = root.join(custom_path);
-        let template = Template::from_file(&full_path).context(format!(
+        let tmpl = Template::from_file(&full_path).context(format!(
             "Failed to load custom template from config: {}",
             custom_path.display()
         ))?;
-        repo = repo.with_custom_template(template);
+        repo = repo.with_custom_template(tmpl);
     }
 
     let (mut adr, path) = if let Some(superseded) = supersedes {

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -114,6 +114,10 @@ LINK FORMAT:
         #[arg(short, long, value_name = "VARIANT")]
         variant: Option<String>,
 
+        /// Path to a custom template file (overrides --format/--variant and config)
+        #[arg(long, value_name = "PATH")]
+        template: Option<PathBuf>,
+
         /// Initial status [default: Proposed]
         #[arg(long, value_name = "STATUS")]
         status: Option<String>,
@@ -583,6 +587,7 @@ fn main() -> Result<()> {
             link,
             format,
             variant,
+            template,
             status,
             tags,
             no_edit,
@@ -596,6 +601,7 @@ fn main() -> Result<()> {
                 link,
                 format,
                 variant,
+                template,
                 status,
                 tags,
                 no_edit,

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1081,6 +1081,40 @@ fn test_new_no_edit_flag() {
 }
 
 // ============================================================================
+// Custom Template Flag Tests
+// ============================================================================
+
+#[test]
+fn test_new_template_flag_missing_file() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Passing a non-existent template file should fail with a clear error
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "new",
+            "--no-edit",
+            "--template",
+            "/nonexistent/path/template.md",
+            "Should fail",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("custom template")
+                .or(predicate::str::contains("/nonexistent/path/template.md")),
+        );
+
+    temp.close().unwrap();
+}
+
+// ============================================================================
 // MADR Format Tests
 // ============================================================================
 

--- a/crates/adrs/tests/scenarios.rs
+++ b/crates/adrs/tests/scenarios.rs
@@ -1391,3 +1391,138 @@ fn scenario_doctor_reports_invalid_frontmatter() {
 
     temp.close().unwrap();
 }
+
+// ============================================================================
+// Scenario: Custom Template via CLI --template Flag
+// ============================================================================
+
+/// User passes --template <path> to adrs new and the custom template is used.
+#[test]
+fn scenario_custom_template_from_cli_flag() {
+    let temp = TempDir::new().unwrap();
+
+    // Step 1: Initialize repository
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Step 2: Write a custom template file
+    let templates_dir = temp.child("templates");
+    templates_dir.create_dir_all().unwrap();
+    fs::write(
+        temp.path().join("templates/my-adr.md"),
+        "# CLI-CUSTOM: {{ number }}. {{ title }}
+
+Provided via --template flag.
+",
+    )
+    .unwrap();
+
+    // Step 3: Create ADR using --template flag
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "new",
+            "--no-edit",
+            "--template",
+            "templates/my-adr.md",
+            "Custom via CLI",
+        ])
+        .assert()
+        .success();
+
+    let adr = temp.child("doc/adr/0002-custom-via-cli.md");
+    adr.assert(predicate::path::exists());
+    let content = fs::read_to_string(adr.path()).unwrap();
+
+    assert!(
+        content.contains("CLI-CUSTOM: 2. Custom via CLI"),
+        "ADR should use the CLI-specified custom template. Got:
+{content}"
+    );
+    assert!(
+        content.contains("Provided via --template flag."),
+        "ADR should contain custom template body"
+    );
+
+    temp.close().unwrap();
+}
+
+/// When both config custom and --template CLI flag are set, the CLI flag wins.
+#[test]
+fn scenario_cli_template_flag_overrides_config() {
+    let temp = TempDir::new().unwrap();
+
+    // Step 1: Initialize with nextgen mode
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "init"])
+        .assert()
+        .success();
+
+    // Step 2: Write a config custom template
+    let templates_dir = temp.child("templates");
+    templates_dir.create_dir_all().unwrap();
+    fs::write(
+        temp.path().join("templates/config-template.md"),
+        "# CONFIG: {{ number }}. {{ title }}
+
+From config.
+",
+    )
+    .unwrap();
+
+    // Step 3: Write a CLI custom template
+    fs::write(
+        temp.path().join("templates/cli-template.md"),
+        "# CLI: {{ number }}. {{ title }}
+
+From CLI flag.
+",
+    )
+    .unwrap();
+
+    // Step 4: Configure config custom template in adrs.toml
+    fs::write(
+        temp.path().join("adrs.toml"),
+        r#"
+adr_dir = "doc/adr"
+mode = "ng"
+
+[templates]
+custom = "templates/config-template.md"
+"#,
+    )
+    .unwrap();
+
+    // Step 5: Create ADR with --template flag -- should use CLI template, not config
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "new",
+            "--no-edit",
+            "--template",
+            "templates/cli-template.md",
+            "CLI Override Test",
+        ])
+        .assert()
+        .success();
+
+    let adr = temp.child("doc/adr/0002-cli-override-test.md");
+    adr.assert(predicate::path::exists());
+    let content = fs::read_to_string(adr.path()).unwrap();
+
+    assert!(
+        content.contains("CLI: 2. CLI Override Test"),
+        "CLI --template should override config custom. Got:
+{content}"
+    );
+    assert!(
+        !content.contains("CONFIG:"),
+        "Config custom template should be bypassed when --template is given"
+    );
+
+    temp.close().unwrap();
+}


### PR DESCRIPTION
## Summary

Exposes the existing core `custom_template` support in the CLI via a new `--template <PATH>` flag on `adrs new`. Also documents the config-driven path in the book.

Precedence: explicit `--template` > config `[templates] custom` > built-in `--format`/`--variant`.

## Changes

- `crates/adrs/src/main.rs`: add `--template <PATH>` arg to `New` command
- `crates/adrs/src/commands/new.rs`: wire `template` parameter with CLI-first precedence
- `book/src/commands/new.md`: document the new flag and add example
- `book/src/templates.md`: note the `--template` CLI override
- `crates/adrs/tests/scenarios.rs`: add scenario tests for CLI flag and flag-over-config
- `crates/adrs/tests/cli.rs`: add test for missing file error

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all-features` passes (all new tests green)
- [ ] `adrs new --help` shows `--template <PATH>`
- [ ] `adrs new --template ./my.md --no-edit "Test"` uses the custom template
- [ ] Config `[templates] custom` still works as before
- [ ] `--template` overrides config `custom`

Closes #122.