### PR TITLE
fix(release): self-healing release create + post-release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,17 @@ jobs:
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          TAG="${{ needs.plan.outputs.tag }}"
+          # Idempotent (#283): if the release already exists -- e.g.
+          # cleanup-on-failure drafted it, or this is a re-run -- upload the
+          # artifacts to it and un-draft, instead of failing with
+          # "a release with the same tag name already exists". Re-runs self-heal.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" artifacts/* --clobber
+            gh release edit "$TAG" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" --draft=false
+          else
+            gh release create "$TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          fi
 
   publish-homebrew-formula:
     needs:
@@ -360,15 +370,56 @@ jobs:
   # Currently there is no announcement target configured, so the job checks out
   # and exits successfully without doing anything else. Add real steps here when a
   # notification target is configured. See issue #244.
+  # Custom job (manual addition; ci is in dist allow-dirty): post-release
+  # verification (#285). Both #217 and #281 shipped incomplete releases that
+  # were only caught by hand. Confirm the release has its full artifact set and
+  # a valid checksum; fail loud and re-draft if not, so a broken release can't
+  # pass silently. `announce` depends on this -- we only announce verified releases.
+  verify-release:
+    needs:
+      - plan
+      - host
+    if: ${{ needs.host.result == 'success' && needs.plan.outputs.publishing == 'true' }}
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Verify release is complete
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          COUNT=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets | length')
+          echo "Release $TAG has $COUNT assets:"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' | sort | sed 's/^/  /'
+          # Expect >= 14: 5 tarballs + 5 .sha256 + 2 installers + sha256.sum + dist-manifest.json
+          if [ "$COUNT" -lt 14 ]; then
+            echo "::error::Incomplete release: $COUNT assets (expected >= 14). Re-drafting so it is not public."
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft
+            exit 1
+          fi
+      - name: Spot-check a checksum
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          DL="$(mktemp -d)"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "adrs-x86_64-unknown-linux-gnu.tar.xz*" --dir "$DL"
+          exp="$(awk '{print $1}' "$DL"/adrs-x86_64-unknown-linux-gnu.tar.xz.sha256)"
+          got="$(sha256sum "$DL"/adrs-x86_64-unknown-linux-gnu.tar.xz | awk '{print $1}')"
+          if [ "$exp" != "$got" ]; then
+            echo "::error::Checksum mismatch for the linux x86_64 tarball (expected $exp, got $got). Re-drafting."
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft
+            exit 1
+          fi
+          echo "Release $TAG verified: complete asset set + checksum OK."
+
   announce:
     needs:
       - plan
       - host
       - publish-homebrew-formula
