### PR TITLE
feat: Allow configuring default status

### DIFF
--- a/book/src/commands/config.md
+++ b/book/src/commands/config.md
@@ -36,6 +36,7 @@ Config source: adrs.toml
 ADR directory: doc/adr
 Full path: /home/user/myproject/doc/adr
 Mode: Compatible
+Default ADR status: accepted
 ```
 
 ### Without Initialization

--- a/book/src/commands/new.md
+++ b/book/src/commands/new.md
@@ -21,7 +21,7 @@ adrs new [OPTIONS] <TITLE>
 | `-f, --format <FORMAT>` | Template format: `nygard` or `madr` (default: `nygard`) |
 | `-v, --variant <VARIANT>` | Template variant: `full`, `minimal`, or `bare` (default: `full`) |
 | `--template <PATH>` | Path to a custom template file (overrides `--format`/`--variant` and config) |
-| `--status <STATUS>` | Initial status (default: `Proposed`) |
+| `--status <STATUS>` | Initial status (default: `default_status` from config, else `Proposed`) |
 | `-s, --supersedes <N>` | ADR number this supersedes |
 | `-l, --link <LINK>` | Link to another ADR |
 | `-t, --tags <TAGS>` | Tags for categorization (comma-separated, requires --ng) |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -33,6 +33,10 @@ adr_dir = "doc/adr"
 # - nextgen: YAML frontmatter with enhanced features
 mode = "compatible"
 
+# Default status for newly created ADRs
+# If omitted, defaults to "proposed"
+default_status = "proposed"
+
 # Template configuration
 [templates]
 # Default format: "nygard" or "madr"
@@ -52,6 +56,7 @@ Create `~/.config/adrs/config.toml` for user-wide defaults:
 ```toml
 # Default mode for new repositories
 mode = "nextgen"
+default_status = "accepted"
 
 [templates]
 format = "madr"

--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -32,6 +32,9 @@ pub struct Config {
     /// The mode of operation.
     pub mode: ConfigMode,
 
+    /// Default status for newly created ADRs.
+    pub default_status: Option<String>,
+
     /// Template configuration.
     #[serde(default)]
     pub templates: TemplateConfig,
@@ -42,6 +45,7 @@ impl Default for Config {
         Self {
             adr_dir: PathBuf::from(DEFAULT_ADR_DIR),
             mode: ConfigMode::Compatible,
+            default_status: None,
             templates: TemplateConfig::default(),
         }
     }
@@ -80,6 +84,7 @@ impl Config {
             return Ok(Self {
                 adr_dir: PathBuf::from(adr_dir),
                 mode: ConfigMode::Compatible,
+                default_status: None,
                 templates: TemplateConfig::default(),
             });
         }
@@ -144,6 +149,9 @@ impl Config {
         }
         if other.templates.custom.is_some() {
             self.templates.custom = other.templates.custom.clone();
+        }
+        if other.default_status.is_some() {
+            self.default_status = other.default_status.clone();
         }
     }
 }
@@ -252,6 +260,7 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
             let config = Config {
                 adr_dir: PathBuf::from(adr_dir),
                 mode: ConfigMode::Compatible,
+                default_status: None,
                 templates: TemplateConfig::default(),
             };
             return Ok(Some((current, config, ConfigSource::Project(legacy_path))));
@@ -360,6 +369,7 @@ mod tests {
         let config = Config::default();
         assert_eq!(config.adr_dir, PathBuf::from("doc/adr"));
         assert_eq!(config.mode, ConfigMode::Compatible);
+        assert!(config.default_status.is_none());
         assert!(config.templates.format.is_none());
         assert!(config.templates.custom.is_none());
     }
@@ -437,6 +447,22 @@ mode = "compatible"
 
         let config = Config::load(temp.path()).unwrap();
         assert_eq!(config.mode, ConfigMode::Compatible);
+    }
+
+    #[test]
+    fn test_load_new_config_with_default_status() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+default_status = "accepted"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert_eq!(config.default_status, Some("accepted".to_string()));
     }
 
     #[test]
@@ -569,6 +595,7 @@ mode = "nextgen"
         let config = Config {
             adr_dir: PathBuf::from("my/adrs"),
             mode: ConfigMode::Compatible,
+            default_status: None,
             templates: TemplateConfig::default(),
         };
 
@@ -586,6 +613,7 @@ mode = "nextgen"
         let config = Config {
             adr_dir: PathBuf::from("docs/decisions"),
             mode: ConfigMode::NextGen,
+            default_status: None,
             templates: TemplateConfig::default(),
         };
 
