### PR TITLE
fix(release): create GitHub release once (fixes empty v0.7.5 release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,13 @@ jobs:
       # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
+        # Manual edit (ci is in dist allow-dirty): always `dist plan`, never
+        # `dist host --steps=create`. Pre-creating the GitHub Release here made
+        # the host job's `gh release create` fail with "already exists",
+        # leaving an empty public release (#281). The release is now created
+        # exactly once, in the `host` job, atomically with its artifacts.
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist plan --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -324,17 +329,17 @@ jobs:
           done
           git push
 
-  # Custom job (manual addition; ci is in dist allow-dirty): the `plan` job runs
-  # `dist host --steps=create`, which publishes the GitHub Release before any
-  # artifacts are built. If an artifact build then fails, `host` is skipped but
-  # the empty release stays public. Convert it to a draft so an incomplete
-  # release is never visible. See issue #242 (root cause of #217).
+  # Custom job (manual addition; ci is in dist allow-dirty): safety net. If any
+  # artifact build OR the host (upload/release) job fails, draft the release so
+  # an incomplete one is never left public. See #242 (root cause of #217) and
+  # #281 (host-failure gap that left v0.7.5's release empty).
   cleanup-on-failure:
     needs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-local-artifacts.result == 'failure' || needs.build-global-artifacts.result == 'failure') }}
+      - host
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-local-artifacts.result == 'failure' || needs.build-global-artifacts.result == 'failure' || needs.host.result == 'failure') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem (#281)
v0.7.5's GitHub release shipped **empty** (0 assets, public). All artifact builds succeeded, but the `host` job's `gh release create "$tag" ... artifacts/*` failed:
```
a release with the same tag name already exists: v0.7.5
```
The `plan` job had already pre-created the release via `dist host --steps=create`, so the `gh release create` couldn't attach the binaries. And `cleanup-on-failure` (#242) only guarded the *build* jobs, so a `host` failure skipped it — leaving the empty release public.

## Fix
- **`plan`**: always `dist plan` (drop `--steps=create`). The release is now created **exactly once**, in `host`, atomically with its artifacts via the existing `gh release create … artifacts/*` step. This also eliminates the empty-release window that `cleanup-on-failure` was patching.
- **`cleanup-on-failure`**: also fire on a `host` failure (`needs: host` + `needs.host.result == 'failure'`), so any incomplete release is always drafted — defense in depth.

`ci` is in dist `allow-dirty`, so these edits persist across `dist generate`.

## Verification
- `release.yml` parses as valid YAML; `gh release create` is the sole release creator; no `--steps=create` remains.
- The PR path only exercises `plan`; the real test is the next tag release (**0.7.6**). Even if anything else slips, the broadened `cleanup-on-failure` now drafts rather than publishes an empty release.

Once merged, release-plz will propose 0.7.6 — merging that ships a clean release with binaries (and gets 0.7.x binaries back to users like the Scoop/Mise case in #217/#281).

Closes #281