### PR TITLE
feat: make --no-edit default configurable in adrs.toml (closes #298)

### DIFF
--- a/book/src/commands/new.md
+++ b/book/src/commands/new.md
@@ -25,7 +25,7 @@ adrs new [OPTIONS] <TITLE>
 | `-s, --supersedes <N>` | ADR number this supersedes |
 | `-l, --link <LINK>` | Link to another ADR |
 | `-t, --tags <TAGS>` | Tags for categorization (comma-separated, requires --ng) |
-| `--no-edit` | Create ADR without opening editor (for scripting/CI) |
+| `--no-edit` | Create ADR without opening editor (for scripting/CI); also configurable via `no_edit = true` in `adrs.toml` |
 | `--ng` | Use NextGen mode (YAML frontmatter) |
 | `-C, --cwd <DIR>` | Working directory |
 | `-h, --help` | Print help |
@@ -33,6 +33,8 @@ adrs new [OPTIONS] <TITLE>
 ## Description
 
 Creates a new ADR file with the next available number. Opens your `$EDITOR` to edit the document. The ADR is saved when you close the editor.
+
+To skip the editor by default for all `adrs new` invocations in a repository, set `no_edit = true` in `adrs.toml`. The `--no-edit` CLI flag takes precedence over the config setting.
 
 ## Examples
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,6 +37,10 @@ mode = "compatible"
 # If omitted, defaults to "proposed"
 default_status = "proposed"
 
+# Skip opening the editor when creating a new ADR (for CI/scripting)
+# If omitted, defaults to false
+no_edit = false
+
 # Template configuration
 [templates]
 # Default format: "nygard" or "madr"

--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -35,6 +35,9 @@ pub struct Config {
     /// Default status for newly created ADRs.
     pub default_status: Option<String>,
 
+    /// Skip opening the editor when creating a new ADR.
+    pub no_edit: bool,
+
     /// Template configuration.
     #[serde(default)]
     pub templates: TemplateConfig,
@@ -46,6 +49,7 @@ impl Default for Config {
             adr_dir: PathBuf::from(DEFAULT_ADR_DIR),
             mode: ConfigMode::Compatible,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig::default(),
         }
     }
@@ -85,6 +89,7 @@ impl Config {
                 adr_dir: PathBuf::from(adr_dir),
                 mode: ConfigMode::Compatible,
                 default_status: None,
+                no_edit: false,
                 templates: TemplateConfig::default(),
             });
         }
@@ -152,6 +157,9 @@ impl Config {
         }
         if other.default_status.is_some() {
             self.default_status = other.default_status.clone();
+        }
+        if other.no_edit {
+            self.no_edit = other.no_edit;
         }
     }
 }
@@ -261,6 +269,7 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
                 adr_dir: PathBuf::from(adr_dir),
                 mode: ConfigMode::Compatible,
                 default_status: None,
+                no_edit: false,
                 templates: TemplateConfig::default(),
             };
             return Ok(Some((current, config, ConfigSource::Project(legacy_path))));
@@ -596,6 +605,7 @@ mode = "nextgen"
             adr_dir: PathBuf::from("my/adrs"),
             mode: ConfigMode::Compatible,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig::default(),
         };
 
@@ -614,6 +624,7 @@ mode = "nextgen"
             adr_dir: PathBuf::from("docs/decisions"),
             mode: ConfigMode::NextGen,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig::default(),
         };
 
@@ -633,6 +644,7 @@ mode = "nextgen"
             adr_dir: PathBuf::from("decisions"),
             mode: ConfigMode::NextGen,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig {
                 format: Some("custom".to_string()),
                 variant: None,
@@ -654,6 +666,7 @@ mode = "nextgen"
             adr_dir: PathBuf::from("architecture/decisions"),
             mode: ConfigMode::Compatible,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig::default(),
         };
 
