### PR TITLE
chore: release v0.7.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.7.5" }
+adrs-core = { path = "crates/adrs-core", version = "0.7.6" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.6] - 2026-06-08
+
+
 ## [0.7.5] - 2026-06-08
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.6] - 2026-06-08
+
+### Features
+
+- Add styled help with ENVIRONMENT VARIABLES and CONFIGURATION sections (closes #290)
+
+### Polish
+
+- Align CLI help layout with jpx/roba + version footer + higher-contrast color
+
+
 ## [0.7.5] - 2026-06-08
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.7.5 -> 0.7.6
* `adrs`: 0.7.5 -> 0.7.6

<details><summary><i><b>Changelog</b></i></summary><p>


## `adrs`

<blockquote>

## [0.7.6] - 2026-06-08

### Features

- Add styled help with ENVIRONMENT VARIABLES and CONFIGURATION sections (closes #290)

### Polish

- Align CLI help layout with jpx/roba + version footer + higher-contrast color
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).