### PR TITLE
feat: update init ADR #0001 template

### DIFF
--- a/crates/adrs-core/src/init_adr.rs
+++ b/crates/adrs-core/src/init_adr.rs
@@ -10,5 +10,4 @@ article
 
 pub const CONSEQUENCES: &str =
     "See Michael Nygard's article, linked above. For a lightweight Rust ADR toolset,
-see [adrs](https://github.com/joshrotenberg/adrs) by Josh Rotenberg. For Python
-see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).";
+see [adrs](https://github.com/joshrotenberg/adrs) by Josh Rotenberg. For the original shell implementation, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).";

--- a/crates/adrs-core/src/init_adr.rs
+++ b/crates/adrs-core/src/init_adr.rs
@@ -1,0 +1,14 @@
+//! Body content for ADR #0001 seeded by [`Repository::init`](crate::Repository::init).
+
+pub const TITLE: &str = "Record architecture decisions";
+
+pub const CONTEXT: &str = "We need to record the architectural decisions made on this project.";
+
+pub const DECISION: &str = "We will use Architecture Decision Records, as described by Michael Nygard in his
+article
+[Documenting Architecture Decisions](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions).";
+
+pub const CONSEQUENCES: &str =
+    "See Michael Nygard's article, linked above. For a lightweight Rust ADR toolset,
+see [adrs](https://github.com/joshrotenberg/adrs) by Josh Rotenberg. For Python
+see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).";

--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -85,6 +85,7 @@ mod config;
 pub mod doctor;
 mod error;
 pub mod export;
+mod init_adr;
 pub mod lint;
 mod parse;
 mod repository;

--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -432,7 +432,8 @@ mod tests {
     fn test_lint_valid_nygard_adr() {
         // Uses the actual ADR #0001 text produced by `adrs init`. The word "described"
         // previously triggered an ADR014 false positive (fixed in mdbook-lint-rulesets 0.14.3).
-        let content = r#"# 1. Record architecture decisions
+        let content = format!(
+            r#"# 1. Record architecture decisions
 
 Date: 2024-03-04
 
@@ -442,16 +443,20 @@ Accepted
 
 ## Context
 
-We need to record the architectural decisions made on this project.
+{}
 
 ## Decision
 
-We will use Architecture Decision Records, as described by Michael Nygard in his article "Documenting Architecture Decisions".
+{}
 
 ## Consequences
 
-See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's adr-tools.
-"#;
+{}
+"#,
+            crate::init_adr::CONTEXT,
+            crate::init_adr::DECISION,
+            crate::init_adr::CONSEQUENCES,
+        );
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir
             .path()

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -107,12 +107,11 @@ impl Repository {
 
         // Only create initial ADR if no ADRs exist
         if existing_adrs == 0 {
-            let mut adr = Adr::new(1, "Record architecture decisions");
+            let mut adr = Adr::new(1, crate::init_adr::TITLE);
             adr.status = AdrStatus::Accepted;
-            adr.context =
-                "We need to record the architectural decisions made on this project.".into();
-            adr.decision = "We will use Architecture Decision Records, as described by Michael Nygard in his article \"Documenting Architecture Decisions\".".into();
-            adr.consequences = "See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's adr-tools.".into();
+            adr.context = crate::init_adr::CONTEXT.into();
+            adr.decision = crate::init_adr::DECISION.into();
+            adr.consequences = crate::init_adr::CONSEQUENCES.into();
             repo.create(&adr)?;
         }
 
@@ -786,11 +785,42 @@ mod tests {
         let repo = Repository::init(temp.path(), None, false).unwrap();
 
         let adr = repo.get(1).unwrap();
-        assert_eq!(adr.title, "Record architecture decisions");
+        assert_eq!(adr.title, crate::init_adr::TITLE);
         assert_eq!(adr.status, AdrStatus::Accepted);
-        assert!(!adr.context.is_empty());
-        assert!(!adr.decision.is_empty());
-        assert!(!adr.consequences.is_empty());
+        assert_eq!(adr.context, crate::init_adr::CONTEXT);
+        assert_eq!(adr.decision, crate::init_adr::DECISION);
+        assert_eq!(adr.consequences, crate::init_adr::CONSEQUENCES);
+    }
+
+    #[test]
+    fn test_init_first_adr_has_markdown_links_in_both_modes() {
+        for ng in [false, true] {
+            let temp = TempDir::new().unwrap();
+            let repo = Repository::init(temp.path(), None, ng).unwrap();
+            let path = repo
+                .adr_path()
+                .join("0001-record-architecture-decisions.md");
+            let content = fs::read_to_string(path).unwrap();
+
+            assert!(
+                content.contains(
+                    "[Documenting Architecture Decisions](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)"
+                ),
+                "expected Nygard article link (ng={ng})"
+            );
+            assert!(
+                content.contains("[adrs](https://github.com/joshrotenberg/adrs)"),
+                "expected adrs link (ng={ng})"
+            );
+            assert!(
+                content.contains("[adr-tools](https://github.com/npryce/adr-tools)"),
+                "expected adr-tools link (ng={ng})"
+            );
+            assert!(
+                content.ends_with('\n'),
+                "init ADR should end with a newline (ng={ng})"
+            );
+        }
     }
 
     // ========== Open Tests ==========

--- a/crates/adrs-core/src/template.rs
+++ b/crates/adrs-core/src/template.rs
@@ -346,6 +346,7 @@ Date: {{ date }}
 ## Consequences
 
 {{ consequences if consequences else "What becomes easier or more difficult to do because of this change?" }}
+
 "#;
 
 /// MADR (Markdown Any Decision Records) 4.0.0 template.

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -624,6 +624,11 @@ fn test_init_adr_content() {
     assert!(content.contains("## Context"));
     assert!(content.contains("## Decision"));
     assert!(content.contains("## Consequences"));
+    assert!(content.contains(
+        "[Documenting Architecture Decisions](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)"
+    ));
+    assert!(content.contains("[adrs](https://github.com/joshrotenberg/adrs)"));
+    assert!(content.contains("[adr-tools](https://github.com/npryce/adr-tools)"));
 
     temp.close().unwrap();
 }

--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -12,9 +12,13 @@ We need to record the architectural decisions made on this project.
 
 ## Decision
 
-We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+We will use Architecture Decision Records, as described by Michael Nygard in his
+article
+[Documenting Architecture Decisions](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
 
 ## Consequences
 
-See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
+See Michael Nygard's article, linked above. For a lightweight Rust ADR toolset,
+see [adrs](https://github.com/joshrotenberg/adrs) by Josh Rotenberg. For Python
+see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
 

--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -19,6 +19,5 @@ article
 ## Consequences
 
 See Michael Nygard's article, linked above. For a lightweight Rust ADR toolset,
-see [adrs](https://github.com/joshrotenberg/adrs) by Josh Rotenberg. For Python
-see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
+see [adrs](https://github.com/joshrotenberg/adrs) by Josh Rotenberg. For the original shell implementation, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
 


### PR DESCRIPTION
- added the markdown link so the text was correct.
- switched the init template to constants
- added adrs to the (short) toolset list
- I honestly don't know what uses the fixtures, so I didn't update it. I'd rather break something in a PR, before making a change I don't understand.
  - Can true it up if needed.
- I don't know if you really wanted a superseded ADR #1 or not...
  - Can true that up as well if wanted.