### PR TITLE
fix(release): trigger cargo-dist only on the CLI v* tag (not adrs-core-v*)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,12 @@ on:
   pull_request:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      # Only the adrs CLI's `v*` tags trigger the binary release. The library
+      # tag `adrs-core-v*` (git_release_enable = false) must NOT run cargo-dist:
+      # it has no binaries, and doing so created a junk GH release that races
+      # release-plz and trips the verify-release check. See #286.
+      # (Manual edit; ci is in dist allow-dirty, so dist generate won't revert it.)
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do


### PR DESCRIPTION
Last item from the release-pipeline audit.

## Problem (#286)
`release.yml` triggered on `**[0-9]+.[0-9]+.[0-9]+*`, which matched **both** `v*` (the dist-able `adrs` CLI) and `adrs-core-v*` (the library). `adrs-core` has `git_release_enable = false` and no binaries, but the `host` job still ran `gh release create adrs-core-v*` — creating a **junk GH release** (currently `adrs-core-v0.7.5`, 1 asset) that:
- races release-plz, and
- with the new `verify-release` job (#288), would fail the next `adrs-core-v*` run (asset count < 14) and re-draft it.

## Fix
Restrict the trigger to `v[0-9]+.[0-9]+.[0-9]+*` — only the CLI's `v*` tags run cargo-dist. `adrs-core-v*` tags no longer trigger the binary release at all; the library is still tagged and published to crates.io by release-plz (no GH release, as configured).

`ci` is in dist `allow-dirty`, so this manual edit persists across `dist generate`.

## Verification
- `release.yml` parses as valid YAML; tag trigger is now `['v[0-9]+.[0-9]+.[0-9]+*']`.
- `v0.7.6` etc. match; `adrs-core-v0.7.6` does not.

## Note
The existing junk `adrs-core-v0.7.5` GitHub *release* (1 asset) can be deleted (keeping the tag) — it shouldn't exist. Flagging rather than doing it here.

Closes #286