### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.6"
+version = "0.8.0"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.7.6" }
+adrs-core = { path = "crates/adrs-core", version = "0.8.0" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2026-06-15
+
+### Features
+
+- Allow configuring default status
+- Make --no-edit default configurable in adrs.toml (closes #298)
+- Configurable default TOC prefix via [generate].toc_prefix in adrs.toml (closes #299)
+- Add export.base_url config for adrs export json (closes #300)
+
+
 ## [0.7.6] - 2026-06-08
 
 

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2026-06-15
+
+### Features
+
+- Allow configuring default status
+- Make --no-edit default configurable in adrs.toml (closes #298)
+- Configurable default TOC prefix via [generate].toc_prefix in adrs.toml (closes #299)
+- Add export.base_url config for adrs export json (closes #300)
+
+
 ## [0.7.6] - 2026-06-08
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.7.6 -> 0.8.0 (⚠ API breaking changes)
* `adrs`: 0.7.6 -> 0.8.0

### ⚠ `adrs-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.default_status in /tmp/.tmpP3bAWw/adrs/crates/adrs-core/src/config.rs:36
  field Config.no_edit in /tmp/.tmpP3bAWw/adrs/crates/adrs-core/src/config.rs:39
  field Config.generate in /tmp/.tmpP3bAWw/adrs/crates/adrs-core/src/config.rs:47
  field Config.export in /tmp/.tmpP3bAWw/adrs/crates/adrs-core/src/config.rs:51
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.8.0] - 2026-06-15

### Features

- Allow configuring default status
- Make --no-edit default configurable in adrs.toml (closes #298)
- Configurable default TOC prefix via [generate].toc_prefix in adrs.toml (closes #299)
- Add export.base_url config for adrs export json (closes #300)
</blockquote>

## `adrs`

<blockquote>

## [0.8.0] - 2026-06-15

### Features

- Allow configuring default status
- Make --no-edit default configurable in adrs.toml (closes #298)
- Configurable default TOC prefix via [generate].toc_prefix in adrs.toml (closes #299)
- Add export.base_url config for adrs export json (closes #300)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).