### PR TITLE
feat: add export.base_url config for adrs export json (closes #300)

### DIFF
--- a/book/src/commands/export.md
+++ b/book/src/commands/export.md
@@ -20,7 +20,7 @@ adrs export json -d path/to/adrs  # Export from directory (no repo needed)
 | `--pretty`, `-p` | Pretty-print the JSON output |
 | `--dir`, `-d` | Export from a directory without requiring an initialized repository |
 | `--metadata-only` | Export metadata without content fields (context, decision, consequences) |
-| `--base-url <URL>` | Set base URL for `source_uri` field (for federation) |
+| `--base-url <URL>` | Set base URL for `source_uri` field (for federation); can also be set in `adrs.toml` |
 
 ### Output Format
 
@@ -61,6 +61,17 @@ adrs export json --metadata-only --base-url "https://github.com/org/repo/blob/ma
 ```
 
 This produces lightweight exports that reference the source files:
+
+#### Configuring base_url in adrs.toml
+
+Since a repo's source URL rarely changes, you can set it once in `adrs.toml` so you do not need to pass `--base-url` on every invocation:
+
+```toml
+[export]
+base_url = "https://github.com/org/repo/blob/main/doc/adr"
+```
+
+With this config, `adrs export json` will include `source_uri` fields automatically. The `--base-url` CLI flag always takes precedence over the config value.
 
 ```json
 {

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -48,6 +48,13 @@ no_edit = false
 # If omitted, defaults to empty string (bare filename links)
 # toc_prefix = "./"
 
+# Export command configuration
+[export]
+# Default base URL for source_uri fields in JSON export
+# (used by 'adrs export json' if --base-url is not given)
+# If omitted, defaults to none (no source_uri fields)
+# base_url = "https://github.com/org/repo/blob/main/doc/adr"
+
 # Template configuration
 [templates]
 # Default format: "nygard" or "madr"

--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -45,6 +45,10 @@ pub struct Config {
     /// Generate command configuration.
     #[serde(default)]
     pub generate: GenerateConfig,
+
+    /// Export command configuration.
+    #[serde(default)]
+    pub export: ExportConfig,
 }
 
 impl Default for Config {
@@ -56,6 +60,7 @@ impl Default for Config {
             no_edit: false,
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         }
     }
 }
@@ -97,6 +102,7 @@ impl Config {
                 no_edit: false,
                 templates: TemplateConfig::default(),
                 generate: GenerateConfig::default(),
+                export: ExportConfig::default(),
             });
         }
 
@@ -169,6 +175,9 @@ impl Config {
         }
         if other.generate.toc_prefix.is_some() {
             self.generate.toc_prefix = other.generate.toc_prefix.clone();
+        }
+        if other.export.base_url.is_some() {
+            self.export.base_url = other.export.base_url.clone();
         }
     }
 }
@@ -281,6 +290,7 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
                 no_edit: false,
                 templates: TemplateConfig::default(),
                 generate: GenerateConfig::default(),
+                export: ExportConfig::default(),
             };
             return Ok(Some((current, config, ConfigSource::Project(legacy_path))));
         }
@@ -381,6 +391,14 @@ pub struct TemplateConfig {
 pub struct GenerateConfig {
     /// Default prefix for TOC links (used by `adrs generate toc` if `--prefix` is not given).
     pub toc_prefix: Option<String>,
+}
+
+/// Export command configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ExportConfig {
+    /// Default base URL for source_uri in JSON export (used by `adrs export json` if `--base-url` is not given).
+    pub base_url: Option<String>,
 }
 
 #[cfg(test)]
@@ -626,6 +644,7 @@ mode = "nextgen"
             no_edit: false,
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -646,6 +665,7 @@ mode = "nextgen"
             no_edit: false,
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -671,6 +691,7 @@ mode = "nextgen"
                 custom: Some(PathBuf::from("my-template.md")),
             },
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -690,6 +711,7 @@ mode = "nextgen"
             no_edit: false,
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -713,6 +735,7 @@ mode = "nextgen"
                 custom: None,
             },
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -1052,6 +1075,7 @@ mode = "nextgen"
                 custom: None,
             },
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         };
 
         base.merge(&other);
