### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.8.0" }
+adrs-core = { path = "crates/adrs-core", version = "0.9.0" }
 
 # Testing
 serial_test = "3"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-07-10
+
+### Bug Fixes
+
+- Reject empty or whitespace-only status values (closes #305)
+- Parse CRLF frontmatter and legacy Date lines (closes #326, #324)
+- Preserve link descriptions and hrefs in metadata writer
+- Add Date line to nygard bare-minimal template (closes #330)
+
+### Documentation
+
+- Fix drift found by v0.9.0 release readiness audit
+
+### Features
+
+- Configurable doctor rules and warnings-as-errors via adrs.toml
+
+### Testing
+
+- Wire up adr-corpus fixtures as a round-trip harness (closes #318)
+- Pin CRLF frontmatter behavior and force LF checkout for corpus fixtures
+
+
 ## [0.8.0] - 2026-06-15
 
 ### Features

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-07-10
+
+### Bug Fixes
+
+- Reject empty or whitespace-only status values (closes #305)
+- Surface --ng as a no-op for adrs doctor (closes #306)
+- Resolve relative CLI paths against the -C working directory
+
+### Documentation
+
+- Fix drift found by v0.9.0 release readiness audit
+- Add bare-minimal to MCP create_adr variant error message
+
+### Features
+
+- Configurable doctor rules and warnings-as-errors via adrs.toml
+
+### Testing
+
+- Assert against original status instead of hardcoded Proposed
+
+
 ## [0.8.0] - 2026-06-15
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `adrs`: 0.8.0 -> 0.9.0

### ⚠ `adrs-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.doctor in /tmp/.tmpHUUSrs/adrs/crates/adrs-core/src/config.rs:55
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.9.0] - 2026-07-10

### Bug Fixes

- Reject empty or whitespace-only status values (closes #305)
- Parse CRLF frontmatter and legacy Date lines (closes #326, #324)
- Preserve link descriptions and hrefs in metadata writer
- Add Date line to nygard bare-minimal template (closes #330)

### Documentation

- Fix drift found by v0.9.0 release readiness audit

### Features

- Configurable doctor rules and warnings-as-errors via adrs.toml

### Testing

- Wire up adr-corpus fixtures as a round-trip harness (closes #318)
- Pin CRLF frontmatter behavior and force LF checkout for corpus fixtures
</blockquote>

## `adrs`

<blockquote>

## [0.9.0] - 2026-07-10

### Bug Fixes

- Reject empty or whitespace-only status values (closes #305)
- Surface --ng as a no-op for adrs doctor (closes #306)
- Resolve relative CLI paths against the -C working directory

### Documentation

- Fix drift found by v0.9.0 release readiness audit
- Add bare-minimal to MCP create_adr variant error message

### Features

- Configurable doctor rules and warnings-as-errors via adrs.toml

### Testing

- Assert against original status instead of hardcoded Proposed
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).