@@ -671,6 +684,7 @@ mode = "nextgen"
             adr_dir: PathBuf::from("docs/adr"),
             mode: ConfigMode::NextGen,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig {
                 format: Some("markdown".to_string()),
                 variant: None,
@@ -1008,6 +1022,7 @@ mode = "nextgen"
             adr_dir: PathBuf::from("custom"),
             mode: ConfigMode::NextGen,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig {
                 format: Some("madr".to_string()),
                 variant: None,
@@ -1044,6 +1059,86 @@ mode = "nextgen"
 
         base.merge(&other);
         assert_eq!(base.default_status, Some("accepted".to_string()));
+    }
+
+    // ========== no_edit Tests ==========
+
+    #[test]
+    fn test_no_edit_defaults_to_false() {
+        let config = Config::default();
+        assert!(!config.no_edit);
+    }
+
+    #[test]
+    fn test_no_edit_true_from_toml() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\nno_edit = true\n",
+        )
+        .unwrap();
+        let config = Config::load(temp.path()).unwrap();
+        assert!(config.no_edit);
+    }
+
+    #[test]
+    fn test_no_edit_false_from_toml() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\nno_edit = false\n",
+        )
+        .unwrap();
+        let config = Config::load(temp.path()).unwrap();
+        assert!(!config.no_edit);
+    }
+
+    #[test]
+    fn test_no_edit_absent_from_toml_defaults_false() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("adrs.toml"), "adr_dir = \"doc/adr\"\n").unwrap();
+        let config = Config::load(temp.path()).unwrap();
+        assert!(!config.no_edit);
+    }
+
+    #[test]
+    fn test_config_merge_no_edit() {
+        let mut base = Config::default();
+        let other = Config {
+            no_edit: true,
+            ..Default::default()
+        };
+        base.merge(&other);
+        assert!(base.no_edit);
+    }
+
+    #[test]
+    fn test_config_merge_no_edit_false_does_not_overwrite_true() {
+        // merge: other.no_edit=false should NOT overwrite base.no_edit=true
+        let mut base = Config {
+            no_edit: true,
+            ..Default::default()
+        };
+        let other = Config::default(); // no_edit = false
+        base.merge(&other);
+        assert!(
+            base.no_edit,
+            "merge with no_edit=false should not overwrite true"
+        );
+    }
+
+    #[test]
+    fn test_no_edit_save_load_roundtrip() {
+        let temp = TempDir::new().unwrap();
+        let original = Config {
+            adr_dir: PathBuf::from("doc/adr"),
+            mode: ConfigMode::NextGen,
+            no_edit: true,
+            ..Default::default()
+        };
+        original.save(temp.path()).unwrap();
+        let loaded = Config::load(temp.path()).unwrap();
+        assert!(loaded.no_edit);
     }
 
     // ========== Config Validation Tests ==========
@@ -1174,6 +1269,7 @@ custom = "templates/my-adr.md"
             adr_dir: PathBuf::from("docs/decisions"),
             mode: ConfigMode::NextGen,
             default_status: None,
