### PR TITLE
fix: surface --ng as a no-op for adrs doctor (closes #306)

### DIFF
--- a/book/src/commands/doctor.md
+++ b/book/src/commands/doctor.md
@@ -12,13 +12,18 @@ adrs doctor [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ng` | Use NextGen mode |
+| `--ng` | No-op for `doctor` (prints a note; see below) |
 | `-C, --cwd <DIR>` | Working directory |
 | `-h, --help` | Print help |
 
 ## Description
 
 Runs diagnostic checks on your ADR repository and reports any issues found.
+
+The global `--ng` flag has no effect on `doctor`. Lint rules detect each ADR's
+format (Nygard or MADR) from the file itself, so the repository mode does not
+change which checks run. Passing `--ng doctor` prints a note to that effect
+rather than ignoring the flag silently.
 
 ## Checks Performed
 

--- a/crates/adrs/src/commands/doctor.rs
+++ b/crates/adrs/src/commands/doctor.rs
@@ -7,7 +7,18 @@ use std::path::Path;
 /// Run health checks on the ADR repository.
 ///
 /// Runs all lint checks (per-file and repository-level).
-pub fn doctor(root: &Path) -> Result<()> {
+///
+/// `ng` reflects whether the global `--ng` flag was passed. It has no effect on
+/// linting: the lint rules detect each ADR's format (Nygard or MADR) from the
+/// file itself, so the repository mode does not change which checks run. When
+/// `--ng` is passed we say so rather than ignoring it silently (see issue #306).
+pub fn doctor(root: &Path, ng: bool) -> Result<()> {
+    if ng {
+        eprintln!(
+            "note: --ng has no effect on 'doctor'; lint rules detect each ADR's format automatically"
+        );
+    }
+
     let repo =
         Repository::open(root).context("Failed to open repository. Have you run 'adrs init'?")?;
 

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -302,6 +302,18 @@ Note: Use --by with 'superseded' to create a link to the replacing ADR.")]
     Config,
 
     /// Check repository health
+    #[command(after_long_help = "\
+EXAMPLES:
+  adrs doctor                  Run all health checks
+
+WHAT IT CHECKS:
+  Per-file lint rules (title format, required sections, dates) and
+  repository-level checks (sequential numbering, duplicates, broken links).
+
+NOTE ON --ng:
+  The global --ng flag has no effect on 'doctor'. Lint rules detect each ADR's
+  format (Nygard or MADR) from the file itself, so the repository mode does not
+  change which checks run. Passing --ng prints a note to that effect.")]
     Doctor,
 
     /// Generate documentation
@@ -690,7 +702,7 @@ fn main() -> Result<()> {
         }
         Commands::Doctor => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
-            commands::doctor(&discovered.root)
+            commands::doctor(&discovered.root, cli.ng)
         }
         Commands::Generate { command } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1507,6 +1507,47 @@ fn test_smoke_full_workflow() {
     temp.close().unwrap();
 }
 
+#[test]
+fn test_doctor_ng_flag_prints_note() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // --ng is a no-op for doctor, but it should not be silently ignored (issue #306).
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "doctor"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("--ng has no effect on 'doctor'"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_doctor_without_ng_flag_prints_no_note() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("--ng").not());
+
+    temp.close().unwrap();
+}
+
 /// Smoke test for MCP feature availability (default since 0.6.1)
 #[test]
 #[cfg(feature = "mcp")]


### PR DESCRIPTION
Closes #306.

## Problem

`adrs --ng doctor` and `adrs doctor` produced identical results. The global `--ng` flag was silently ignored by `doctor`, so users passing it expecting stricter enforcement got no indication the flag had no effect.

## Root cause

The lint pipeline in `adrs-core` detects each ADR's format (Nygard or MADR) from the file itself (frontmatter presence). The repository mode (`--ng` / `mode = "ng"`) does not, and should not, change which lint rules run. So `--ng` is a genuine no-op for `doctor`. The gap was that it was ignored silently.

## Change

Make the no-op explicit rather than wiring mode into linting (which would not change any rule behavior):

- `main.rs`: pass `cli.ng` into `commands::doctor`; add `after_long_help` to the `Doctor` subcommand documenting the no-op.
- `commands/doctor.rs`: print a note to stderr when `--ng` is passed, explaining that lint rules detect format automatically.
- `book/src/commands/doctor.md`: document that `--ng` is a no-op for `doctor`.
- `tests/cli.rs`: cover that the note appears with `--ng` and does not appear without it.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: all pass (new tests `test_doctor_ng_flag_prints_note`, `test_doctor_without_ng_flag_prints_no_note`)