@@ -1300,6 +1324,7 @@ custom = "templates/my-adr.md"
                 custom: Some(PathBuf::from("templates/custom.md")),
             },
             generate: GenerateConfig::default(),
+            export: ExportConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -1474,6 +1499,100 @@ toc_prefix = "./"
             loaded.generate.toc_prefix,
             Some("wiki/adr/".to_string()),
             "toc_prefix should survive a save/load round-trip"
+        );
+    }
+
+    // ========== ExportConfig / base_url Tests ==========
+
+    #[test]
+    fn test_export_config_default() {
+        let config = ExportConfig::default();
+        assert!(config.base_url.is_none());
+    }
+
+    #[test]
+    fn test_export_base_url_from_toml() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+
+[export]
+base_url = "https://github.com/org/repo/blob/main/doc/adr"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert_eq!(
+            config.export.base_url,
+            Some("https://github.com/org/repo/blob/main/doc/adr".to_string())
+        );
+    }
+
+    #[test]
+    fn test_export_base_url_absent_defaults_none() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("adrs.toml"), "adr_dir = \"doc/adr\"\n").unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert!(config.export.base_url.is_none());
+    }
+
+    #[test]
+    fn test_config_merge_export_base_url() {
+        let mut base = Config::default();
+        let other = Config {
+            export: ExportConfig {
+                base_url: Some("https://example.com/adr".to_string()),
+            },
+            ..Default::default()
+        };
+
+        base.merge(&other);
+        assert_eq!(
+            base.export.base_url,
+            Some("https://example.com/adr".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_merge_export_base_url_none_does_not_overwrite() {
+        let mut base = Config {
+            export: ExportConfig {
+                base_url: Some("https://existing.example.com/adr".to_string()),
+            },
+            ..Default::default()
+        };
+        let other = Config::default(); // export.base_url = None
+
+        base.merge(&other);
+        assert_eq!(
+            base.export.base_url,
+            Some("https://existing.example.com/adr".to_string()),
+            "merge with export.base_url=None should not overwrite existing value"
+        );
+    }
+
+    #[test]
+    fn test_export_base_url_save_load_roundtrip() {
+        let temp = TempDir::new().unwrap();
+        let original = Config {
+            mode: ConfigMode::NextGen,
+            export: ExportConfig {
+                base_url: Some("https://github.com/org/repo/blob/main/doc/adr".to_string()),
+            },
+            ..Default::default()
+        };
+
+        original.save(temp.path()).unwrap();
+        let loaded = Config::load(temp.path()).unwrap();
+
+        assert_eq!(
+            loaded.export.base_url,
+            Some("https://github.com/org/repo/blob/main/doc/adr".to_string()),
+            "export.base_url should survive a save/load round-trip"
         );
     }
 }

--- a/crates/adrs/src/commands/export.rs
+++ b/crates/adrs/src/commands/export.rs
@@ -12,7 +12,10 @@ use std::path::Path;
 /// Options:
 /// - `metadata_only`: If true, excludes content fields (context, decision, consequences)
 ///   and sets source_uri based on base_url.
-/// - `base_url`: Base URL for constructing source_uri values.
+/// - `base_url`: Base URL for constructing source_uri values (CLI flag).
+/// - `config_base_url`: Base URL from `export.base_url` in adrs.toml (config).
+///
+/// Precedence: `--base-url` CLI flag > `export.base_url` config > built-in default (None).
 pub fn export_json(
     root: &Path,
     adr_number: Option<u32>,
@@ -20,7 +23,11 @@ pub fn export_json(
     pretty: bool,
     metadata_only: bool,
     base_url: Option<String>,
+    config_base_url: Option<String>,
 ) -> Result<()> {
+    // Precedence: --base-url CLI flag > export.base_url config > built-in default (None)
+    let base_url = base_url.or(config_base_url);
+
     let json = if let Some(dir_path) = dir {
         // Export from arbitrary directory (no repo required)
         if adr_number.is_some() {

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -71,6 +71,8 @@ CONFIGURATION:
     no_edit = true              # skip editor for new ADRs (default: false)
     [generate]
     toc_prefix = \"./\"          # default prefix for 'generate toc' links (default: empty)
+    [export]
+    base_url = \"https://github.com/org/repo/blob/main/doc/adr\"  # default base URL for 'export json' (default: none)
 
 Version:       ", env!("CARGO_PKG_VERSION"), "
 Documentation: https://joshrotenberg.com/adrs/"))]
@@ -725,7 +727,7 @@ fn main() -> Result<()> {
                 base_url,
             } => {
                 if let Some(ref dir_path) = dir {
-                    // Export from arbitrary directory - no repo needed
+                    // Export from arbitrary directory - no repo needed, no config available
                     commands::export_json(
                         &start_dir,
                         adr,
@@ -733,6 +735,7 @@ fn main() -> Result<()> {
                         pretty,
                         metadata_only,
                         base_url,
+                        None,
                     )
                 } else {
                     // Export from repository
@@ -744,6 +747,7 @@ fn main() -> Result<()> {
                         pretty,
                         metadata_only,
                         base_url,
+                        discovered.config.export.base_url,
                     )
                 }
             }

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -890,6 +890,116 @@ fn test_export_json_after_init() {
     temp.close().unwrap();
 }
 
+// Tests for export.base_url config support (#300)
+
+#[test]
+fn test_export_json_config_base_url_no_flag() {
+    // When export.base_url is set in adrs.toml, adrs export json (no --base-url)
+    // should include source_uri fields.
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Write adrs.toml with [export] base_url
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\n\n[export]\nbase_url = \"https://example.com/adr\"\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["export", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("source_uri"))
+        .stdout(predicate::str::contains("https://example.com/adr"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_export_json_flag_overrides_config_base_url() {
+    // --base-url CLI flag takes precedence over export.base_url in config.
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\n\n[export]\nbase_url = \"https://config.example.com/adr\"\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "export",
+            "json",
+            "--base-url",
+            "https://flag.example.com/adr",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("https://flag.example.com/adr"))
+        .stdout(predicate::str::is_match("source_uri").unwrap());
+
+    // The config URL should NOT appear
+    let output = adrs()
+        .current_dir(temp.path())
+        .args([
+            "export",
+            "json",
+            "--base-url",
+            "https://flag.example.com/adr",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        !output_str.contains("https://config.example.com/adr"),
+        "config base_url should not appear when --base-url flag is set"
+    );
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_export_json_no_base_url_no_source_uri() {
+    // When neither --base-url nor export.base_url in config is set,
+    // export output should not contain source_uri fields.
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Write adrs.toml WITHOUT [export] section
+    fs::write(temp.path().join("adrs.toml"), "adr_dir = \"doc/adr\"\n").unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["export", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("source_uri").not());
+
+    temp.close().unwrap();
+}
+
 // ============================================================================
 // Import Command
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds an `[export]` table to `adrs.toml` with a `base_url` field, allowing the JSON export base URL to be configured once rather than passed on every `adrs export json` invocation.

Precedence: `--base-url` CLI flag > `export.base_url` config > built-in default (none, no `source_uri` fields).

Closes #300.

## Plan

### Changes

1. **`crates/adrs-core/src/config.rs`** -- add `ExportConfig { base_url: Option<String> }` struct, `pub export: ExportConfig` field on `Config`, update `Default` impl, all named struct literals, and `merge()`.

2. **`crates/adrs/src/commands/export.rs`** -- add `config_base_url: Option<String>` parameter, resolve `let base_url = base_url.or(config_base_url)`.

3. **`crates/adrs/src/main.rs`** -- thread `discovered.config.export.base_url` into the repo-path export dispatch; pass `None` for the `--dir` path. Update `[export]` CONFIGURATION section in `--help` text.

4. **`book/src/configuration.md`** -- add `[export]` table to the `adrs.toml` example.

5. **`book/src/commands/export.md`** -- mention config support for `base_url`.

### Tests

- Unit tests in `config.rs`: load, absent defaults, merge precedence, save/load round-trip.
- Integration tests in `crates/adrs/tests/cli.rs`: config value applies with no flag; `--base-url` overrides config; neither set produces no `source_uri` fields.