### PR TITLE
feat: configurable default TOC prefix via [generate].toc_prefix in adrs.toml (closes #299)

### DIFF
--- a/book/src/commands/generate.md
+++ b/book/src/commands/generate.md
@@ -88,6 +88,18 @@ adrs generate toc -i intro.md -O outro.md > doc/adr/README.md
 adrs generate toc -p "wiki/adr/"
 ```
 
+#### Configuring a Default Prefix
+
+Instead of passing `--prefix` on every invocation, set it once in `adrs.toml`:
+
+```toml
+[generate]
+toc_prefix = "./"
+```
+
+Then `adrs generate toc` (with no `--prefix`) will apply `"./"` automatically.
+The `--prefix` CLI flag overrides this config value when provided.
+
 ---
 
 ## generate graph

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -41,6 +41,13 @@ default_status = "proposed"
 # If omitted, defaults to false
 no_edit = false
 
+# Generate command configuration
+[generate]
+# Default prefix for TOC links (used by 'adrs generate toc' if --prefix is not given)
+# Useful for CI jobs that always regenerate the TOC with the same prefix.
+# If omitted, defaults to empty string (bare filename links)
+# toc_prefix = "./"
+
 # Template configuration
 [templates]
 # Default format: "nygard" or "madr"

--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -41,6 +41,10 @@ pub struct Config {
     /// Template configuration.
     #[serde(default)]
     pub templates: TemplateConfig,
+
+    /// Generate command configuration.
+    #[serde(default)]
+    pub generate: GenerateConfig,
 }
 
 impl Default for Config {
@@ -51,6 +55,7 @@ impl Default for Config {
             default_status: None,
             no_edit: false,
             templates: TemplateConfig::default(),
+            generate: GenerateConfig::default(),
         }
     }
 }
@@ -91,6 +96,7 @@ impl Config {
                 default_status: None,
                 no_edit: false,
                 templates: TemplateConfig::default(),
+                generate: GenerateConfig::default(),
             });
         }
 
@@ -160,6 +166,9 @@ impl Config {
         }
         if other.no_edit {
             self.no_edit = other.no_edit;
+        }
+        if other.generate.toc_prefix.is_some() {
+            self.generate.toc_prefix = other.generate.toc_prefix.clone();
         }
     }
 }
@@ -271,6 +280,7 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
                 default_status: None,
                 no_edit: false,
                 templates: TemplateConfig::default(),
+                generate: GenerateConfig::default(),
             };
             return Ok(Some((current, config, ConfigSource::Project(legacy_path))));
         }
@@ -363,6 +373,14 @@ pub struct TemplateConfig {
 
     /// Path to a custom template file.
     pub custom: Option<PathBuf>,
+}
+
+/// Generate command configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GenerateConfig {
+    /// Default prefix for TOC links (used by `adrs generate toc` if `--prefix` is not given).
+    pub toc_prefix: Option<String>,
 }
 
 #[cfg(test)]
@@ -607,6 +625,7 @@ mode = "nextgen"
             default_status: None,
             no_edit: false,
             templates: TemplateConfig::default(),
+            generate: GenerateConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -626,6 +645,7 @@ mode = "nextgen"
             default_status: None,
             no_edit: false,
             templates: TemplateConfig::default(),
+            generate: GenerateConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -650,6 +670,7 @@ mode = "nextgen"
                 variant: None,
                 custom: Some(PathBuf::from("my-template.md")),
             },
+            generate: GenerateConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -668,6 +689,7 @@ mode = "nextgen"
             default_status: None,
             no_edit: false,
             templates: TemplateConfig::default(),
+            generate: GenerateConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -690,6 +712,7 @@ mode = "nextgen"
                 variant: None,
                 custom: None,
             },
+            generate: GenerateConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -1028,6 +1051,7 @@ mode = "nextgen"
                 variant: None,
                 custom: None,
             },
+            generate: GenerateConfig::default(),
         };
 
         base.merge(&other);
@@ -1275,6 +1299,7 @@ custom = "templates/my-adr.md"
                 variant: Some("minimal".to_string()),
                 custom: Some(PathBuf::from("templates/custom.md")),
             },
+            generate: GenerateConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -1362,5 +1387,93 @@ custom = "templates/my-adr.md"
         assert_eq!(base.templates.format, Some("madr".to_string()));
         assert_eq!(base.templates.variant, Some("minimal".to_string()));
         assert_eq!(base.templates.custom, Some(PathBuf::from("template.md")));
+    }
+
+    // ========== GenerateConfig / toc_prefix Tests ==========
+
+    #[test]
+    fn test_generate_config_default() {
+        let config = GenerateConfig::default();
+        assert!(config.toc_prefix.is_none());
+    }
+
+    #[test]
+    fn test_generate_toc_prefix_from_toml() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+
+[generate]
+toc_prefix = "./"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert_eq!(config.generate.toc_prefix, Some("./".to_string()));
+    }
+
+    #[test]
+    fn test_generate_toc_prefix_absent_defaults_none() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("adrs.toml"), "adr_dir = \"doc/adr\"\n").unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert!(config.generate.toc_prefix.is_none());
+    }
+
+    #[test]
+    fn test_config_merge_generate_toc_prefix() {
+        let mut base = Config::default();
+        let other = Config {
+            generate: GenerateConfig {
+                toc_prefix: Some("./".to_string()),
+            },
+            ..Default::default()
+        };
+
+        base.merge(&other);
+        assert_eq!(base.generate.toc_prefix, Some("./".to_string()));
+    }
+
+    #[test]
+    fn test_config_merge_generate_toc_prefix_none_does_not_overwrite() {
+        let mut base = Config {
+            generate: GenerateConfig {
+                toc_prefix: Some("docs/".to_string()),
+            },
+            ..Default::default()
+        };
+        let other = Config::default(); // toc_prefix = None
+
+        base.merge(&other);
+        assert_eq!(
+            base.generate.toc_prefix,
+            Some("docs/".to_string()),
+            "merge with toc_prefix=None should not overwrite existing value"
+        );
+    }
+
+    #[test]
+    fn test_generate_toc_prefix_save_load_roundtrip() {
+        let temp = TempDir::new().unwrap();
+        let original = Config {
+            mode: ConfigMode::NextGen,
+            generate: GenerateConfig {
+                toc_prefix: Some("wiki/adr/".to_string()),
+            },
+            ..Default::default()
+        };
+
+        original.save(temp.path()).unwrap();
+        let loaded = Config::load(temp.path()).unwrap();
+
+        assert_eq!(
+            loaded.generate.toc_prefix,
+            Some("wiki/adr/".to_string()),
+            "toc_prefix should survive a save/load round-trip"
+        );
     }
 }

--- a/crates/adrs/src/commands/generate.rs
+++ b/crates/adrs/src/commands/generate.rs
@@ -12,6 +12,7 @@ pub fn generate_toc(
     intro: Option<PathBuf>,
     outro: Option<PathBuf>,
     prefix: Option<String>,
+    config_prefix: Option<String>,
 ) -> Result<()> {
     let repo =
         Repository::open(root).context("ADR repository not found. Run 'adrs init' first.")?;
@@ -25,7 +26,8 @@ pub fn generate_toc(
     }
 
     // Print TOC
-    let prefix = prefix.unwrap_or_default();
+    // Precedence: --prefix CLI flag > generate.toc_prefix config > built-in default (empty)
+    let prefix = prefix.or(config_prefix).unwrap_or_default();
     for (i, adr) in adrs.iter().enumerate() {
         let bullet = if ordered {
             format!("{}.", i + 1)

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -69,6 +69,8 @@ CONFIGURATION:
     variant = \"full\"    # full (default), minimal, or bare
     default_status = \"accepted\" # proposed (default), accepted, deprecated, superseded, or custom
     no_edit = true              # skip editor for new ADRs (default: false)
+    [generate]
+    toc_prefix = \"./\"          # default prefix for 'generate toc' links (default: empty)
 
 Version:       ", env!("CARGO_PKG_VERSION"), "
 Documentation: https://joshrotenberg.com/adrs/"))]
@@ -696,7 +698,14 @@ fn main() -> Result<()> {
                     intro,
                     outro,
                     prefix,
-                } => commands::generate_toc(&discovered.root, ordered, intro, outro, prefix),
+                } => commands::generate_toc(
+                    &discovered.root,
+                    ordered,
+                    intro,
+                    outro,
+                    prefix,
+                    discovered.config.generate.toc_prefix,
+                ),
                 GenerateCommands::Graph { prefix, extension } => {
                     commands::generate_graph(&discovered.root, prefix, &extension)
                 }

--- a/crates/adrs/tests/scenarios.rs
+++ b/crates/adrs/tests/scenarios.rs
@@ -1690,3 +1690,165 @@ custom = "templates/config-template.md"
 
     temp.close().unwrap();
 }
+
+// ============================================================================
+// Scenario: Configurable default TOC prefix via [generate].toc_prefix
+// ============================================================================
+
+/// When `[generate] toc_prefix` is set in adrs.toml, `adrs generate toc`
+/// (with no `--prefix` flag) emits links with that prefix.
+#[test]
+fn scenario_config_toc_prefix_applies_without_flag() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Step 1: Initialize repository
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Step 2: Create an ADR so there is something to list
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "Config prefix test"])
+        .assert()
+        .success();
+
+    // Step 3: Set toc_prefix in adrs.toml
+    fs::write(
+        temp.path().join("adrs.toml"),
+        r#"
+adr_dir = "doc/adr"
+mode = "compatible"
+
+[generate]
+toc_prefix = "./"
+"#,
+    )
+    .unwrap();
+
+    // Step 4: Generate TOC without --prefix; prefix from config should apply
+    let output = adrs()
+        .current_dir(temp.path())
+        .args(["generate", "toc"])
+        .output()
+        .unwrap();
+
+    let toc = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "generate toc should succeed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        toc.contains("./"),
+        "TOC links should include config toc_prefix './'. Got:\n{toc}"
+    );
+    assert!(
+        toc.contains("Config prefix test"),
+        "TOC should contain the ADR title. Got:\n{toc}"
+    );
+
+    temp.close().unwrap();
+}
+
+/// When both `[generate] toc_prefix` is set in config and `--prefix` is
+/// provided on the CLI, the CLI flag takes precedence.
+#[test]
+fn scenario_config_toc_prefix_overridden_by_cli_flag() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Step 1: Initialize repository
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Step 2: Create an ADR
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "CLI prefix override test"])
+        .assert()
+        .success();
+
+    // Step 3: Set toc_prefix in config
+    fs::write(
+        temp.path().join("adrs.toml"),
+        r#"
+adr_dir = "doc/adr"
+mode = "compatible"
+
+[generate]
+toc_prefix = "./"
+"#,
+    )
+    .unwrap();
+
+    // Step 4: Generate TOC with explicit --prefix; CLI wins
+    let output = adrs()
+        .current_dir(temp.path())
+        .args(["generate", "toc", "--prefix", "wiki/"])
+        .output()
+        .unwrap();
+
+    let toc = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "generate toc should succeed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        toc.contains("wiki/"),
+        "CLI --prefix should override config toc_prefix. Got:\n{toc}"
+    );
+    assert!(
+        !toc.contains("(./"),
+        "Config toc_prefix should be suppressed when --prefix is given. Got:\n{toc}"
+    );
+
+    temp.close().unwrap();
+}
+
+/// When neither `[generate] toc_prefix` nor `--prefix` is set, TOC links
+/// use no prefix (just the filename).
+#[test]
+fn scenario_config_toc_prefix_absent_uses_default() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Step 1: Initialize repository
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Step 2: Create an ADR
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "No prefix test"])
+        .assert()
+        .success();
+
+    // Step 3: Generate TOC with no config and no --prefix
+    let output = adrs()
+        .current_dir(temp.path())
+        .args(["generate", "toc"])
+        .output()
+        .unwrap();
+
+    let toc = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "generate toc should succeed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // The link should be directly to the filename with no prefix
+    assert!(
+        toc.contains("(0002-no-prefix-test.md)"),
+        "TOC links should use bare filename when no prefix is set. Got:\n{toc}"
+    );
+
+    temp.close().unwrap();
+}


### PR DESCRIPTION
## Summary

Adds a `[generate]` table to `adrs.toml` with a `toc_prefix` field, allowing the `adrs generate toc` command to use a default link prefix from config without requiring `--prefix` on every invocation.

## Plan

### Config layer (`crates/adrs-core/src/config.rs`)
- Add `GenerateConfig { toc_prefix: Option<String> }` sub-struct (same shape as `TemplateConfig`)
- Add `pub generate: GenerateConfig` field to `Config`
- Update `Default`, all struct literals, and `merge()` to handle the new field

### Command layer (`crates/adrs/src/commands/generate.rs`)
- Add `config_prefix: Option<String>` parameter to `generate_toc`
- Resolve: `prefix.or(config_prefix).unwrap_or_default()` (CLI flag > config > empty)

### CLI wiring (`crates/adrs/src/main.rs`)
- Pass `discovered.config.generate.toc_prefix` to `generate_toc`
- Update CONFIGURATION help block to mention `[generate]`

### Tests
- Unit tests in `config.rs`: load, absent-default, merge precedence, save/load round-trip
- Scenario tests in `scenarios.rs`: config prefix applies without flag; CLI flag overrides config; neither set = no prefix

### Docs
- `book/src/configuration.md`: add `[generate]` section to TOML example
- `book/src/commands/generate.md`: note config override in `generate toc` section

Closes #299.