### PR TITLE
polish: align CLI help with jpx/roba (layout + version footer + contrast)

### DIFF
--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -16,37 +16,21 @@ mod mcp;
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Green.on_default().bold())
     .usage(AnsiColor::Green.on_default().bold())
-    .literal(AnsiColor::Cyan.on_default())
-    .placeholder(AnsiColor::BrightBlack.on_default());
+    .literal(AnsiColor::Cyan.on_default().bold())
+    .placeholder(AnsiColor::Cyan.on_default());
 
 #[derive(Parser)]
 #[command(name = "adrs")]
 #[command(author, version)]
 #[command(styles = STYLES)]
 #[command(about = "Manage Architecture Decision Records")]
-#[command(after_help = "\
-Run `adrs <command> --help` for command details. See `adrs --help` for environment variables and configuration.")]
-#[command(after_long_help = "\
-ENVIRONMENT VARIABLES:
-  ADR_DIRECTORY    Override the ADR directory (e.g., ADR_DIRECTORY=docs/decisions adrs list)
-  ADRS_CONFIG      Explicit path to adrs.toml config file (e.g., ADRS_CONFIG=/path/to/adrs.toml adrs list)
-
-CONFIGURATION:
-  adrs.toml is discovered by walking up from the current directory. A global config is
-  also read from $XDG_CONFIG_HOME/adrs/adrs.toml (or ~/.config/adrs/adrs.toml on Linux/macOS,
-  %APPDATA%/adrs/adrs.toml on Windows), and from ~/.adrs.toml as a fallback.
-
-  Compatible mode (default): metadata stored in markdown body, compatible with adr-tools.
-  NextGen mode (--ng): YAML frontmatter with extended fields (tags, deciders, custom fields).
-
-  Template format and variant can be set in adrs.toml:
-    format = \"madr\"     # nygard (default) or madr
-    variant = \"full\"    # full (default), minimal, or bare")]
 #[command(long_about = "\
 A command-line tool for creating and managing Architecture Decision Records (ADRs).
 
-Compatible with adr-tools repositories. Supports both Nygard and MADR 4.0.0 formats.
-
+Compatible with adr-tools repositories. Supports both Nygard and MADR 4.0.0 formats.")]
+#[command(after_help = "\
+Run `adrs <command> --help` for command details, or `adrs --help` for getting started, examples, environment variables, and configuration.")]
+#[command(after_long_help = concat!("\
 GETTING STARTED:
   adrs init                    Create a new ADR repository
   adrs new \"My Decision\"       Create your first ADR
@@ -68,7 +52,24 @@ EXAMPLES:
   adrs link 3 Amends 1                          Link two ADRs (auto-derives reverse)
   adrs generate toc > doc/adr/README.md         Generate table of contents
 
-DOCUMENTATION: https://joshrotenberg.com/adrs/")]
+ENVIRONMENT VARIABLES:
+  ADR_DIRECTORY    Override the ADR directory (default: doc/adr)
+  ADRS_CONFIG      Explicit path to the adrs.toml config file
+
+CONFIGURATION:
+  adrs.toml is discovered by walking up from the current directory. A global config
+  is also read from $XDG_CONFIG_HOME/adrs/adrs.toml (~/.config/adrs/adrs.toml on
+  Linux/macOS, %APPDATA%/adrs/adrs.toml on Windows), and ~/.adrs.toml as a fallback.
+
+  Compatible mode (default): metadata stored in the markdown body (adr-tools compatible).
+  NextGen mode (--ng):       YAML frontmatter with extended fields (tags, deciders).
+
+  Template format and variant can be set in adrs.toml:
+    format = \"madr\"     # nygard (default) or madr
+    variant = \"full\"    # full (default), minimal, or bare
+
+Version:       ", env!("CARGO_PKG_VERSION"), "
+Documentation: https://joshrotenberg.com/adrs/"))]
 struct Cli {
     /// Enable NextGen mode with YAML frontmatter for richer metadata
     #[arg(


### PR DESCRIPTION
Follow-up to #290/#291 after seeing the actual rendered `--help` next to jpx and roba.

## Changes
- **Layout** — moved GETTING STARTED / FORMATS / MODES / EXAMPLES from `long_about` into `after_long_help`, so the whole reference renders *below* the command/option list (matching jpx/roba). `long_about` trimmed to a 2-line description.
- **Version footer** — added `Version: <CARGO_PKG_VERSION>` + `Documentation:` at the very bottom, like jpx's footer.
- **Contrast** — bold-cyan literals (flags/commands) + cyan placeholders, instead of the dim `BrightBlack` placeholders. Headers/usage stay bold green.
- **Nit** — fixed the `ADRS_CONFIG` line that wrapped mid-word.

## Verification
- `adrs --help` now flows: short description → Usage/Commands/Options → GETTING STARTED…CONFIGURATION → `Version: 0.7.5` / `Documentation:` footer.
- `adrs -h` stays short.
- Forced-color render confirms green-bold headers + bold-cyan flags; `--help | cat` is plain (color off on non-TTY).
- fmt + clippy clean; help tests pass.

Refs #290