+      - verify-release
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
-    # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    # "host" and "verify-release" however must succeed, no skipping allowed!
+    if: ${{ always() && needs.host.result == 'success' && needs.verify-release.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,14 +28,24 @@ maintainer merges the Release PR
   -> release.yml triggers on the tag
 
 release.yml jobs:
-  plan          -- runs `dist host --steps=create`, creates the draft GitHub Release
+  plan          -- runs `dist plan` (computes targets/manifest; does NOT create
+                   the release)
   build-local-artifacts  -- builds per-platform binaries (5 targets)
   build-global-artifacts -- builds installers (shell, powershell) and checksums
-  host          -- runs `dist host --steps=upload --steps=release`, uploads artifacts
+  host          -- uploads artifacts and creates the GitHub Release ONCE, with all
+                   artifacts attached. Sole release creator. Idempotent: a re-run
+                   uploads to the existing release instead of failing (#283).
+  verify-release -- confirms the published release has its full asset set + a valid
+                   checksum; re-drafts and fails if incomplete (#285)
   publish-homebrew-formula -- pushes the .rb formula to joshrotenberg/homebrew-brew
-  announce      -- no-op placeholder (no announcement target configured)
-  cleanup-on-failure -- converts the release to a draft if any build job fails
+  announce      -- no-op placeholder; runs only after verify-release succeeds
+  cleanup-on-failure -- drafts the release if any build OR host job fails (#242, #281)
 ```
+
+Note: a CI/workflow-only change merged to `main` does NOT trigger a release
+(release-plz only cuts a release for crate version bumps, #287). To validate a
+pipeline change end-to-end, bundle it with a crate change, or push the next
+version normally -- the fixed workflow runs on the next tag.
 
 ### Target platforms
 
@@ -88,20 +98,33 @@ Both secrets must be set at `https://github.com/joshrotenberg/adrs/settings/secr
 
 ## Recovery: incomplete release (missing artifacts)
 
-If the release workflow fails mid-run (e.g. a build job fails), the
-`cleanup-on-failure` job converts the GitHub Release to a draft so an
-incomplete release is never publicly visible. See issue #242.
+If the release workflow fails mid-run, the `cleanup-on-failure` job converts the
+GitHub Release to a draft so an incomplete release is never publicly visible (it
+fires on any build OR host failure). The `verify-release` job additionally
+re-drafts and fails if the published release is missing assets. See #242, #281, #285.
 
 To recover:
 
 1. Investigate the failed job in the Actions tab.
 2. Fix the root cause (e.g. a dependency issue, a flaky runner).
-3. Re-run the failed job from the Actions UI: go to the failed workflow run
-   and click "Re-run failed jobs."
-4. Once all jobs pass, verify the release artifacts (see above).
-5. If the release is still in draft state after a successful re-run, undraft it:
+3. Re-run the failed jobs from the Actions UI ("Re-run failed jobs"). The
+   "Create GitHub Release" step is idempotent (#283): a re-run uploads artifacts
+   to the existing/drafted release and un-drafts it, instead of failing with
+   "a release with the same tag name already exists".
+4. Once all jobs pass (including `verify-release`), confirm the release artifacts.
+
+If a re-run fails with `HTTP 403: Resource not accessible by integration`, the
+re-run got a restricted `GITHUB_TOKEN` (a known GitHub re-run quirk). Recover
+manually with your own `gh` auth instead: download the run's built artifacts and
+attach them to the release.
 
    ```bash
+   gh run download <run-id> -D /tmp/rel && cd /tmp/rel
+   gh release create v<VERSION> --repo joshrotenberg/adrs --verify-tag \
+     --title "adrs <VERSION>" --notes-file <notes> \
+     artifacts-build-local-*/adrs-* artifacts-build-global/adrs-installer.* \
+     artifacts-build-global/adrs.rb artifacts-build-global/sha256.sum
+   # or, if the (drafted) release already exists:
    gh release edit v<VERSION> --repo joshrotenberg/adrs --draft=false
    ```
 


### PR DESCRIPTION
From the release-pipeline audit. Addresses *why* releases keep breaking: the pipeline failed **open** (any hiccup left a broken public release; recovery needed manual surgery). This makes it **self-healing** and **self-checking**.

## Changes
- **Idempotent release creation (#283)** — the host job's "Create GitHub Release" step now: if the release exists (e.g. `cleanup-on-failure` drafted it, or this is a re-run), `gh release upload --clobber` + `gh release edit --draft=false`; otherwise `gh release create`. A re-run after any failure now self-heals instead of dying on *"a release with the same tag name already exists"* (the trap that forced the manual v0.7.5 recovery).
- **Post-release verification job (#285)** — new `verify-release` job after `host`: asserts the release has its full asset set (≥14) and a valid checksum, **re-drafting + failing loud** if incomplete. `announce` now depends on it. This automates the manual smoke test and would have caught both #217 and #281 in seconds.
- **RELEASING.md (#284, #287)** — corrected flow (plan = `dist plan`, host = sole creator), documented the idempotent re-run, the 403 re-run-token quirk + manual recovery, and the CI-only-change-doesn't-release gap.

## Net effect
A broken release now (a) can't pass silently — `verify-release` catches it, and (b) recovers with a one-click re-run — `create` is idempotent. `cleanup-on-failure` (any build **or** host failure) + `verify-release` are both fail-closed-to-draft.

## Verification
- `release.yml` parses as valid YAML.
- The PR path only runs `plan`; `verify-release` runs on a real tag (publishing). Real end-to-end proof is the next release.

Remaining audit items filed separately: #286 (adrs-core tag race), #287 (CI-only release gap, documented here).

Closes #283
Closes #284
Closes #285