@@ -604,6 +632,7 @@ mode = "nextgen"
         let config = Config {
             adr_dir: PathBuf::from("decisions"),
             mode: ConfigMode::NextGen,
+            default_status: None,
             templates: TemplateConfig {
                 format: Some("custom".to_string()),
                 variant: None,
@@ -624,6 +653,7 @@ mode = "nextgen"
         let original = Config {
             adr_dir: PathBuf::from("architecture/decisions"),
             mode: ConfigMode::Compatible,
+            default_status: None,
             templates: TemplateConfig::default(),
         };
 
@@ -640,6 +670,7 @@ mode = "nextgen"
         let original = Config {
             adr_dir: PathBuf::from("docs/adr"),
             mode: ConfigMode::NextGen,
+            default_status: None,
             templates: TemplateConfig {
                 format: Some("markdown".to_string()),
                 variant: None,
@@ -976,6 +1007,7 @@ mode = "nextgen"
         let other = Config {
             adr_dir: PathBuf::from("custom"),
             mode: ConfigMode::NextGen,
+            default_status: None,
             templates: TemplateConfig {
                 format: Some("madr".to_string()),
                 variant: None,
@@ -1000,6 +1032,18 @@ mode = "nextgen"
         base.merge(&other);
         // Should keep original since other has default
         assert_eq!(base.adr_dir, PathBuf::from("original"));
+    }
+
+    #[test]
+    fn test_config_merge_default_status() {
+        let mut base = Config::default();
+        let other = Config {
+            default_status: Some("accepted".to_string()),
+            ..Default::default()
+        };
+
+        base.merge(&other);
+        assert_eq!(base.default_status, Some("accepted".to_string()));
     }
 
     // ========== Config Validation Tests ==========
@@ -1129,6 +1173,7 @@ custom = "templates/my-adr.md"
         let original = Config {
             adr_dir: PathBuf::from("docs/decisions"),
             mode: ConfigMode::NextGen,
+            default_status: None,
             templates: TemplateConfig {
                 format: Some("madr".to_string()),
                 variant: Some("minimal".to_string()),

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -322,7 +322,10 @@ impl Repository {
     /// Create a new ADR with the given title.
     pub fn new_adr(&self, title: impl Into<String>) -> Result<(Adr, PathBuf)> {
         let number = self.next_number()?;
-        let adr = Adr::new(number, title);
+        let mut adr = Adr::new(number, title);
+        if let Some(default_status) = self.config.default_status.as_deref() {
+            adr.status = default_status.parse::<AdrStatus>().unwrap();
+        }
         let path = self.create(&adr)?;
         Ok((adr, path))
     }
@@ -856,6 +859,27 @@ mod tests {
         let (_, path) = repo.new_adr("Test ADR").unwrap();
         assert!(path.exists());
         assert!(path.to_string_lossy().contains("0002-test-adr.md"));
+    }
+
+    #[test]
+    fn test_new_adr_uses_custom_default_status_from_config() {
+        let temp = TempDir::new().unwrap();
+        Repository::init(temp.path(), None, false).unwrap();
+
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+mode = "compatible"
+default_status = "draft"
+"#,
+        )
+        .unwrap();
+
+        let repo = Repository::open(temp.path()).unwrap();
+        let (adr, _) = repo.new_adr("Custom status ADR").unwrap();
+
+        assert_eq!(adr.status, AdrStatus::Custom("draft".into()));
     }
 
     // ========== Get and Find Tests ==========

--- a/crates/adrs/src/commands/config.rs
+++ b/crates/adrs/src/commands/config.rs
@@ -24,6 +24,9 @@ pub fn config_with_discovery(start_dir: &Path, discovered: Option<DiscoveredConf
                 disc.root.join(&disc.config.adr_dir).display()
             );
             println!("Mode: {:?}", disc.config.mode);
+            if let Some(ref default_status) = disc.config.default_status {
+                println!("Default ADR status: {}", default_status);
+            }
             if let Some(ref format) = disc.config.templates.format {
                 println!("Template format: {}", format);
             }

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -43,12 +43,10 @@ pub fn new(
         TemplateVariant::default()
     };
 
-    // Parse status if specified
-    let initial_status = if let Some(ref s) = status {
-        s.parse::<AdrStatus>().unwrap_or(AdrStatus::Proposed)
-    } else {
-        AdrStatus::Proposed
-    };
+    // Parse CLI status override if specified.
+    let cli_status = status
+        .as_deref()
+        .map(|s| s.parse::<AdrStatus>().unwrap_or(AdrStatus::Proposed));
 
     let mut repo = Repository::open(root)
         .context("ADR repository not found. Run 'adrs init' first.")?
@@ -88,9 +86,9 @@ pub fn new(
         repo.new_adr(&title).context("Failed to create new ADR")?
     };
 
-    // Set custom status if specified (and not superseding, which sets its own status)
-    if supersedes.is_none() && status.is_some() {
-        adr.status = initial_status;
+    // Apply explicit CLI status if specified (superseding sets its own status).
+    if supersedes.is_none() && let Some(status) = cli_status {
+        adr.status = status;
         repo.update_metadata(&adr)
             .context("Failed to update ADR status")?;
     }

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -87,7 +87,9 @@ pub fn new(
     };
 
     // Apply explicit CLI status if specified (superseding sets its own status).
-    if supersedes.is_none() && let Some(status) = cli_status {
+    if supersedes.is_none()
+        && let Some(status) = cli_status
+    {
         adr.status = status;
         repo.update_metadata(&adr)
             .context("Failed to update ADR status")?;

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -67,6 +67,7 @@ CONFIGURATION:
   Template format and variant can be set in adrs.toml:
     format = \"madr\"     # nygard (default) or madr
     variant = \"full\"    # full (default), minimal, or bare
+    default_status = \"accepted\" # proposed (default), accepted, deprecated, superseded, or custom
 
 Version:       ", env!("CARGO_PKG_VERSION"), "
 Documentation: https://joshrotenberg.com/adrs/"))]
@@ -145,7 +146,7 @@ LINK FORMAT:
         #[arg(long, value_name = "PATH")]
         template: Option<PathBuf>,
 
-        /// Initial status [default: Proposed]
+        /// Initial status [default: config default_status or Proposed]
         #[arg(long, value_name = "STATUS")]
         status: Option<String>,
 

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -626,7 +626,7 @@ fn build_router(root: PathBuf) -> McpRouter {
         rw,
         state,
         "create_adr",
-        "Create a new Architecture Decision Record. The ADR will be created with 'proposed' status and requires human review before acceptance. Returns the created ADR details including its number and file path.",
+        "Create a new Architecture Decision Record. The ADR will use the repository's configured default status (proposed if not configured) and requires human review before acceptance. Returns the created ADR details including its number and file path.",
         CreateAdrParams,
         create_adr_impl
     );

--- a/crates/adrs/tests/scenarios.rs
+++ b/crates/adrs/tests/scenarios.rs
@@ -620,6 +620,74 @@ variant = "minimal"
 }
 
 // ============================================================================
+// Scenario: Custom default_status from Config
+// ============================================================================
+
+/// User configures default_status in adrs.toml and expects `adrs new`
+/// to use it when --status is not provided.
+#[test]
+fn scenario_config_driven_default_status() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Step 1: Initialize repository
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Step 2: Configure default_status in adrs.toml
+    fs::write(
+        temp.path().join("adrs.toml"),
+        r#"
+adr_dir = "doc/adr"
+mode = "compatible"
+default_status = "accepted"
+"#,
+    )
+    .unwrap();
+
+    // Step 3: Create ADR without --status
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "Config default status test"])
+        .assert()
+        .success();
+
+    // Step 4: Verify status came from config
+    let adr = temp.child("doc/adr/0002-config-default-status-test.md");
+    adr.assert(predicate::path::exists());
+    let content = fs::read_to_string(adr.path()).unwrap();
+
+    assert!(
+        content.contains("## Status\n\nAccepted"),
+        "ADR should use configured default status. Got:\n{content}"
+    );
+
+    // Step 5: CLI --status still overrides config
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "new",
+            "--no-edit",
+            "--status",
+            "deprecated",
+            "CLI status override test",
+        ])
+        .assert()
+        .success();
+
+    let override_adr = temp.child("doc/adr/0003-cli-status-override-test.md");
+    let override_content = fs::read_to_string(override_adr.path()).unwrap();
+    assert!(
+        override_content.contains("## Status\n\nDeprecated"),
+        "CLI --status should override config default_status"
+    );
+
+    temp.close().unwrap();
+}
+
+// ============================================================================
 // Scenario: Custom Template from Config
 // ============================================================================
 


### PR DESCRIPTION
Allows a user flow where PR merging means approving an ADR, so the ADR itself should be created as accepted.
Users can now configure a `default_status` in the config file which will be used if no `--status` is presented to `adrs new`