+            no_edit: false,
             templates: TemplateConfig {
                 format: Some("madr".to_string()),
                 variant: Some("minimal".to_string()),

--- a/crates/adrs/src/commands/config.rs
+++ b/crates/adrs/src/commands/config.rs
@@ -27,6 +27,9 @@ pub fn config_with_discovery(start_dir: &Path, discovered: Option<DiscoveredConf
             if let Some(ref default_status) = disc.config.default_status {
                 println!("Default ADR status: {}", default_status);
             }
+            if disc.config.no_edit {
+                println!("No edit: true");
+            }
             if let Some(ref format) = disc.config.templates.format {
                 println!("Template format: {}", format);
             }

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -127,8 +127,10 @@ pub fn new(
         }
     }
 
-    // Open in editor unless --no-edit was specified
-    if !no_edit {
+    // Open in editor unless --no-edit flag or config no_edit is set.
+    // Precedence: --no-edit CLI flag > no_edit config > built-in default (false).
+    let skip_editor = no_edit || config.no_edit;
+    if !skip_editor {
         edit::edit_file(&path).context("Failed to open editor")?;
     }
 

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -68,6 +68,7 @@ CONFIGURATION:
     format = \"madr\"     # nygard (default) or madr
     variant = \"full\"    # full (default), minimal, or bare
     default_status = \"accepted\" # proposed (default), accepted, deprecated, superseded, or custom
+    no_edit = true              # skip editor for new ADRs (default: false)
 
 Version:       ", env!("CARGO_PKG_VERSION"), "
 Documentation: https://joshrotenberg.com/adrs/"))]

--- a/crates/adrs/tests/scenarios.rs
+++ b/crates/adrs/tests/scenarios.rs
@@ -688,6 +688,102 @@ default_status = "accepted"
 }
 
 // ============================================================================
+// Scenario: config no_edit = true skips editor
+// ============================================================================
+
+/// When no_edit = true in adrs.toml, `adrs new` succeeds without launching
+/// an editor. In headless CI there is no TTY, so a successful non-interactive
+/// create (without EDITOR set and without --no-edit flag) proves the editor
+/// was skipped.
+///
+/// Note: the editor-OPENS path (no_edit false, no flag) is impractical to
+/// assert in headless CI because it would block waiting for user input.
+#[test]
+fn scenario_config_no_edit_skips_editor() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Step 1: Initialize repository
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Step 2: Write adrs.toml with no_edit = true
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\nmode = \"compatible\"\nno_edit = true\n",
+    )
+    .unwrap();
+
+    // Step 3: Create ADR without --no-edit flag; succeeds without editor.
+    // No EDITOR env set -- if the editor were launched, this would fail or block.
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "Config no-edit test"])
+        .assert()
+        .success();
+
+    // Verify ADR was created
+    let adr = temp.child("doc/adr/0002-config-no-edit-test.md");
+    adr.assert(predicate::path::exists());
+
+    temp.close().unwrap();
+}
+
+/// --no-edit flag works without the config setting.
+#[test]
+fn scenario_no_edit_flag_without_config() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "Flag only no-edit test"])
+        .assert()
+        .success();
+
+    let adr = temp.child("doc/adr/0002-flag-only-no-edit-test.md");
+    adr.assert(predicate::path::exists());
+
+    temp.close().unwrap();
+}
+
+/// --no-edit flag and config no_edit = true together are idempotent.
+#[test]
+fn scenario_no_edit_flag_and_config_together() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\nno_edit = true\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "Both flag and config no-edit"])
+        .assert()
+        .success();
+
+    let adr = temp.child("doc/adr/0002-both-flag-and-config-no-edit.md");
+    adr.assert(predicate::path::exists());
+
+    temp.close().unwrap();
+}
+
+// ============================================================================
 // Scenario: Custom Template from Config
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Makes the `--no-edit` flag for `adrs new` configurable via `adrs.toml` as `no_edit = true`. Teams using CI-driven workflows (where an editor opening is never wanted) can now set this once in their config instead of passing `--no-edit` every time.

Closes #298.

## Changes

- `crates/adrs-core/src/config.rs`: add `no_edit: bool` field (default `false`), update `Default` impl, update `merge()`, add unit tests (load true/false, absent=false, merge precedence, save/load round-trip)
- `crates/adrs/src/commands/new.rs`: resolve `skip_editor = no_edit || config.no_edit` (CLI flag > config > default)
- `crates/adrs/src/commands/config.rs`: print `No edit: true` when set
- `crates/adrs/src/main.rs`: add `no_edit` to CONFIGURATION help block
- `book/src/configuration.md`: document `no_edit` option
- `book/src/commands/new.md`: note `no_edit` config option
- `crates/adrs/tests/scenarios.rs`: three new integration scenarios (config skips editor, flag without config, flag + config idempotent)

## Precedence

`--no-edit` CLI flag > `no_edit` config > built-in default (false)