### PR TITLE
feat: add styled help with env-var and configuration self-documentation (closes #290)

### DIFF
--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -2,6 +2,7 @@
 
 use adrs_core::{ConfigSource, discover};
 use anyhow::{Context, Result};
+use clap::builder::styling::{AnsiColor, Styles};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};
 use std::io;
@@ -12,10 +13,35 @@ mod commands;
 #[cfg(feature = "mcp")]
 mod mcp;
 
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Green.on_default().bold())
+    .usage(AnsiColor::Green.on_default().bold())
+    .literal(AnsiColor::Cyan.on_default())
+    .placeholder(AnsiColor::BrightBlack.on_default());
+
 #[derive(Parser)]
 #[command(name = "adrs")]
 #[command(author, version)]
+#[command(styles = STYLES)]
 #[command(about = "Manage Architecture Decision Records")]
+#[command(after_help = "\
+Run `adrs <command> --help` for command details. See `adrs --help` for environment variables and configuration.")]
+#[command(after_long_help = "\
+ENVIRONMENT VARIABLES:
+  ADR_DIRECTORY    Override the ADR directory (e.g., ADR_DIRECTORY=docs/decisions adrs list)
+  ADRS_CONFIG      Explicit path to adrs.toml config file (e.g., ADRS_CONFIG=/path/to/adrs.toml adrs list)
+
+CONFIGURATION:
+  adrs.toml is discovered by walking up from the current directory. A global config is
+  also read from $XDG_CONFIG_HOME/adrs/adrs.toml (or ~/.config/adrs/adrs.toml on Linux/macOS,
+  %APPDATA%/adrs/adrs.toml on Windows), and from ~/.adrs.toml as a fallback.
+
+  Compatible mode (default): metadata stored in markdown body, compatible with adr-tools.
+  NextGen mode (--ng): YAML frontmatter with extended fields (tags, deciders, custom fields).
+
+  Template format and variant can be set in adrs.toml:
+    format = \"madr\"     # nygard (default) or madr
+    variant = \"full\"    # full (default), minimal, or bare")]
 #[command(long_about = "\
 A command-line tool for creating and managing Architecture Decision Records (ADRs).
 

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -24,6 +24,25 @@ fn test_help() {
 }
 
 #[test]
+fn test_long_help_contains_env_vars() {
+    adrs()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ENVIRONMENT VARIABLES"))
+        .stdout(predicate::str::contains("ADR_DIRECTORY"));
+}
+
+#[test]
+fn test_short_help_no_env_vars() {
+    adrs()
+        .arg("-h")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ENVIRONMENT VARIABLES").not());
+}
+
+#[test]
 fn test_version() {
     adrs()
         .arg("--version")


### PR DESCRIPTION
## Summary

Adds styled, self-documenting help to the `adrs` CLI matching the pattern from sibling projects jpx/roba.

- Adds a `STYLES` const (green-bold headers/usage, cyan literals, dim placeholders) via `clap::builder::styling`, applied with `#[command(styles = STYLES)]` on `Cli` -- color auto-disables on non-TTY and honors `NO_COLOR`.
- Adds a short `after_help` pointer so `-h` stays scannable.
- Adds `after_long_help` with **ENVIRONMENT VARIABLES** (`ADR_DIRECTORY`, `ADRS_CONFIG`) and **CONFIGURATION** (`adrs.toml` discovery, compatible vs NextGen mode, template format/variant) sections.
- Adds two new CLI tests: `--help` contains "ENVIRONMENT VARIABLES" and "ADR_DIRECTORY"; `-h` does not.

Closes #290.

## Test plan

- [ ] `cargo test --all-features` green (including new `test_long_help_contains_env_vars` and `test_short_help_no_env_vars`)
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo run -p adrs -- --help` shows ENVIRONMENT VARIABLES section with ADR_DIRECTORY and ADRS_CONFIG
- [ ] `cargo run -p adrs -- -h` stays short -- no ENVIRONMENT VARIABLES dump
- [ ] `cargo run -p adrs -- --help | cat` is plain text (no ANSI escapes on non-TTY)