### PR TITLE
fix: use COMMITTER_TOKEN for homebrew tap checkout (closes #294)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,7 +314,13 @@ jobs:
         with:
           persist-credentials: true
           repository: "joshrotenberg/homebrew-brew"
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Manual edit: use COMMITTER_TOKEN (the PAT with tap repo access).
+          # HOMEBREW_TAP_TOKEN is the cargo-dist default but is not configured
+          # in this repo. This line was restored from v0.7.4 after the cargo-dist
+          # 0.32 regen in #275 broke it. ci is in dist allow-dirty so this
+          # edit persists across regeneration, but double-check if upgrading
+          # cargo-dist again (see #294).
+          token: ${{ secrets.COMMITTER_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

The `publish-homebrew-formula` job in `.github/workflows/release.yml` was
failing with "Input required and not supplied: token" because it referenced
`secrets.HOMEBREW_TAP_TOKEN`, which does not exist in this repo.

Only `CARGO_REGISTRY_TOKEN` and `COMMITTER_TOKEN` are configured. The
`COMMITTER_TOKEN` PAT has tap repo access and was the working secret before
the cargo-dist 0.32 regeneration in #275 changed the secret name to the
cargo-dist default `HOMEBREW_TAP_TOKEN`.

## Fix

Change exactly one line in the `publish-homebrew-formula` job's checkout step:

```
token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
```
->
```
token: ${{ secrets.COMMITTER_TOKEN }}
```

A comment is added noting that this is a manual edit (since `ci` is in dist
`allow-dirty`) so a future `cargo dist generate` does not silently revert it
to the broken default.

Closes #294.