### PR TITLE
fix: reject empty or whitespace-only status values (closes #305)

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -360,6 +360,17 @@ impl Repository {
         status: AdrStatus,
         superseded_by: Option<u32>,
     ) -> Result<PathBuf> {
+        // Reject empty or whitespace-only custom statuses. Serializing one
+        // yields a YAML null that fails to deserialize, silently dropping the
+        // ADR from `list()` (see issue #305).
+        if let AdrStatus::Custom(s) = &status
+            && s.trim().is_empty()
+        {
+            return Err(Error::InvalidStatus(
+                "status cannot be empty or whitespace-only".to_string(),
+            ));
+        }
+
         let mut adr = self.get(number)?;
         adr.status = status.clone();
 
@@ -1845,6 +1856,34 @@ Decision.
             "Should not have extra blank line before closing ---: {:?}",
             result
         );
+    }
+
+    #[test]
+    fn test_set_status_rejects_empty_custom() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = "---\nnumber: 2\ntitle: Test\ndate: 2026-01-15\nstatus: proposed\n---\n\n## Context\n\nContext.\n";
+        let adr_path = repo.adr_path().join("0002-test.md");
+        fs::write(&adr_path, content).unwrap();
+
+        // Whitespace-only and empty custom statuses must be rejected (#305).
+        for bad in ["", " ", "   ", "\t"] {
+            let err = repo
+                .set_status(2, AdrStatus::Custom(bad.to_string()), None)
+                .unwrap_err();
+            assert!(
+                matches!(err, Error::InvalidStatus(_)),
+                "expected InvalidStatus for {:?}, got {:?}",
+                bad,
+                err
+            );
+        }
+
+        // The file must be untouched and still parse.
+        let result = fs::read_to_string(&adr_path).unwrap();
+        assert!(result.contains("status: proposed"));
+        assert!(repo.get(2).is_ok());
     }
 
     #[test]

--- a/crates/adrs/src/commands/status.rs
+++ b/crates/adrs/src/commands/status.rs
@@ -11,6 +11,13 @@ pub fn status(
     new_status: &str,
     superseded_by: Option<u32>,
 ) -> Result<()> {
+    // Reject empty or whitespace-only status values. Writing one produces a
+    // YAML null in the frontmatter, which fails to deserialize and silently
+    // drops the ADR from `repo.list()` (see issue #305).
+    if new_status.trim().is_empty() {
+        anyhow::bail!("Status cannot be empty or whitespace-only");
+    }
+
     let repo = Repository::open(root).context("Failed to open ADR repository")?;
 
     // Parse the status
@@ -46,4 +53,31 @@ pub fn status(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_status_rejects_empty_and_whitespace() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        repo.new_adr("Test decision").unwrap();
+
+        for bad in ["", " ", "   ", "\t"] {
+            let err = status(temp.path(), 1, bad, None).unwrap_err();
+            assert!(
+                err.to_string().contains("empty or whitespace-only"),
+                "expected empty-status error for {:?}, got: {}",
+                bad,
+                err
+            );
+        }
+
+        // The ADR must remain findable and its status unchanged.
+        let adr = repo.get(1).unwrap();
+        assert_eq!(adr.status, AdrStatus::Proposed);
+    }
 }

--- a/crates/adrs/src/commands/status.rs
+++ b/crates/adrs/src/commands/status.rs
@@ -64,7 +64,7 @@ mod tests {
     fn test_status_rejects_empty_and_whitespace() {
         let temp = TempDir::new().unwrap();
         let repo = Repository::init(temp.path(), None, true).unwrap();
-        repo.new_adr("Test decision").unwrap();
+        let before = repo.get(1).unwrap().status;
 
         for bad in ["", " ", "   ", "\t"] {
             let err = status(temp.path(), 1, bad, None).unwrap_err();
@@ -78,6 +78,6 @@ mod tests {
 
         // The ADR must remain findable and its status unchanged.
         let adr = repo.get(1).unwrap();
-        assert_eq!(adr.status, AdrStatus::Proposed);
+        assert_eq!(adr.status, before);
     }
 }


### PR DESCRIPTION
## Problem

`adrs status N " "` silently corrupts an ADR. Closes #305.

Setting a status to a space-only string caused `update_frontmatter_metadata` to write `status: ` (a YAML null) into the frontmatter. A null value does not deserialize into any named `AdrStatus` variant or `AdrStatus::Custom(String)`, so `parse_file` returns an error. Because `repo.list()` uses `filter_map(...ok())`, the file is silently omitted, and `get(N)` then returns `AdrNotFound`. The ADR becomes invisible to `list`, `status`, and `get`.

## Change

- CLI `status` command: reject empty or whitespace-only status values before opening the repository, with the message `Status cannot be empty or whitespace-only`.
- `Repository::set_status` (adrs-core): defense-in-depth guard that returns `Error::InvalidStatus` when a `Custom` status is empty or whitespace-only, so no caller can write the corrupting YAML null.

The CLI path still accepts legitimate custom statuses (adr-tools compatibility); only empty/whitespace values are rejected. The MCP `update_status`/`bulk_update_status` paths already rejected all custom statuses, so they were unaffected.

## Tests

- `adrs-core`: `test_set_status_rejects_empty_custom` verifies empty, space, multi-space, and tab custom statuses are rejected and the file is left intact and parseable.
- `adrs`: `test_status_rejects_empty_and_whitespace` verifies the CLI command bails on the same inputs and leaves the ADR findable with its original status.