### PR TITLE
fix: preserve MADR 4.0.0 content when updating ADR body sections

### DIFF
--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -103,7 +103,7 @@ pub use lint::{
     lint_all,
 };
 pub use parse::Parser;
-pub use repository::Repository;
+pub use repository::{BodySectionPatch, Repository};
 pub use template::{Template, TemplateEngine, TemplateFormat, TemplateVariant};
 pub use types::{Adr, AdrLink, AdrStatus, LinkKind};
 

--- a/crates/adrs-core/src/parse.rs
+++ b/crates/adrs-core/src/parse.rs
@@ -16,6 +16,22 @@ static LINK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 /// Regex for extracting ADR number from filename.
 static NUMBER_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(\d{4})-.*\.md$").unwrap());
 
+/// Map a markdown H2 heading (normalized to lowercase) to a canonical ADR body field.
+///
+/// Recognizes section names from the two supported on-disk formats:
+/// - **Nygard/adr-tools** — `Context`, `Decision`, `Consequences` (Michael Nygard's
+///   layout, as implemented by [adr-tools](https://github.com/npryce/adr-tools))
+/// - **MADR 4.0.0** — `Context and Problem Statement`, `Decision Outcome`, and
+///   `Consequences` when present as a top-level H2
+pub(crate) fn canonical_section_field(section: &str) -> Option<&'static str> {
+    match section.trim().to_lowercase().as_str() {
+        "context" | "context and problem statement" => Some("context"),
+        "decision" | "decision outcome" => Some("decision"),
+        "consequences" => Some("consequences"),
+        _ => None,
+    }
+}
+
 /// Parser for ADR files.
 #[derive(Debug, Default)]
 pub struct Parser {
@@ -90,16 +106,15 @@ impl Parser {
             }
         }
 
-        // Parse body sections
+        // Parse body sections (Nygard/adr-tools and MADR 4.0.0 heading aliases)
         let sections = self.parse_sections(body);
-        if let Some(context) = sections.get("context") {
-            adr.context = context.clone();
-        }
-        if let Some(decision) = sections.get("decision") {
-            adr.decision = decision.clone();
-        }
-        if let Some(consequences) = sections.get("consequences") {
-            adr.consequences = consequences.clone();
+        for (key, value) in &sections {
+            match canonical_section_field(key) {
+                Some("context") => adr.context = value.clone(),
+                Some("decision") => adr.decision = value.clone(),
+                Some("consequences") => adr.consequences = value.clone(),
+                _ => {}
+            }
         }
 
         Ok(adr)
@@ -164,19 +179,14 @@ impl Parser {
     /// Apply a parsed section to the ADR.
     fn apply_section(&self, adr: &mut Adr, section: &str, content: &str) {
         let content = content.trim().to_string();
-        match section {
-            "status" => {
-                self.parse_status_section(adr, &content);
-            }
-            "context" => {
-                adr.context = content;
-            }
-            "decision" => {
-                adr.decision = content;
-            }
-            "consequences" => {
-                adr.consequences = content;
-            }
+        if section == "status" {
+            self.parse_status_section(adr, &content);
+            return;
+        }
+        match canonical_section_field(section) {
+            Some("context") => adr.context = content,
+            Some("decision") => adr.decision = content,
+            Some("consequences") => adr.consequences = content,
             _ => {}
         }
     }
@@ -899,6 +909,8 @@ We will use Redis.
         assert_eq!(adr.number, 2);
         assert_eq!(adr.title, "Use Redis for caching");
         assert_eq!(adr.status, AdrStatus::Proposed);
+        assert!(adr.context.contains("caching solution"));
+        assert!(adr.decision.contains("use Redis"));
     }
 
     #[test]
@@ -923,6 +935,32 @@ Context.
         assert_eq!(adr.number, 1);
         assert_eq!(adr.title, "Use MADR Format");
         assert_eq!(adr.status, AdrStatus::Accepted);
+        assert_eq!(adr.context, "Context.");
+    }
+
+    #[test]
+    fn test_parse_madr_frontmatter_populates_body_sections() {
+        let content = r#"---
+number: 1
+title: Use MADR Format
+date: 2024-09-15
+status: accepted
+---
+
+## Context and Problem Statement
+
+We need a standard format for ADRs.
+
+## Decision Outcome
+
+Chosen option: "MADR 4.0.0", because it provides rich metadata.
+"#;
+
+        let parser = Parser::new();
+        let adr = parser.parse(content).unwrap();
+
+        assert!(adr.context.contains("standard format"));
+        assert!(adr.decision.contains("MADR 4.0.0"));
     }
 
     #[test]

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -784,19 +784,56 @@ impl Repository {
         Ok(result)
     }
 
-    fn is_fence_delimiter(line: &str) -> bool {
-        let trimmed = line.trim();
-        trimmed.starts_with("```") || trimmed.starts_with("~~~")
+    /// CommonMark fence opener/closer: 0–3 leading spaces, then a run of ≥3
+    /// `` ` `` or `~`. Lines indented ≥4 spaces are indented code, not fences.
+    fn fence_run(line: &str) -> Option<(char, usize)> {
+        let indent = line.chars().take_while(|c| *c == ' ').count();
+        if indent >= 4 {
+            return None;
+        }
+        let rest = &line[indent..];
+        let ch = rest.chars().next()?;
+        if ch != '`' && ch != '~' {
+            return None;
+        }
+        let run = rest.chars().take_while(|c| *c == ch).count();
+        if run < 3 {
+            return None;
+        }
+        Some((ch, run))
+    }
+
+    /// Whether `line` can close an open fence of `(ch, open_len)` (same character,
+    /// run length ≥ opener, only whitespace after the run).
+    fn is_fence_close(line: &str, ch: char, open_len: usize) -> bool {
+        let Some((close_ch, run)) = Self::fence_run(line) else {
+            return false;
+        };
+        if close_ch != ch || run < open_len {
+            return false;
+        }
+        let indent = line.chars().take_while(|c| *c == ' ').count();
+        let after_run = &line[indent + run..];
+        after_run.chars().all(|c| c == ' ' || c == '\t')
     }
 
     fn in_fence_at_line(lines: &[&str], index: usize) -> bool {
-        let mut in_fence = false;
+        let mut open: Option<(char, usize)> = None;
         for line in &lines[..index] {
-            if Self::is_fence_delimiter(line) {
-                in_fence = !in_fence;
+            match open {
+                None => {
+                    if let Some((ch, run)) = Self::fence_run(line) {
+                        open = Some((ch, run));
+                    }
+                }
+                Some((ch, open_len)) => {
+                    if Self::is_fence_close(line, ch, open_len) {
+                        open = None;
+                    }
+                }
             }
         }
-        in_fence
+        open.is_some()
     }
 
     fn is_h2_outside_fence(lines: &[&str], index: usize) -> bool {

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -900,12 +900,12 @@ impl Repository {
 
         let mut consequences_applied = false;
 
-        // Nygard-style ADRs use a top-level `## Consequences` H2; that section is
-        // patched separately. Leave Decision bytes untouched when only consequences
-        // is set and a Consequences H2 exists later in the file.
+        // Top-level `## Consequences` H2 (anywhere outside fences) is patched
+        // separately. Leave Decision bytes untouched when only consequences is
+        // set and such an H2 exists — including before Decision Outcome.
         if patch.decision.is_none()
             && patch.consequences.is_some()
-            && Self::has_consequences_h2_after(lines, body_end)
+            && Self::has_consequences_h2(lines)
         {
             Self::append_lines(result, lines, body_start, body_end, content);
             return (true, false);
@@ -927,7 +927,7 @@ impl Repository {
 
         if intro_end >= body_end {
             if let Some(ref text) = patch.consequences
-                && !Self::has_consequences_h2_after(lines, body_end)
+                && !Self::has_consequences_h2(lines)
                 && madr_decision_outcome
             {
                 Self::write_madr_consequences_subsection(result, text);
@@ -972,7 +972,7 @@ impl Repository {
 
         if let Some(ref text) = patch.consequences
             && !consequences_applied
-            && !Self::has_consequences_h2_after(lines, body_end)
+            && !Self::has_consequences_h2(lines)
             && madr_decision_outcome
         {
             Self::write_madr_consequences_subsection(result, text);
@@ -982,9 +982,10 @@ impl Repository {
         (true, consequences_applied)
     }
 
-    fn has_consequences_h2_after(lines: &[&str], start: usize) -> bool {
-        lines[start..].iter().enumerate().any(|(offset, line)| {
-            Self::is_h2_outside_fence(lines, start + offset) && Self::is_consequences_h2(line)
+    /// True when a fence-aware `## Consequences` H2 exists anywhere in the file.
+    fn has_consequences_h2(lines: &[&str]) -> bool {
+        lines.iter().enumerate().any(|(idx, line)| {
+            Self::is_h2_outside_fence(lines, idx) && Self::is_consequences_h2(line)
         })
     }
 

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -17,7 +17,16 @@ use walkdir::WalkDir;
 /// `None` for a field means leave that section's on-disk bytes untouched.
 /// `Some(text)` replaces the targeted portion (for MADR 4.0.0 `## Decision Outcome`,
 /// only the intro before `###` subsections unless `consequences` is also set).
+///
+/// # Migration from pre-`BodySectionPatch` `update(&adr)`
+///
+/// The previous `Repository::update(&adr)` re-rendered body sections from
+/// `adr.context` / `adr.decision` / `adr.consequences`. An empty
+/// [`BodySectionPatch::default()`] does **not** do that: it only updates
+/// metadata. To change body text, put the new content in the corresponding
+/// patch field; values on `adr` alone are ignored for body content.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct BodySectionPatch {
     /// Patch the context section (`## Context` / `## Context and Problem Statement`).
     pub context: Option<String>,
@@ -28,9 +37,36 @@ pub struct BodySectionPatch {
 }
 
 impl BodySectionPatch {
+    /// Create an empty patch (metadata-only when passed to [`Repository::update`]).
+    pub fn new() -> Self {
+        Self {
+            context: None,
+            decision: None,
+            consequences: None,
+        }
+    }
+
     /// Returns true when no body sections should be modified.
     pub fn is_empty(&self) -> bool {
         self.context.is_none() && self.decision.is_none() && self.consequences.is_none()
+    }
+
+    /// Set the context section patch.
+    pub fn with_context(mut self, text: impl Into<String>) -> Self {
+        self.context = Some(text.into());
+        self
+    }
+
+    /// Set the decision section patch.
+    pub fn with_decision(mut self, text: impl Into<String>) -> Self {
+        self.decision = Some(text.into());
+        self
+    }
+
+    /// Set the consequences section patch.
+    pub fn with_consequences(mut self, text: impl Into<String>) -> Self {
+        self.consequences = Some(text.into());
+        self
     }
 }
 
@@ -445,6 +481,11 @@ impl Repository {
     /// metadata bytes on disk are left unchanged. When `body` is empty, metadata
     /// (status, links, tags, and MADR 4.0.0 frontmatter fields) is updated via the
     /// same path as [`Self::update_metadata`].
+    ///
+    /// Empty `body` does **not** re-render context/decision/consequences from `adr`
+    /// (unlike the pre-`BodySectionPatch` API). Mutating those fields on `adr` and
+    /// calling `update(&adr, BodySectionPatch::default())` writes metadata only;
+    /// body text on disk is unchanged. Pass the new text in `body` to patch sections.
     ///
     /// `adr.title` and `adr.date` are not written by this method.
     ///

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -2464,7 +2464,6 @@ decision-makers: mschoettle
         let adr = adrs.iter().find(|a| a.number == 2).unwrap();
         assert_eq!(adr.decision_makers, vec!["mschoettle"]);
     }
-
     // ========== Link metadata round-trip Tests (#323, #325) ==========
 
     #[test]
@@ -2581,5 +2580,717 @@ Context.
             Repository::link_href(&target),
             "0003-use-rust-for-backend-services.md"
         );
+    // ========== BodySectionPatch preservation tests (issue #310) ==========
+
+    /// Extract from `## {heading}` through the line before the next H2 (inclusive).
+    fn extract_h2_block(content: &str, heading: &str) -> Option<String> {
+        let lines: Vec<&str> = content.lines().collect();
+        let marker = format!("## {heading}");
+        let start = lines.iter().position(|l| l.trim() == marker)?;
+        let end = lines[(start + 1)..]
+            .iter()
+            .position(|l| l.starts_with("## "))
+            .map(|p| start + 1 + p)
+            .unwrap_or(lines.len());
+        Some(lines[start..end].join("\n"))
+    }
+
+    fn assert_h2_block_unchanged(before: &str, after: &str, heading: &str) {
+        assert_eq!(
+            extract_h2_block(before, heading),
+            extract_h2_block(after, heading),
+            "section `{heading}` should be byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_update_ng_nygard_rich_context_preserved_on_decision_patch() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Rich context ADR
+date: 2026-01-15
+status: proposed
+---
+
+## Context
+
+We need caching. See the [Redis docs](https://redis.io).
+
+* Requirement one
+* Requirement two
+
+Use `redis-cli` for debugging.
+
+## Decision
+
+Old decision.
+
+## Consequences
+
+Old consequences.
+"#;
+        let adr_path = repo.adr_path().join("0002-rich-context-adr.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.decision = "New decision.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                decision: Some("New decision.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_h2_block_unchanged(&before, &after, "Context");
+        assert_h2_block_unchanged(&before, &after, "Consequences");
+        assert!(after.contains("New decision."));
+    }
+
+    #[test]
+    fn test_update_madr_rich_context_preserved_on_consequences_patch() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Rich MADR context
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+We need caching. See the [Redis docs](https://redis.io).
+
+* Requirement one
+* Requirement two
+
+Use `redis-cli` for debugging.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Old consequence
+"#;
+        let adr_path = repo.adr_path().join("0002-rich-madr-context.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.consequences = "* New consequence".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                consequences: Some("* New consequence".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_h2_block_unchanged(&before, &after, "Context and Problem Statement");
+        assert!(after.contains("Chosen option: \"Redis\", because it is fast."));
+        assert!(after.contains("* New consequence"));
+        assert!(!after.contains("* Old consequence"));
+    }
+
+    #[test]
+    fn test_update_legacy_rich_context_preserved_on_decision_patch() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let content = r#"# 2. Legacy rich context
+
+Date: 2026-01-15
+
+## Status
+
+Proposed
+
+## Context
+
+We need caching. See the [Redis docs](https://redis.io).
+
+* Requirement one
+* Requirement two
+
+Use `redis-cli` for debugging.
+
+## Decision
+
+Old decision.
+
+## Consequences
+
+Old consequences.
+"#;
+        let adr_path = repo.adr_path().join("0002-legacy-rich-context.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.decision = "New decision.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                decision: Some("New decision.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_h2_block_unchanged(&before, &after, "Context");
+        assert_h2_block_unchanged(&before, &after, "Consequences");
+        assert!(after.contains("New decision."));
+    }
+
+    #[test]
+    fn test_update_madr_decision_only_preserves_h3_subsections() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Decision patch MADR
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Old intro text.
+
+### Consequences
+
+* Good, because it is fast
+* Bad, because it uses memory
+
+### Confirmation
+
+Confirm via load tests.
+"#;
+        let adr_path = repo.adr_path().join("0002-decision-patch-madr.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.decision = "New intro text.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                decision: Some("New intro text.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("New intro text."));
+        assert!(!after.contains("Old intro text."));
+        assert!(after.contains("### Consequences"));
+        assert!(after.contains("* Good, because it is fast"));
+        assert!(after.contains("* Bad, because it uses memory"));
+        assert!(after.contains("### Confirmation"));
+        assert!(after.contains("Confirm via load tests."));
+        assert_h2_block_unchanged(&before, &after, "Context and Problem Statement");
+    }
+
+    #[test]
+    fn test_update_madr_decision_and_consequences_together_preserves_other_h3() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Combined patch MADR
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Old intro.
+
+### Consequences
+
+* Old consequence
+
+### Confirmation
+
+Confirm via load tests.
+"#;
+        let adr_path = repo.adr_path().join("0002-combined-patch-madr.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.decision = "New intro.".into();
+        adr.consequences = "* New consequence".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                decision: Some("New intro.".into()),
+                consequences: Some("* New consequence".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("New intro."));
+        assert!(after.contains("* New consequence"));
+        assert!(!after.contains("Old intro."));
+        assert!(!after.contains("* Old consequence"));
+        assert!(after.contains("### Confirmation"));
+        assert!(after.contains("Confirm via load tests."));
+        assert_h2_block_unchanged(&before, &after, "Context and Problem Statement");
+    }
+
+    #[test]
+    fn test_update_ng_nygard_consequences_only_patch() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Nygard consequences patch
+date: 2026-01-15
+status: proposed
+---
+
+## Context
+
+Original context.
+
+## Decision
+
+Original decision.
+
+## Consequences
+
+* Old item
+"#;
+        let adr_path = repo.adr_path().join("0002-nygard-consequences-patch.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.consequences = "* New item".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                consequences: Some("* New item".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_h2_block_unchanged(&before, &after, "Context");
+        assert_h2_block_unchanged(&before, &after, "Decision");
+        assert!(after.contains("* New item"));
+        assert!(!after.contains("* Old item"));
+    }
+
+    #[test]
+    fn test_update_ng_nygard_context_only_preserves_consequences_section() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Nygard context patch
+date: 2026-01-15
+status: proposed
+---
+
+## Context
+
+Old context.
+
+## Decision
+
+Original decision.
+
+## Consequences
+
+* Good, because it is fast
+* Bad, because it uses memory
+"#;
+        let adr_path = repo.adr_path().join("0002-nygard-context-patch.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "New context.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("New context.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_h2_block_unchanged(&before, &after, "Decision");
+        assert_h2_block_unchanged(&before, &after, "Consequences");
+        assert!(after.contains("New context."));
+    }
+
+    #[test]
+    fn test_update_metadata_only_preserves_madr_body_byte_identical() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Metadata only MADR
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Intro.
+
+### Consequences
+
+* Good item
+
+### Confirmation
+
+Confirm via tests.
+"#;
+        let adr_path = repo.adr_path().join("0002-metadata-only-madr.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = fs::read_to_string(&adr_path).unwrap();
+        let body_start = before.find("\n\n## Context").unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.status = AdrStatus::Accepted;
+        repo.update(&adr, BodySectionPatch::default()).unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_eq!(
+            &before[body_start..],
+            &after[after.find("\n\n## Context").unwrap()..]
+        );
+        assert!(after.contains("status: accepted"));
+    }
+
+    #[test]
+    fn test_update_madr_consequences_appends_h3_when_missing() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Append consequences MADR
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Intro only, no consequences subsection yet.
+"#;
+        let adr_path = repo.adr_path().join("0002-append-consequences-madr.md");
+        fs::write(&adr_path, content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.consequences = "* Appended consequence".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                consequences: Some("* Appended consequence".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("Intro only, no consequences subsection yet."));
+        assert!(after.contains("### Consequences"));
+        assert!(after.contains("* Appended consequence"));
+    }
+
+    #[test]
+    fn test_update_madr_in_compatible_mode_repo() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let content = r#"---
+number: 2
+title: Compatible repo MADR file
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Original context.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Good item
+
+### Confirmation
+
+Confirm via tests.
+"#;
+        let adr_path = repo.adr_path().join("0002-compatible-repo-madr-file.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "Updated context.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("Updated context."));
+        assert_h2_block_unchanged(&before, &after, "Decision Outcome");
+    }
+
+    #[test]
+    fn test_update_madr_decision_only_without_h3_subsections() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Simple decision MADR
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Old single-paragraph decision.
+"#;
+        let adr_path = repo.adr_path().join("0002-simple-decision-madr.md");
+        fs::write(&adr_path, content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.decision = "New single-paragraph decision.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                decision: Some("New single-paragraph decision.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("New single-paragraph decision."));
+        assert!(!after.contains("Old single-paragraph decision."));
+    }
+
+    #[test]
+    fn test_update_madr_optional_sections_preserved_byte_identical() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: MADR optional sections
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Original context.
+
+## Considered Options
+
+* Redis
+* Memcached
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Good item
+
+## Pros and Cons of the Options
+
+### Redis
+
+* Good, because fast
+* Bad, because memory
+
+### Memcached
+
+* Good, because simple
+* Bad, because strings only
+
+## More Information
+
+See [MADR](https://adr.github.io/madr/) for details.
+"#;
+        let adr_path = repo.adr_path().join("0002-madr-optional-sections.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "Updated context.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("Updated context."));
+        assert_h2_block_unchanged(&before, &after, "Considered Options");
+        assert_h2_block_unchanged(&before, &after, "Decision Outcome");
+        assert_h2_block_unchanged(&before, &after, "Pros and Cons of the Options");
+        assert_h2_block_unchanged(&before, &after, "More Information");
+    }
+
+    #[test]
+    fn test_update_unchanged_sections_byte_identical_after_context_patch() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Byte identity check
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Original context.
+
+## Decision Outcome
+
+Intro.
+
+### Consequences
+
+* Good item
+
+### Confirmation
+
+Confirm via tests.
+"#;
+        let adr_path = repo.adr_path().join("0002-byte-identity-check.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "Updated context.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_h2_block_unchanged(&before, &after, "Decision Outcome");
+    }
+
+    #[test]
+    fn test_update_madr_context_patch_does_not_round_trip_lossy_fields() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Lossy parse guard
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Original context.
+
+## Decision Outcome
+
+See [Redis docs](https://redis.io) and use `redis-cli`.
+
+* Chosen option: "Redis"
+* Because it is **fast**
+
+### Consequences
+
+* Good item
+"#;
+        let adr_path = repo.adr_path().join("0002-lossy-parse-guard.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        // Simulate MCP path: get() lossy-parses decision, but we only patch context.
+        adr.context = "Updated context.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_h2_block_unchanged(&before, &after, "Decision Outcome");
+        assert!(after.contains("[Redis docs](https://redis.io)"));
+        assert!(after.contains("`redis-cli`"));
+        assert!(after.contains("**fast**"));
     }
 }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -1930,8 +1930,8 @@ Chosen option: "Redis", because it supports data structures beyond simple key-va
 
     #[test]
     fn test_set_status_via_mapping_preserves_unknown_keys_and_body() {
-        // Mapping rewrite (ADR 0006 / PR #311) re-emits frontmatter YAML and does
-        // not round-trip comments. Unknown keys and the markdown body must survive.
+        // Frontmatter is re-emitted via a YAML Mapping (ADR 0006) and does not
+        // round-trip comments. Unknown keys and the markdown body must survive.
         let temp = TempDir::new().unwrap();
         let repo = Repository::init(temp.path(), None, true).unwrap();
 

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -37,6 +37,28 @@ static FM_CONSULTED_RE: LazyLock<Regex> =
 static FM_INFORMED_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^informed:(?: [^\n]+|\n(?:(?:  - [^\n]+\n)*))").unwrap());
 
+/// Selects which ADR body sections to patch on [`Repository::update`].
+///
+/// `None` for a field means leave that section's on-disk bytes untouched.
+/// `Some(text)` replaces the targeted portion (for MADR 4.0.0 `## Decision Outcome`,
+/// only the intro before `###` subsections unless `consequences` is also set).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BodySectionPatch {
+    /// Patch the context section (`## Context` / `## Context and Problem Statement`).
+    pub context: Option<String>,
+    /// Patch the decision intro (`## Decision` / `## Decision Outcome` body before H3 subsections).
+    pub decision: Option<String>,
+    /// Patch consequences (`## Consequences`, or MADR `### Consequences` under Decision Outcome).
+    pub consequences: Option<String>,
+}
+
+impl BodySectionPatch {
+    /// Returns true when no body sections should be modified.
+    pub fn is_empty(&self) -> bool {
+        self.context.is_none() && self.decision.is_none() && self.consequences.is_none()
+    }
+}
+
 /// A repository of Architecture Decision Records.
 #[derive(Debug)]
 pub struct Repository {
@@ -444,11 +466,12 @@ impl Repository {
 
     /// Update an existing ADR.
     ///
-    /// Updates metadata (status, links, tags, and MADR 4.0.0 frontmatter fields) and
-    /// body sections (context, decision, consequences) in place, preserving the
-    /// on-disk heading names (Nygard/adr-tools or MADR 4.0.0) and any extra
-    /// MADR 4.0.0 sections (e.g. `Considered Options`).
-    pub fn update(&self, adr: &Adr) -> Result<PathBuf> {
+    /// Updates metadata (status, links, tags, and MADR 4.0.0 frontmatter fields) and,
+    /// for each field set in `body`, the matching body section in place.
+    ///
+    /// Unlisted sections are left byte-for-byte unchanged on disk, including MADR
+    /// `### Consequences` / `### Confirmation` subsections under `## Decision Outcome`.
+    pub fn update(&self, adr: &Adr, body: BodySectionPatch) -> Result<PathBuf> {
         let path = adr
             .path
             .clone()
@@ -462,7 +485,11 @@ impl Repository {
             self.update_legacy_metadata(adr, &content)?
         };
 
-        let updated = self.update_body_sections(adr, &content)?;
+        let updated = if body.is_empty() {
+            content
+        } else {
+            self.update_body_sections(&content, &body)?
+        };
         fs::write(&path, updated)?;
 
         Ok(path)
@@ -672,11 +699,8 @@ impl Repository {
         Ok(result)
     }
 
-    /// Surgically replace context/decision/consequences section bodies in an ADR file.
-    ///
-    /// Preserves the original section headings (Nygard/adr-tools or MADR 4.0.0) and
-    /// all other content.
-    fn update_body_sections(&self, adr: &Adr, content: &str) -> Result<String> {
+    /// Patch only the body sections listed in `patch`, preserving everything else.
+    fn update_body_sections(&self, content: &str, patch: &BodySectionPatch) -> Result<String> {
         let lines: Vec<&str> = content.lines().collect();
         let mut result = String::with_capacity(content.len());
         let mut i = 0;
@@ -684,23 +708,44 @@ impl Repository {
         while i < lines.len() {
             let line = lines[i];
             if let Some(heading_text) = line.strip_prefix("## ")
-                && crate::parse::canonical_section_field(heading_text.trim()).is_some()
+                && let Some(field) = crate::parse::canonical_section_field(heading_text.trim())
             {
                 result.push_str(line);
                 result.push('\n');
                 i += 1;
+                let body_end = Self::next_h2_index(&lines, i);
 
-                // Skip the original section body up to the next H2 heading.
-                while i < lines.len() && !lines[i].starts_with("## ") {
-                    i += 1;
+                match field {
+                    "context" => {
+                        if let Some(ref text) = patch.context {
+                            Self::write_section_body(&mut result, text);
+                        } else {
+                            Self::append_lines(&mut result, &lines, i, body_end, content);
+                        }
+                    }
+                    "decision" => {
+                        Self::patch_decision_section(
+                            &mut result,
+                            &lines,
+                            content,
+                            i,
+                            body_end,
+                            patch,
+                        );
+                    }
+                    "consequences" => {
+                        if let Some(ref text) = patch.consequences {
+                            Self::write_section_body(&mut result, text);
+                        } else {
+                            Self::append_lines(&mut result, &lines, i, body_end, content);
+                        }
+                    }
+                    _ => {
+                        Self::append_lines(&mut result, &lines, i, body_end, content);
+                    }
                 }
 
-                let new_body = Self::section_content_for_heading(heading_text.trim(), adr);
-                result.push('\n');
-                result.push_str(new_body);
-                if !new_body.ends_with('\n') {
-                    result.push('\n');
-                }
+                i = body_end;
                 continue;
             }
 
@@ -718,13 +763,109 @@ impl Repository {
         Ok(result)
     }
 
-    fn section_content_for_heading<'a>(heading: &str, adr: &'a Adr) -> &'a str {
-        match crate::parse::canonical_section_field(heading) {
-            Some("context") => &adr.context,
-            Some("decision") => &adr.decision,
-            Some("consequences") => &adr.consequences,
-            _ => "",
+    fn next_h2_index(lines: &[&str], start: usize) -> usize {
+        lines[start..]
+            .iter()
+            .position(|l| l.starts_with("## "))
+            .map(|p| start + p)
+            .unwrap_or(lines.len())
+    }
+
+    fn append_lines(result: &mut String, lines: &[&str], start: usize, end: usize, content: &str) {
+        for (offset, line) in lines[start..end].iter().enumerate() {
+            result.push_str(line);
+            if start + offset < end - 1 || content.ends_with('\n') {
+                result.push('\n');
+            }
         }
+    }
+
+    fn write_section_body(result: &mut String, text: &str) {
+        result.push('\n');
+        result.push_str(text);
+        if !text.ends_with('\n') {
+            result.push('\n');
+        }
+    }
+
+    fn is_consequences_h3(line: &str) -> bool {
+        line.strip_prefix("### ")
+            .is_some_and(|title| title.trim().eq_ignore_ascii_case("consequences"))
+    }
+
+    /// Patch `## Decision` / `## Decision Outcome`, preserving MADR H3 subsections
+    /// unless `patch.decision` or `patch.consequences` targets them.
+    fn patch_decision_section(
+        result: &mut String,
+        lines: &[&str],
+        content: &str,
+        body_start: usize,
+        body_end: usize,
+        patch: &BodySectionPatch,
+    ) {
+        if patch.decision.is_none() && patch.consequences.is_none() {
+            Self::append_lines(result, lines, body_start, body_end, content);
+            return;
+        }
+
+        let body = &lines[body_start..body_end];
+        let first_h3 = body.iter().position(|l| l.starts_with("### "));
+        let intro_end = first_h3.map(|idx| body_start + idx).unwrap_or(body_end);
+
+        if let Some(ref text) = patch.decision {
+            Self::write_section_body(result, text);
+        } else {
+            Self::append_lines(result, lines, body_start, intro_end, content);
+        }
+
+        if intro_end >= body_end {
+            if let Some(ref text) = patch.consequences {
+                Self::write_madr_consequences_subsection(result, text);
+            }
+            return;
+        }
+
+        let mut j = intro_end;
+        let mut consequences_written = false;
+
+        while j < body_end {
+            if !lines[j].starts_with("### ") {
+                j += 1;
+                continue;
+            }
+
+            let sub_start = j;
+            let sub_end = lines[sub_start + 1..body_end]
+                .iter()
+                .position(|l| l.starts_with("## ") || l.starts_with("### "))
+                .map(|p| sub_start + 1 + p)
+                .unwrap_or(body_end);
+
+            if Self::is_consequences_h3(lines[sub_start]) {
+                consequences_written = true;
+                if let Some(ref text) = patch.consequences {
+                    result.push_str(lines[sub_start]);
+                    result.push('\n');
+                    Self::write_section_body(result, text);
+                    j = sub_end;
+                    continue;
+                }
+            }
+
+            Self::append_lines(result, lines, sub_start, sub_end, content);
+            j = sub_end;
+        }
+
+        if let Some(ref text) = patch.consequences
+            && !consequences_written
+        {
+            Self::write_madr_consequences_subsection(result, text);
+        }
+    }
+
+    fn write_madr_consequences_subsection(result: &mut String, text: &str) {
+        result.push_str("### Consequences\n");
+        Self::write_section_body(result, text);
     }
 
     /// Format links as YAML block for frontmatter insertion.
@@ -1393,7 +1534,7 @@ default_status = "draft"
         let mut adr = repo.get(1).unwrap();
         adr.status = AdrStatus::Deprecated;
 
-        repo.update(&adr).unwrap();
+        repo.update(&adr, BodySectionPatch::default()).unwrap();
 
         let updated = repo.get(1).unwrap();
         assert_eq!(updated.status, AdrStatus::Deprecated);
@@ -1408,7 +1549,7 @@ default_status = "draft"
         let original_title = adr.title.clone();
         adr.status = AdrStatus::Deprecated;
 
-        repo.update(&adr).unwrap();
+        repo.update(&adr, BodySectionPatch::default()).unwrap();
 
         let updated = repo.get(1).unwrap();
         assert_eq!(updated.title, original_title);
@@ -2060,7 +2201,14 @@ Chosen option: "Redis", because it supports data structures beyond simple key-va
 
         let mut adr = repo.get(2).unwrap();
         adr.context = "Updated context text.".into();
-        repo.update(&adr).unwrap();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context text.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let result = fs::read_to_string(&adr_path).unwrap();
 
@@ -2070,9 +2218,109 @@ Chosen option: "Redis", because it supports data structures beyond simple key-va
         assert!(result.contains("* Memcached"));
         assert!(result.contains("## Decision Outcome"));
         assert!(result.contains("Chosen option: \"Redis\""));
+        assert!(result.contains("### Consequences"));
+        assert!(result.contains("* Good, because it provides pub/sub"));
         assert!(!result.contains("What is the change that we're proposing"));
         assert!(!result.contains("## Context\n"));
         assert!(!result.contains("## Decision\n"));
+    }
+
+    #[test]
+    fn test_update_madr_context_preserves_decision_h3_subsections() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let madr_content = r#"---
+number: 2
+title: Use Redis
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Original context.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Good, because it provides pub/sub
+* Bad, because it needs memory
+
+### Confirmation
+
+We will confirm via load tests.
+"#;
+        let adr_path = repo.adr_path().join("0002-use-redis.md");
+        fs::write(&adr_path, madr_content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "Updated context only.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context only.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let result = fs::read_to_string(&adr_path).unwrap();
+        assert!(result.contains("Updated context only."));
+        assert!(result.contains("Chosen option: \"Redis\", because it is fast."));
+        assert!(result.contains("### Consequences"));
+        assert!(result.contains("* Good, because it provides pub/sub"));
+        assert!(result.contains("* Bad, because it needs memory"));
+        assert!(result.contains("### Confirmation"));
+        assert!(result.contains("We will confirm via load tests."));
+    }
+
+    #[test]
+    fn test_update_madr_consequences_patches_h3_subsection() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let madr_content = r#"---
+number: 2
+title: Use Redis
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Old consequence
+"#;
+        let adr_path = repo.adr_path().join("0002-use-redis.md");
+        fs::write(&adr_path, madr_content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.consequences = "* New consequence".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                consequences: Some("* New consequence".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let result = fs::read_to_string(&adr_path).unwrap();
+        assert!(result.contains("Chosen option: \"Redis\", because it is fast."));
+        assert!(result.contains("### Consequences"));
+        assert!(result.contains("* New consequence"));
+        assert!(!result.contains("* Old consequence"));
     }
 
     /// MADR 4.0.0 section bodies must round-trip through parse → update → parse.
@@ -2101,7 +2349,14 @@ We will use PostgreSQL 16.
 
         let mut adr = repo.get(2).unwrap();
         adr.context = "Updated context only.".into();
-        repo.update(&adr).unwrap();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context only.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let reloaded = repo.get(2).unwrap();
         assert_eq!(reloaded.context, "Updated context only.");

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -793,6 +793,11 @@ impl Repository {
             .is_some_and(|title| title.trim().eq_ignore_ascii_case("consequences"))
     }
 
+    fn is_consequences_h2(line: &str) -> bool {
+        line.strip_prefix("## ")
+            .is_some_and(|title| title.trim().eq_ignore_ascii_case("consequences"))
+    }
+
     /// Patch `## Decision` / `## Decision Outcome`, preserving MADR H3 subsections
     /// unless `patch.decision` or `patch.consequences` targets them.
     fn patch_decision_section(
@@ -808,6 +813,19 @@ impl Repository {
             return;
         }
 
+        // Nygard-style ADRs use a top-level `## Consequences` H2; that section is
+        // patched separately. Leave Decision bytes untouched when only consequences
+        // is set and a Consequences H2 exists later in the file.
+        if patch.decision.is_none()
+            && patch.consequences.is_some()
+            && lines[body_end..]
+                .iter()
+                .any(|l| Self::is_consequences_h2(l))
+        {
+            Self::append_lines(result, lines, body_start, body_end, content);
+            return;
+        }
+
         let body = &lines[body_start..body_end];
         let first_h3 = body.iter().position(|l| l.starts_with("### "));
         let intro_end = first_h3.map(|idx| body_start + idx).unwrap_or(body_end);
@@ -819,7 +837,11 @@ impl Repository {
         }
 
         if intro_end >= body_end {
-            if let Some(ref text) = patch.consequences {
+            if let Some(ref text) = patch.consequences
+                && !lines[body_end..]
+                    .iter()
+                    .any(|l| Self::is_consequences_h2(l))
+            {
                 Self::write_madr_consequences_subsection(result, text);
             }
             return;
@@ -858,6 +880,9 @@ impl Repository {
 
         if let Some(ref text) = patch.consequences
             && !consequences_written
+            && !lines[body_end..]
+                .iter()
+                .any(|l| Self::is_consequences_h2(l))
         {
             Self::write_madr_consequences_subsection(result, text);
         }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -6,36 +6,11 @@ use crate::{
 };
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
-use regex::Regex;
+use serde_yaml_neo::{Mapping, Value};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 use walkdir::WalkDir;
-
-/// Regex for matching the status line in YAML frontmatter.
-static FM_STATUS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^status:\s*.*$").unwrap());
-
-/// Regex for matching the links block in YAML frontmatter (multi-line).
-static FM_LINKS_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?m)^links:\n(?:(?:  .+\n)*)").unwrap());
-
-/// Regex for matching the tags block in YAML frontmatter (multi-line).
-static FM_TAGS_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?m)^tags:\n(?:(?:  .+\n)*)").unwrap());
-
-/// Regex for matching MADR 4.0.0 `decision-makers` in YAML frontmatter (scalar or list).
-static FM_DECISION_MAKERS_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?m)^decision-makers:(?: [^\n]+|\n(?:(?:  - [^\n]+\n)*))").unwrap()
-});
-
-/// Regex for matching MADR 4.0.0 `consulted` in YAML frontmatter (scalar or list).
-static FM_CONSULTED_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?m)^consulted:(?: [^\n]+|\n(?:(?:  - [^\n]+\n)*))").unwrap());
-
-/// Regex for matching MADR 4.0.0 `informed` in YAML frontmatter (scalar or list).
-static FM_INFORMED_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?m)^informed:(?: [^\n]+|\n(?:(?:  - [^\n]+\n)*))").unwrap());
 
 /// Selects which ADR body sections to patch on [`Repository::update`].
 ///
@@ -546,11 +521,15 @@ impl Repository {
         Ok(path)
     }
 
-    /// Surgically update metadata fields in a YAML frontmatter file.
+    /// Update managed metadata fields in a YAML frontmatter file.
     ///
-    /// Replaces only `status:`, `links:`, and `tags:` blocks in the frontmatter.
-    /// YAML comments (e.g., SPDX headers), unknown fields, and the entire
-    /// markdown body are preserved untouched.
+    /// Parses the frontmatter into a YAML [`Mapping`], mutates managed keys
+    /// (`status`, `links`, `tags`, and MADR people fields), and re-emits the
+    /// mapping. Unknown keys are preserved; the markdown body is untouched.
+    /// When no managed field changes, the original file bytes are returned.
+    ///
+    /// Re-emitting via a standard YAML parser may drop YAML comments (e.g. SPDX
+    /// headers) when any managed field changes — see ADR 0006.
     fn update_frontmatter_metadata(&self, adr: &Adr, content: &str) -> Result<String> {
         // Split into frontmatter and body at the closing `---`
         let Some(rest) = content.strip_prefix("---\n") else {
@@ -577,72 +556,58 @@ impl Repository {
         let yaml_block = &rest[..end_idx + 1]; // include trailing \n
         let after_yaml = &rest[end_idx..]; // starts with \n---\n...
 
-        // 1. Replace status line
-        let new_status = format!("status: {}", adr.status.to_string().to_lowercase());
-        let yaml_block = FM_STATUS_RE.replace(yaml_block, new_status.as_str());
-
-        // 2. Replace or remove links block
-        let links_yaml = Self::format_links_yaml(&adr.links);
-        let yaml_block = if FM_LINKS_RE.is_match(&yaml_block) {
-            FM_LINKS_RE
-                .replace(&yaml_block, links_yaml.as_str())
-                .into_owned()
-        } else if !links_yaml.is_empty() {
-            // Append links before end of frontmatter
-            let mut s = yaml_block.into_owned();
-            if !s.ends_with('\n') {
-                s.push('\n');
-            }
-            s.push_str(&links_yaml);
-            s
-        } else {
-            yaml_block.into_owned()
+        let parsed: Value = serde_yaml_neo::from_str(yaml_block)?;
+        let Value::Mapping(mut map) = parsed else {
+            return Err(Error::InvalidFormat {
+                path: Default::default(),
+                reason: "Frontmatter YAML must be a mapping".into(),
+            });
         };
 
-        // 3. Replace or remove tags block
-        let tags_yaml = Self::format_tags_yaml(&adr.tags);
-        let yaml_block = if FM_TAGS_RE.is_match(&yaml_block) {
-            FM_TAGS_RE
-                .replace(&yaml_block, tags_yaml.as_str())
-                .into_owned()
-        } else if !tags_yaml.is_empty() {
-            let mut s = yaml_block;
-            if !s.ends_with('\n') {
-                s.push('\n');
-            }
-            s.push_str(&tags_yaml);
-            s
-        } else {
-            yaml_block
-        };
+        let mut dirty = false;
 
-        // 4. Replace or remove MADR 4.0.0 metadata blocks when values changed
-        let on_disk_people = Self::parse_people_fields_yaml(&yaml_block);
-        let mut yaml_block = yaml_block;
-        if on_disk_people.decision_makers != adr.decision_makers {
-            yaml_block = Self::replace_optional_yaml_block(
-                &yaml_block,
-                &FM_DECISION_MAKERS_RE,
-                Self::format_string_list_yaml("decision-makers", &adr.decision_makers),
-            );
-        }
-        if on_disk_people.consulted != adr.consulted {
-            yaml_block = Self::replace_optional_yaml_block(
-                &yaml_block,
-                &FM_CONSULTED_RE,
-                Self::format_string_list_yaml("consulted", &adr.consulted),
-            );
-        }
-        if on_disk_people.informed != adr.informed {
-            yaml_block = Self::replace_optional_yaml_block(
-                &yaml_block,
-                &FM_INFORMED_RE,
-                Self::format_string_list_yaml("informed", &adr.informed),
-            );
+        // 1. status
+        let status_val = Value::String(adr.status.to_string().to_lowercase());
+        if map.get(Self::yaml_str_key("status")) != Some(&status_val) {
+            map.insert(Self::yaml_str_key("status"), status_val);
+            dirty = true;
         }
 
-        let yaml_block = yaml_block.trim_end_matches('\n');
-        Ok(format!("---\n{}{}", yaml_block, after_yaml))
+        // 2. links
+        if Self::set_yaml_sequence_field(&mut map, "links", &adr.links)? {
+            dirty = true;
+        }
+
+        // 3. tags
+        if Self::set_yaml_string_list_field(&mut map, "tags", &adr.tags)? {
+            dirty = true;
+        }
+
+        // 4. MADR people fields — skip-if-unchanged guard (removed in a follow-up).
+        let on_disk_people = Self::parse_people_fields_yaml(yaml_block);
+        if on_disk_people.decision_makers != adr.decision_makers
+            && Self::set_yaml_string_list_field(&mut map, "decision-makers", &adr.decision_makers)?
+        {
+            dirty = true;
+        }
+        if on_disk_people.consulted != adr.consulted
+            && Self::set_yaml_string_list_field(&mut map, "consulted", &adr.consulted)?
+        {
+            dirty = true;
+        }
+        if on_disk_people.informed != adr.informed
+            && Self::set_yaml_string_list_field(&mut map, "informed", &adr.informed)?
+        {
+            dirty = true;
+        }
+
+        if !dirty {
+            return Ok(content.to_string());
+        }
+
+        let new_yaml = serde_yaml_neo::to_string(&Value::Mapping(map))?;
+        let new_yaml = new_yaml.trim_end_matches('\n');
+        Ok(format!("---\n{new_yaml}{after_yaml}"))
     }
 
     /// Surgically update metadata in a legacy (no-frontmatter) ADR file.
@@ -989,63 +954,31 @@ impl Repository {
         Self::write_section_body(result, text);
     }
 
-    /// Format links as YAML block for frontmatter insertion.
-    fn format_links_yaml(links: &[AdrLink]) -> String {
-        if links.is_empty() {
-            return String::new();
-        }
-        let mut s = String::from("links:\n");
-        for link in links {
-            let kind_str = match &link.kind {
-                LinkKind::Supersedes => "supersedes",
-                LinkKind::SupersededBy => "supersededby",
-                LinkKind::Amends => "amends",
-                LinkKind::AmendedBy => "amendedby",
-                LinkKind::RelatesTo => "relatesto",
-                LinkKind::Custom(c) => c.as_str(),
-            };
-            s.push_str(&format!(
-                "  - target: {}\n    kind: {}\n",
-                link.target, kind_str
-            ));
-            if let Some(description) = &link.description {
-                s.push_str(&format!("    description: {}\n", description));
-            }
-        }
-        s
+    fn yaml_str_key(key: &str) -> Value {
+        Value::String(key.to_string())
     }
 
-    /// Format tags as YAML block for frontmatter insertion.
-    fn format_tags_yaml(tags: &[String]) -> String {
-        Self::format_string_list_yaml("tags", tags)
-    }
-
-    /// Format a YAML list field (or remove it when empty).
-    fn format_string_list_yaml(field: &str, values: &[String]) -> String {
+    /// Set or remove a sequence-valued frontmatter field. Returns true if `map` changed.
+    fn set_yaml_sequence_field<T: serde::Serialize>(
+        map: &mut Mapping,
+        key: &str,
+        values: &[T],
+    ) -> Result<bool> {
+        let key = Self::yaml_str_key(key);
         if values.is_empty() {
-            return String::new();
+            return Ok(map.remove(&key).is_some());
         }
-        let mut s = format!("{field}:\n");
-        for value in values {
-            s.push_str(&format!("  - {value}\n"));
+        let desired = serde_yaml_neo::to_value(values)?;
+        if map.get(&key) == Some(&desired) {
+            return Ok(false);
         }
-        s
+        map.insert(key, desired);
+        Ok(true)
     }
 
-    /// Replace, remove, or append an optional YAML block in frontmatter.
-    fn replace_optional_yaml_block(yaml_block: &str, regex: &Regex, new_yaml: String) -> String {
-        if regex.is_match(yaml_block) {
-            regex.replace(yaml_block, new_yaml.as_str()).into_owned()
-        } else if !new_yaml.is_empty() {
-            let mut s = yaml_block.to_string();
-            if !s.ends_with('\n') {
-                s.push('\n');
-            }
-            s.push_str(&new_yaml);
-            s
-        } else {
-            yaml_block.to_string()
-        }
+    /// Set or remove a string-list frontmatter field. Returns true if `map` changed.
+    fn set_yaml_string_list_field(map: &mut Mapping, key: &str, values: &[String]) -> Result<bool> {
+        Self::set_yaml_sequence_field(map, key, values)
     }
 
     fn parse_people_fields_yaml(yaml_block: &str) -> PeopleFieldsYaml {
@@ -1962,17 +1895,19 @@ Chosen option: "Redis", because it supports data structures beyond simple key-va
     }
 
     #[test]
-    fn test_set_status_preserves_yaml_comments() {
+    fn test_set_status_via_mapping_preserves_unknown_keys_and_body() {
+        // Mapping rewrite (ADR 0006 / PR #311) re-emits frontmatter YAML and does
+        // not round-trip comments. Unknown keys and the markdown body must survive.
         let temp = TempDir::new().unwrap();
         let repo = Repository::init(temp.path(), None, true).unwrap();
 
         let content_with_comments = r#"---
 # SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2026 Example Corp
 number: 2
 title: Use MADR format
 date: 2026-01-15
 status: proposed
+custom-meta: keep-me
 ---
 
 ## Context and Problem Statement
@@ -1990,16 +1925,15 @@ Use MADR 4.0.0.
 
         let result = fs::read_to_string(&adr_path).unwrap();
 
-        // YAML comments must be preserved
-        assert!(
-            result.contains("# SPDX-License-Identifier: MIT"),
-            "SPDX comment was destroyed"
-        );
-        assert!(
-            result.contains("# SPDX-FileCopyrightText: 2026 Example Corp"),
-            "Copyright comment was destroyed"
-        );
         assert!(result.contains("status: accepted"));
+        assert!(
+            result.contains("custom-meta: keep-me"),
+            "unknown frontmatter key was dropped\n{result}"
+        );
+        assert!(
+            result.contains("## Decision Outcome") && result.contains("Use MADR 4.0.0."),
+            "markdown body must survive\n{result}"
+        );
     }
 
     #[test]
@@ -2536,8 +2470,11 @@ Context.
 
         let result = fs::read_to_string(&adr_path).unwrap();
         assert!(result.contains("tags:"));
-        assert!(result.contains("  - security"));
-        assert!(result.contains("  - api"));
+        // serde_yaml emits block sequences at column 0; both indent styles are valid.
+        assert!(
+            result.contains("- security") && result.contains("- api"),
+            "tags missing from frontmatter\n{result}"
+        );
         // Body preserved
         assert!(result.contains("## Context\n\nContext."));
     }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -578,24 +578,26 @@ impl Repository {
             dirty = true;
         }
 
-        // 3. tags
-        if Self::set_yaml_string_list_field(&mut map, "tags", &adr.tags)? {
+        // 3. tags (string-or-list on disk)
+        if !Self::yaml_string_list_matches(&map, "tags", &adr.tags)
+            && Self::set_yaml_string_list_field(&mut map, "tags", &adr.tags)?
+        {
             dirty = true;
         }
 
-        // 4. MADR people fields — skip-if-unchanged guard (removed in a follow-up).
-        let on_disk_people = Self::parse_people_fields_yaml(yaml_block);
-        if on_disk_people.decision_makers != adr.decision_makers
+        // 4. MADR people fields (string-or-list on disk; leave Value untouched when
+        // semantically equal so block scalars survive no-op metadata writes).
+        if !Self::yaml_string_list_matches(&map, "decision-makers", &adr.decision_makers)
             && Self::set_yaml_string_list_field(&mut map, "decision-makers", &adr.decision_makers)?
         {
             dirty = true;
         }
-        if on_disk_people.consulted != adr.consulted
+        if !Self::yaml_string_list_matches(&map, "consulted", &adr.consulted)
             && Self::set_yaml_string_list_field(&mut map, "consulted", &adr.consulted)?
         {
             dirty = true;
         }
-        if on_disk_people.informed != adr.informed
+        if !Self::yaml_string_list_matches(&map, "informed", &adr.informed)
             && Self::set_yaml_string_list_field(&mut map, "informed", &adr.informed)?
         {
             dirty = true;
@@ -981,32 +983,22 @@ impl Repository {
         Self::set_yaml_sequence_field(map, key, values)
     }
 
-    fn parse_people_fields_yaml(yaml_block: &str) -> PeopleFieldsYaml {
-        serde_yaml_neo::from_str::<PeopleFieldsYamlPartial>(yaml_block)
-            .map(|partial| PeopleFieldsYaml {
-                decision_makers: partial.decision_makers,
-                consulted: partial.consulted,
-                informed: partial.informed,
-            })
-            .unwrap_or_default()
+    /// Whether a frontmatter string-or-list field already matches `desired`
+    /// (same rules as `Adr`'s `string_or_vec` deserializer).
+    fn yaml_string_list_matches(map: &Mapping, key: &str, desired: &[String]) -> bool {
+        match map.get(Self::yaml_str_key(key)) {
+            None | Some(Value::Null) => desired.is_empty(),
+            Some(Value::String(s)) => desired.len() == 1 && desired[0] == *s,
+            Some(Value::Sequence(seq)) => {
+                let got: Option<Vec<&str>> = seq.iter().map(|v| v.as_str()).collect();
+                match got {
+                    Some(got) => got == desired.iter().map(String::as_str).collect::<Vec<_>>(),
+                    None => false,
+                }
+            }
+            Some(_) => false,
+        }
     }
-}
-
-#[derive(Debug, Default, PartialEq, Eq)]
-struct PeopleFieldsYaml {
-    decision_makers: Vec<String>,
-    consulted: Vec<String>,
-    informed: Vec<String>,
-}
-
-#[derive(serde::Deserialize, Default)]
-struct PeopleFieldsYamlPartial {
-    #[serde(rename = "decision-makers", default)]
-    decision_makers: Vec<String>,
-    #[serde(default)]
-    consulted: Vec<String>,
-    #[serde(default)]
-    informed: Vec<String>,
 }
 
 /// Count existing ADR files in a directory.

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -466,10 +466,14 @@ impl Repository {
 
     /// Update an existing ADR.
     ///
-    /// Updates metadata (status, links, tags, and MADR 4.0.0 frontmatter fields) and,
-    /// for each field set in `body`, the matching body section in place.
+    /// When `body` is non-empty, only the listed body sections are patched in place;
+    /// metadata bytes on disk are left unchanged. When `body` is empty, metadata
+    /// (status, links, tags, and MADR 4.0.0 frontmatter fields) is updated via the
+    /// same path as [`Self::update_metadata`].
     ///
-    /// Unlisted sections are left byte-for-byte unchanged on disk, including MADR
+    /// `adr.title` and `adr.date` are not written by this method.
+    ///
+    /// Unlisted body sections are left byte-for-byte unchanged on disk, including MADR
     /// `### Consequences` / `### Confirmation` subsections under `## Decision Outcome`.
     pub fn update(&self, adr: &Adr, body: BodySectionPatch) -> Result<PathBuf> {
         let path = adr
@@ -479,10 +483,14 @@ impl Repository {
 
         let content = fs::read_to_string(&path)?;
 
-        let content = if content.starts_with("---\n") {
-            self.update_frontmatter_metadata(adr, &content)?
+        let content = if body.is_empty() {
+            if content.starts_with("---\n") {
+                self.update_frontmatter_metadata(adr, &content)?
+            } else {
+                self.update_legacy_metadata(adr, &content)?
+            }
         } else {
-            self.update_legacy_metadata(adr, &content)?
+            content
         };
 
         let updated = if body.is_empty() {
@@ -608,22 +616,30 @@ impl Repository {
             yaml_block
         };
 
-        // 4. Replace or remove MADR 4.0.0 metadata blocks
-        let yaml_block = Self::replace_optional_yaml_block(
-            &yaml_block,
-            &FM_DECISION_MAKERS_RE,
-            Self::format_string_list_yaml("decision-makers", &adr.decision_makers),
-        );
-        let yaml_block = Self::replace_optional_yaml_block(
-            &yaml_block,
-            &FM_CONSULTED_RE,
-            Self::format_string_list_yaml("consulted", &adr.consulted),
-        );
-        let yaml_block = Self::replace_optional_yaml_block(
-            &yaml_block,
-            &FM_INFORMED_RE,
-            Self::format_string_list_yaml("informed", &adr.informed),
-        );
+        // 4. Replace or remove MADR 4.0.0 metadata blocks when values changed
+        let on_disk_people = Self::parse_people_fields_yaml(&yaml_block);
+        let mut yaml_block = yaml_block;
+        if on_disk_people.decision_makers != adr.decision_makers {
+            yaml_block = Self::replace_optional_yaml_block(
+                &yaml_block,
+                &FM_DECISION_MAKERS_RE,
+                Self::format_string_list_yaml("decision-makers", &adr.decision_makers),
+            );
+        }
+        if on_disk_people.consulted != adr.consulted {
+            yaml_block = Self::replace_optional_yaml_block(
+                &yaml_block,
+                &FM_CONSULTED_RE,
+                Self::format_string_list_yaml("consulted", &adr.consulted),
+            );
+        }
+        if on_disk_people.informed != adr.informed {
+            yaml_block = Self::replace_optional_yaml_block(
+                &yaml_block,
+                &FM_INFORMED_RE,
+                Self::format_string_list_yaml("informed", &adr.informed),
+            );
+        }
 
         let yaml_block = yaml_block.trim_end_matches('\n');
         Ok(format!("---\n{}{}", yaml_block, after_yaml))
@@ -704,10 +720,14 @@ impl Repository {
         let lines: Vec<&str> = content.lines().collect();
         let mut result = String::with_capacity(content.len());
         let mut i = 0;
+        let mut found_context = patch.context.is_none();
+        let mut found_decision = patch.decision.is_none();
+        let mut found_consequences = patch.consequences.is_none();
 
         while i < lines.len() {
             let line = lines[i];
-            if let Some(heading_text) = line.strip_prefix("## ")
+            if Self::is_h2_outside_fence(&lines, i)
+                && let Some(heading_text) = line.strip_prefix("## ")
                 && let Some(field) = crate::parse::canonical_section_field(heading_text.trim())
             {
                 result.push_str(line);
@@ -717,6 +737,9 @@ impl Repository {
 
                 match field {
                     "context" => {
+                        if patch.context.is_some() {
+                            found_context = true;
+                        }
                         if let Some(ref text) = patch.context {
                             Self::write_section_body(&mut result, text);
                         } else {
@@ -724,7 +747,7 @@ impl Repository {
                         }
                     }
                     "decision" => {
-                        Self::patch_decision_section(
+                        let (decision_found, consequences_applied) = Self::patch_decision_section(
                             &mut result,
                             &lines,
                             content,
@@ -732,8 +755,17 @@ impl Repository {
                             body_end,
                             patch,
                         );
+                        if decision_found {
+                            found_decision = true;
+                        }
+                        if consequences_applied {
+                            found_consequences = true;
+                        }
                     }
                     "consequences" => {
+                        if patch.consequences.is_some() {
+                            found_consequences = true;
+                        }
                         if let Some(ref text) = patch.consequences {
                             Self::write_section_body(&mut result, text);
                         } else {
@@ -756,6 +788,25 @@ impl Repository {
             i += 1;
         }
 
+        if !found_context {
+            return Err(Error::InvalidFormat {
+                path: PathBuf::new(),
+                reason: "context patch requested but no matching section heading found".into(),
+            });
+        }
+        if !found_decision {
+            return Err(Error::InvalidFormat {
+                path: PathBuf::new(),
+                reason: "decision patch requested but no matching section heading found".into(),
+            });
+        }
+        if !found_consequences {
+            return Err(Error::InvalidFormat {
+                path: PathBuf::new(),
+                reason: "consequences patch requested but no matching section heading found".into(),
+            });
+        }
+
         if content.ends_with('\n') && !result.ends_with('\n') {
             result.push('\n');
         }
@@ -763,18 +814,42 @@ impl Repository {
         Ok(result)
     }
 
+    fn is_fence_delimiter(line: &str) -> bool {
+        let trimmed = line.trim();
+        trimmed.starts_with("```") || trimmed.starts_with("~~~")
+    }
+
+    fn in_fence_at_line(lines: &[&str], index: usize) -> bool {
+        let mut in_fence = false;
+        for line in &lines[..index] {
+            if Self::is_fence_delimiter(line) {
+                in_fence = !in_fence;
+            }
+        }
+        in_fence
+    }
+
+    fn is_h2_outside_fence(lines: &[&str], index: usize) -> bool {
+        lines[index].starts_with("## ") && !Self::in_fence_at_line(lines, index)
+    }
+
+    fn is_h3_outside_fence(lines: &[&str], index: usize) -> bool {
+        lines[index].starts_with("### ") && !Self::in_fence_at_line(lines, index)
+    }
+
     fn next_h2_index(lines: &[&str], start: usize) -> usize {
         lines[start..]
             .iter()
-            .position(|l| l.starts_with("## "))
-            .map(|p| start + p)
+            .enumerate()
+            .find(|(offset, _)| Self::is_h2_outside_fence(lines, start + offset))
+            .map(|(offset, _)| start + offset)
             .unwrap_or(lines.len())
     }
 
     fn append_lines(result: &mut String, lines: &[&str], start: usize, end: usize, content: &str) {
         for (offset, line) in lines[start..end].iter().enumerate() {
             result.push_str(line);
-            if start + offset < end - 1 || content.ends_with('\n') {
+            if start + offset < end - 1 || end < lines.len() || content.ends_with('\n') {
                 result.push('\n');
             }
         }
@@ -800,6 +875,8 @@ impl Repository {
 
     /// Patch `## Decision` / `## Decision Outcome`, preserving MADR H3 subsections
     /// unless `patch.decision` or `patch.consequences` targets them.
+    ///
+    /// Returns `(found_decision, consequences_applied)`.
     fn patch_decision_section(
         result: &mut String,
         lines: &[&str],
@@ -807,28 +884,32 @@ impl Repository {
         body_start: usize,
         body_end: usize,
         patch: &BodySectionPatch,
-    ) {
+    ) -> (bool, bool) {
         if patch.decision.is_none() && patch.consequences.is_none() {
             Self::append_lines(result, lines, body_start, body_end, content);
-            return;
+            return (false, false);
         }
+
+        let mut consequences_applied = false;
 
         // Nygard-style ADRs use a top-level `## Consequences` H2; that section is
         // patched separately. Leave Decision bytes untouched when only consequences
         // is set and a Consequences H2 exists later in the file.
         if patch.decision.is_none()
             && patch.consequences.is_some()
-            && lines[body_end..]
-                .iter()
-                .any(|l| Self::is_consequences_h2(l))
+            && Self::has_consequences_h2_after(lines, body_end)
         {
             Self::append_lines(result, lines, body_start, body_end, content);
-            return;
+            return (true, false);
         }
 
         let body = &lines[body_start..body_end];
-        let first_h3 = body.iter().position(|l| l.starts_with("### "));
-        let intro_end = first_h3.map(|idx| body_start + idx).unwrap_or(body_end);
+        let first_h3 = body
+            .iter()
+            .enumerate()
+            .find(|(offset, _)| Self::is_h3_outside_fence(lines, body_start + offset))
+            .map(|(offset, _)| body_start + offset);
+        let intro_end = first_h3.unwrap_or(body_end);
 
         if let Some(ref text) = patch.decision {
             Self::write_section_body(result, text);
@@ -838,20 +919,18 @@ impl Repository {
 
         if intro_end >= body_end {
             if let Some(ref text) = patch.consequences
-                && !lines[body_end..]
-                    .iter()
-                    .any(|l| Self::is_consequences_h2(l))
+                && !Self::has_consequences_h2_after(lines, body_end)
             {
                 Self::write_madr_consequences_subsection(result, text);
+                consequences_applied = true;
             }
-            return;
+            return (true, consequences_applied);
         }
 
         let mut j = intro_end;
-        let mut consequences_written = false;
 
         while j < body_end {
-            if !lines[j].starts_with("### ") {
+            if !Self::is_h3_outside_fence(lines, j) {
                 j += 1;
                 continue;
             }
@@ -859,19 +938,23 @@ impl Repository {
             let sub_start = j;
             let sub_end = lines[sub_start + 1..body_end]
                 .iter()
-                .position(|l| l.starts_with("## ") || l.starts_with("### "))
-                .map(|p| sub_start + 1 + p)
+                .enumerate()
+                .find(|(offset, _)| {
+                    let idx = sub_start + 1 + offset;
+                    Self::is_h2_outside_fence(lines, idx) || Self::is_h3_outside_fence(lines, idx)
+                })
+                .map(|(offset, _)| sub_start + 1 + offset)
                 .unwrap_or(body_end);
 
-            if Self::is_consequences_h3(lines[sub_start]) {
-                consequences_written = true;
-                if let Some(ref text) = patch.consequences {
-                    result.push_str(lines[sub_start]);
-                    result.push('\n');
-                    Self::write_section_body(result, text);
-                    j = sub_end;
-                    continue;
-                }
+            if Self::is_consequences_h3(lines[sub_start])
+                && let Some(ref text) = patch.consequences
+            {
+                consequences_applied = true;
+                result.push_str(lines[sub_start]);
+                result.push('\n');
+                Self::write_section_body(result, text);
+                j = sub_end;
+                continue;
             }
 
             Self::append_lines(result, lines, sub_start, sub_end, content);
@@ -879,13 +962,20 @@ impl Repository {
         }
 
         if let Some(ref text) = patch.consequences
-            && !consequences_written
-            && !lines[body_end..]
-                .iter()
-                .any(|l| Self::is_consequences_h2(l))
+            && !consequences_applied
+            && !Self::has_consequences_h2_after(lines, body_end)
         {
             Self::write_madr_consequences_subsection(result, text);
+            consequences_applied = true;
         }
+
+        (true, consequences_applied)
+    }
+
+    fn has_consequences_h2_after(lines: &[&str], start: usize) -> bool {
+        lines[start..].iter().enumerate().any(|(offset, line)| {
+            Self::is_h2_outside_fence(lines, start + offset) && Self::is_consequences_h2(line)
+        })
     }
 
     fn write_madr_consequences_subsection(result: &mut String, text: &str) {
@@ -951,6 +1041,33 @@ impl Repository {
             yaml_block.to_string()
         }
     }
+
+    fn parse_people_fields_yaml(yaml_block: &str) -> PeopleFieldsYaml {
+        serde_yaml_neo::from_str::<PeopleFieldsYamlPartial>(yaml_block)
+            .map(|partial| PeopleFieldsYaml {
+                decision_makers: partial.decision_makers,
+                consulted: partial.consulted,
+                informed: partial.informed,
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct PeopleFieldsYaml {
+    decision_makers: Vec<String>,
+    consulted: Vec<String>,
+    informed: Vec<String>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct PeopleFieldsYamlPartial {
+    #[serde(rename = "decision-makers", default)]
+    decision_makers: Vec<String>,
+    #[serde(default)]
+    consulted: Vec<String>,
+    #[serde(default)]
+    informed: Vec<String>,
 }
 
 /// Count existing ADR files in a directory.
@@ -2605,6 +2722,8 @@ Context.
             Repository::link_href(&target),
             "0003-use-rust-for-backend-services.md"
         );
+    }
+
     // ========== BodySectionPatch preservation tests (issue #310) ==========
 
     /// Extract from `## {heading}` through the line before the next H2 (inclusive).
@@ -3317,5 +3436,203 @@ See [Redis docs](https://redis.io) and use `redis-cli`.
         assert!(after.contains("[Redis docs](https://redis.io)"));
         assert!(after.contains("`redis-cli`"));
         assert!(after.contains("**fast**"));
+    }
+
+    // ========== BodySectionPatch write-path regressions ==========
+
+    #[test]
+    fn test_fence_in_decision_outcome_preserved_on_consequences_patch() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Fenced example in decision
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+```markdown
+## Consequences
+
+Example consequences inside a fence.
+```
+
+Trailing text after the fence.
+
+### Consequences
+
+* Good, because it provides pub/sub
+
+### Confirmation
+
+We will confirm via load tests.
+"#;
+        let adr_path = repo.adr_path().join("0002-fenced-decision-outcome.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = content.to_string();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.consequences = "* Updated consequence".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                consequences: Some("* Updated consequence".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("```markdown"));
+        assert!(after.contains("Example consequences inside a fence."));
+        assert!(after.contains("Trailing text after the fence."));
+        assert!(after.contains("### Confirmation"));
+        assert!(after.contains("We will confirm via load tests."));
+        assert!(after.contains("* Updated consequence"));
+        assert_h2_block_unchanged(&before, &after, "Context and Problem Statement");
+    }
+
+    #[test]
+    fn test_body_patch_preserves_sections_without_trailing_newline() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let content = "# 2. Compact file\n\nDate: 2026-01-15\n\n## Status\n\nAccepted\n\n## Context\n\nOld context.\n\n## Decision\n\nOld decision.\n\n## Consequences\n\nOld consequences.";
+        let adr_path = repo.adr_path().join("0002-no-trailing-newline.md");
+        fs::write(&adr_path, content).unwrap();
+        assert_ne!(fs::read(&adr_path).unwrap().last(), Some(&b'\n'));
+
+        let mut adr = repo.get(2).unwrap();
+        adr.decision = "New decision.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                decision: Some("New decision.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(!after.contains("Old context.## Decision"));
+        let reparsed = repo.get(2).unwrap();
+        assert!(reparsed.decision.contains("New decision."));
+    }
+
+    #[test]
+    fn test_people_field_yaml_unchanged_skip_rewrite() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Zero indent consulted
+date: 2026-01-15
+status: proposed
+consulted:
+- alice
+- bob
+---
+
+## Context
+
+Context.
+"#;
+        let adr_path = repo.adr_path().join("0002-zero-indent-consulted.md");
+        fs::write(&adr_path, content).unwrap();
+        let before = fs::read_to_string(&adr_path).unwrap();
+
+        let adr = repo.get(2).unwrap();
+        repo.update_metadata(&adr).unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn test_body_only_update_preserves_non_canonical_status() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let content = r#"# 2. Non-canonical status
+
+Date: 2026-01-15
+
+## Status
+
+Approved by the architecture board on 2026-01-15.
+
+## Context
+
+Original context.
+
+## Decision
+
+Decision.
+
+## Consequences
+
+Consequences.
+"#;
+        let adr_path = repo.adr_path().join("0002-non-canonical-status.md");
+        fs::write(&adr_path, content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "Updated context.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                context: Some("Updated context.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("Approved by the architecture board"));
+        assert!(after.contains("Updated context."));
+    }
+
+    #[test]
+    fn test_missing_section_patch_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let content = r#"# 2. No decision or consequences sections
+
+Date: 2026-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+Context only.
+"#;
+        let adr_path = repo.adr_path().join("0002-no-consequences.md");
+        fs::write(&adr_path, content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.consequences = "New consequences.".into();
+        let err = repo
+            .update(
+                &adr,
+                BodySectionPatch {
+                    consequences: Some("New consequences.".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("consequences patch requested"));
     }
 }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -989,6 +989,11 @@ impl Repository {
     }
 
     fn write_madr_consequences_subsection(result: &mut String, text: &str) {
+        // append_lines may omit a final newline when the source file has none
+        // and the append ends at EOF; re-establish a separator before the H3.
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
         result.push_str("### Consequences\n");
         Self::write_section_body(result, text);
     }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -747,6 +747,8 @@ impl Repository {
                         }
                     }
                     "decision" => {
+                        let madr_decision_outcome =
+                            heading_text.trim().eq_ignore_ascii_case("Decision Outcome");
                         let (decision_found, consequences_applied) = Self::patch_decision_section(
                             &mut result,
                             &lines,
@@ -754,6 +756,7 @@ impl Repository {
                             i,
                             body_end,
                             patch,
+                            madr_decision_outcome,
                         );
                         if decision_found {
                             found_decision = true;
@@ -884,6 +887,7 @@ impl Repository {
         body_start: usize,
         body_end: usize,
         patch: &BodySectionPatch,
+        madr_decision_outcome: bool,
     ) -> (bool, bool) {
         if patch.decision.is_none() && patch.consequences.is_none() {
             Self::append_lines(result, lines, body_start, body_end, content);
@@ -920,6 +924,7 @@ impl Repository {
         if intro_end >= body_end {
             if let Some(ref text) = patch.consequences
                 && !Self::has_consequences_h2_after(lines, body_end)
+                && madr_decision_outcome
             {
                 Self::write_madr_consequences_subsection(result, text);
                 consequences_applied = true;
@@ -964,6 +969,7 @@ impl Repository {
         if let Some(ref text) = patch.consequences
             && !consequences_applied
             && !Self::has_consequences_h2_after(lines, body_end)
+            && madr_decision_outcome
         {
             Self::write_madr_consequences_subsection(result, text);
             consequences_applied = true;
@@ -3634,5 +3640,90 @@ Context only.
             )
             .unwrap_err();
         assert!(err.to_string().contains("consequences patch requested"));
+    }
+
+    #[test]
+    fn test_nygard_consequences_patch_errors_without_consequences_section() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let content = r#"# 3. Nygard decision without consequences section
+
+Date: 2026-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+Context.
+
+## Decision
+
+We decided X.
+"#;
+        let adr_path = repo.adr_path().join("0003-nygard-no-consequences.md");
+        fs::write(&adr_path, content).unwrap();
+
+        let mut adr = repo.get(3).unwrap();
+        adr.consequences = "New consequences.".into();
+        let err = repo
+            .update(
+                &adr,
+                BodySectionPatch {
+                    consequences: Some("New consequences.".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("consequences patch requested"));
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(!after.contains("### Consequences"));
+        assert!(!after.contains("New consequences."));
+    }
+
+    #[test]
+    fn test_decision_patch_preserves_fence_in_context() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let content = r#"# 4. Fence in context
+
+Date: 2026-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+Example:
+
+```
+## Decision
+not a real heading
+```
+
+## Decision
+
+We decided.
+"#;
+        let adr_path = repo.adr_path().join("0004-fence-in-context.md");
+        fs::write(&adr_path, content).unwrap();
+
+        repo.update(
+            &repo.get(4).unwrap(),
+            BodySectionPatch {
+                decision: Some("Updated decision.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&adr_path).unwrap();
+        assert!(after.contains("## Decision\nnot a real heading"));
+        assert!(after.contains("Updated decision."));
+        assert!(!after.contains("We decided."));
     }
 }

--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -24,6 +24,19 @@ static FM_LINKS_RE: LazyLock<Regex> =
 static FM_TAGS_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^tags:\n(?:(?:  .+\n)*)").unwrap());
 
+/// Regex for matching MADR 4.0.0 `decision-makers` in YAML frontmatter (scalar or list).
+static FM_DECISION_MAKERS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?m)^decision-makers:(?: [^\n]+|\n(?:(?:  - [^\n]+\n)*))").unwrap()
+});
+
+/// Regex for matching MADR 4.0.0 `consulted` in YAML frontmatter (scalar or list).
+static FM_CONSULTED_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^consulted:(?: [^\n]+|\n(?:(?:  - [^\n]+\n)*))").unwrap());
+
+/// Regex for matching MADR 4.0.0 `informed` in YAML frontmatter (scalar or list).
+static FM_INFORMED_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^informed:(?: [^\n]+|\n(?:(?:  - [^\n]+\n)*))").unwrap());
+
 /// A repository of Architecture Decision Records.
 #[derive(Debug)]
 pub struct Repository {
@@ -430,17 +443,27 @@ impl Repository {
     }
 
     /// Update an existing ADR.
+    ///
+    /// Updates metadata (status, links, tags, and MADR 4.0.0 frontmatter fields) and
+    /// body sections (context, decision, consequences) in place, preserving the
+    /// on-disk heading names (Nygard/adr-tools or MADR 4.0.0) and any extra
+    /// MADR 4.0.0 sections (e.g. `Considered Options`).
     pub fn update(&self, adr: &Adr) -> Result<PathBuf> {
         let path = adr
             .path
             .clone()
             .unwrap_or_else(|| self.adr_path().join(adr.filename()));
 
-        let link_titles = self.resolve_link_titles(adr);
-        let content = self
-            .template_engine
-            .render(adr, &self.config, &link_titles)?;
-        fs::write(&path, content)?;
+        let content = fs::read_to_string(&path)?;
+
+        let content = if content.starts_with("---\n") {
+            self.update_frontmatter_metadata(adr, &content)?
+        } else {
+            self.update_legacy_metadata(adr, &content)?
+        };
+
+        let updated = self.update_body_sections(adr, &content)?;
+        fs::write(&path, updated)?;
 
         Ok(path)
     }
@@ -558,6 +581,23 @@ impl Repository {
             yaml_block
         };
 
+        // 4. Replace or remove MADR 4.0.0 metadata blocks
+        let yaml_block = Self::replace_optional_yaml_block(
+            &yaml_block,
+            &FM_DECISION_MAKERS_RE,
+            Self::format_string_list_yaml("decision-makers", &adr.decision_makers),
+        );
+        let yaml_block = Self::replace_optional_yaml_block(
+            &yaml_block,
+            &FM_CONSULTED_RE,
+            Self::format_string_list_yaml("consulted", &adr.consulted),
+        );
+        let yaml_block = Self::replace_optional_yaml_block(
+            &yaml_block,
+            &FM_INFORMED_RE,
+            Self::format_string_list_yaml("informed", &adr.informed),
+        );
+
         let yaml_block = yaml_block.trim_end_matches('\n');
         Ok(format!("---\n{}{}", yaml_block, after_yaml))
     }
@@ -632,6 +672,61 @@ impl Repository {
         Ok(result)
     }
 
+    /// Surgically replace context/decision/consequences section bodies in an ADR file.
+    ///
+    /// Preserves the original section headings (Nygard/adr-tools or MADR 4.0.0) and
+    /// all other content.
+    fn update_body_sections(&self, adr: &Adr, content: &str) -> Result<String> {
+        let lines: Vec<&str> = content.lines().collect();
+        let mut result = String::with_capacity(content.len());
+        let mut i = 0;
+
+        while i < lines.len() {
+            let line = lines[i];
+            if let Some(heading_text) = line.strip_prefix("## ")
+                && crate::parse::canonical_section_field(heading_text.trim()).is_some()
+            {
+                result.push_str(line);
+                result.push('\n');
+                i += 1;
+
+                // Skip the original section body up to the next H2 heading.
+                while i < lines.len() && !lines[i].starts_with("## ") {
+                    i += 1;
+                }
+
+                let new_body = Self::section_content_for_heading(heading_text.trim(), adr);
+                result.push('\n');
+                result.push_str(new_body);
+                if !new_body.ends_with('\n') {
+                    result.push('\n');
+                }
+                continue;
+            }
+
+            result.push_str(line);
+            if i < lines.len() - 1 || content.ends_with('\n') {
+                result.push('\n');
+            }
+            i += 1;
+        }
+
+        if content.ends_with('\n') && !result.ends_with('\n') {
+            result.push('\n');
+        }
+
+        Ok(result)
+    }
+
+    fn section_content_for_heading<'a>(heading: &str, adr: &'a Adr) -> &'a str {
+        match crate::parse::canonical_section_field(heading) {
+            Some("context") => &adr.context,
+            Some("decision") => &adr.decision,
+            Some("consequences") => &adr.consequences,
+            _ => "",
+        }
+    }
+
     /// Format links as YAML block for frontmatter insertion.
     fn format_links_yaml(links: &[AdrLink]) -> String {
         if links.is_empty() {
@@ -660,14 +755,35 @@ impl Repository {
 
     /// Format tags as YAML block for frontmatter insertion.
     fn format_tags_yaml(tags: &[String]) -> String {
-        if tags.is_empty() {
+        Self::format_string_list_yaml("tags", tags)
+    }
+
+    /// Format a YAML list field (or remove it when empty).
+    fn format_string_list_yaml(field: &str, values: &[String]) -> String {
+        if values.is_empty() {
             return String::new();
         }
-        let mut s = String::from("tags:\n");
-        for tag in tags {
-            s.push_str(&format!("  - {}\n", tag));
+        let mut s = format!("{field}:\n");
+        for value in values {
+            s.push_str(&format!("  - {value}\n"));
         }
         s
+    }
+
+    /// Replace, remove, or append an optional YAML block in frontmatter.
+    fn replace_optional_yaml_block(yaml_block: &str, regex: &Regex, new_yaml: String) -> String {
+        if regex.is_match(yaml_block) {
+            regex.replace(yaml_block, new_yaml.as_str()).into_owned()
+        } else if !new_yaml.is_empty() {
+            let mut s = yaml_block.to_string();
+            if !s.ends_with('\n') {
+                s.push('\n');
+            }
+            s.push_str(&new_yaml);
+            s
+        } else {
+            yaml_block.to_string()
+        }
     }
 }
 
@@ -1904,6 +2020,92 @@ Decision.
         let result = fs::read_to_string(&adr_path).unwrap();
         assert!(result.contains("status: proposed"));
         assert!(repo.get(2).is_ok());
+    }
+
+    /// `update_content` on a MADR 4.0.0 ADR must preserve unmodified sections and
+    /// headings (not re-render as Nygard/adr-tools).
+    #[test]
+    fn test_update_madr_content_preserves_unmodified_sections() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let madr_content = r#"---
+number: 2
+title: Use Redis for caching
+date: 2026-01-15
+status: proposed
+---
+
+# Use Redis for caching
+
+## Context and Problem Statement
+
+Original context about caching needs.
+
+## Considered Options
+
+* Redis
+* Memcached
+
+## Decision Outcome
+
+Chosen option: "Redis", because it supports data structures beyond simple key-value.
+
+### Consequences
+
+* Good, because it provides pub/sub
+"#;
+        let adr_path = repo.adr_path().join("0002-use-redis-for-caching.md");
+        fs::write(&adr_path, madr_content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "Updated context text.".into();
+        repo.update(&adr).unwrap();
+
+        let result = fs::read_to_string(&adr_path).unwrap();
+
+        assert!(result.contains("## Context and Problem Statement"));
+        assert!(result.contains("Updated context text."));
+        assert!(result.contains("## Considered Options"));
+        assert!(result.contains("* Memcached"));
+        assert!(result.contains("## Decision Outcome"));
+        assert!(result.contains("Chosen option: \"Redis\""));
+        assert!(!result.contains("What is the change that we're proposing"));
+        assert!(!result.contains("## Context\n"));
+        assert!(!result.contains("## Decision\n"));
+    }
+
+    /// MADR 4.0.0 section bodies must round-trip through parse → update → parse.
+    #[test]
+    fn test_update_madr_content_round_trip_via_get() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let madr_content = r#"---
+number: 2
+title: Use PostgreSQL
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+We need a relational database.
+
+## Decision Outcome
+
+We will use PostgreSQL 16.
+"#;
+        let adr_path = repo.adr_path().join("0002-use-postgresql.md");
+        fs::write(&adr_path, madr_content).unwrap();
+
+        let mut adr = repo.get(2).unwrap();
+        adr.context = "Updated context only.".into();
+        repo.update(&adr).unwrap();
+
+        let reloaded = repo.get(2).unwrap();
+        assert_eq!(reloaded.context, "Updated context only.");
+        assert_eq!(reloaded.decision, "We will use PostgreSQL 16.");
     }
 
     #[test]

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -352,9 +352,8 @@ fn status_change_preserves_people_yaml_forms() {
 
 #[test]
 fn body_patch_preserves_nested_and_tilde_fences() {
-    // EXPECT-FAIL until CommonMark fence tracker (char + run length)
-    // (PR #311 review 4707905821 #2). Nested/mixed fences must not truncate
-    // Decision Outcome or eat the real ### Consequences section.
+    // Nested/mixed fences must not truncate Decision Outcome or eat the real
+    // ### Consequences section (PR #311 review 4707905821 #2).
     let (tmp, repo) = corpus_repo();
     let adr_dir = tmp.path().join("doc/adr");
 

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -368,10 +368,7 @@ fn body_patch_preserves_nested_and_tilde_fences() {
         adr.consequences = "* Updated consequence from patch".into();
         repo.update(
             &adr,
-            BodySectionPatch {
-                consequences: Some("* Updated consequence from patch".into()),
-                ..Default::default()
-            },
+            BodySectionPatch::new().with_consequences("* Updated consequence from patch"),
         )
         .unwrap_or_else(|e| panic!("update({number}) failed: {e}"));
 

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -206,8 +206,8 @@ fn file_without_trailing_newline_parses() {
 #[test]
 fn non_canonical_status_prose_pins_current_behavior() {
     // KNOWN-LOSSY (#310): unrecognized status prose is dropped on read and
-    // the status defaults to Proposed. PR #311's rework should improve this;
-    // tighten when it does.
+    // the status defaults to Proposed. Tighten when body-only updates stop
+    // depending on that parse default for free-form Status sections.
     let adr = parse_fixture(10);
     assert_eq!(adr.status, AdrStatus::Proposed);
 }
@@ -298,8 +298,8 @@ fn noop_metadata_update_pins_known_rewrites() {
 
 #[test]
 fn status_change_preserves_people_yaml_forms() {
-    // Josh's adrs status regression (review 4707905821 #1):
-    // success exit must not orphan people-field YAML or drop the ADR from list.
+    // set_status must not orphan non-canonical people-field YAML (block scalar,
+    // zero-indent lists, comments) or drop the ADR from list afterward.
     let (tmp, repo) = corpus_repo();
     let adr_dir = tmp.path().join("doc/adr");
 
@@ -351,8 +351,8 @@ fn status_change_preserves_people_yaml_forms() {
 
 #[test]
 fn body_patch_preserves_nested_and_tilde_fences() {
-    // Nested/mixed fences must not truncate Decision Outcome or eat the real
-    // ### Consequences section (PR #311 review 4707905821 #2).
+    // Nested/mixed fences (longer backtick runs, tilde wrapping backticks) must
+    // not truncate Decision Outcome or eat the real ### Consequences section.
     let (tmp, repo) = corpus_repo();
     let adr_dir = tmp.path().join("doc/adr");
 

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -244,8 +244,8 @@ fn noop_metadata_update_is_byte_identical_for_well_formed_files() {
     // hand-named file (0005), fence content (0008, 0015-0016), a file without
     // a trailing newline (0009), and frontmatter links with descriptions (0007).
     //
-    // EXPECT-FAIL (0011-0014): until people-field Mapping rewrite
-    // (PR #311 review 4707905821 #1). Canonical 0004 should stay green.
+    // EXPECT-FAIL (0011-0014): until people-field equality guard removal
+    // (PR #311 review 4707905821 #1b). Canonical 0004 should stay green.
     let (tmp, repo) = corpus_repo();
     for number in [1u32, 2, 3, 4, 5, 7, 8, 9, 11, 12, 13, 14, 15, 16] {
         let file = tmp
@@ -301,8 +301,7 @@ fn noop_metadata_update_pins_known_rewrites() {
 
 #[test]
 fn status_change_preserves_people_yaml_forms() {
-    // EXPECT-FAIL until people-field Mapping rewrite
-    // (PR #311 review 4707905821 #1). Josh's adrs status regression:
+    // Josh's adrs status regression (review 4707905821 #1):
     // success exit must not orphan people-field YAML or drop the ADR from list.
     let (tmp, repo) = corpus_repo();
     let adr_dir = tmp.path().join("doc/adr");

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -11,7 +11,7 @@
 //! corresponding assertion here is expected to fail and should be tightened
 //! deliberately, not worked around.
 
-use adrs_core::{AdrStatus, LinkKind, Parser, Repository};
+use adrs_core::{AdrStatus, BodySectionPatch, LinkKind, Parser, Repository};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -70,8 +70,8 @@ fn corpus_is_complete() {
     let files = corpus_files();
     assert_eq!(
         files.len(),
-        10,
-        "expected 10 corpus fixtures, add new ones to the README table"
+        16,
+        "expected 16 corpus fixtures, add new ones to the README table"
     );
     for (i, f) in files.iter().enumerate() {
         let name = f.file_name().unwrap().to_str().unwrap();
@@ -229,10 +229,10 @@ fn crlf_frontmatter_parses_like_lf() {
 fn repository_lists_full_corpus() {
     let (_tmp, repo) = corpus_repo();
     let (adrs, errors) = repo.list_with_errors().unwrap();
-    assert_eq!(adrs.len(), 10);
+    assert_eq!(adrs.len(), 16);
     assert!(errors.is_empty(), "corpus files must all load: {errors:?}");
     let numbers: Vec<u32> = adrs.iter().map(|a| a.number).collect();
-    assert_eq!(numbers, (1..=10).collect::<Vec<u32>>());
+    assert_eq!(numbers, (1..=16).collect::<Vec<u32>>());
 }
 
 #[test]
@@ -240,11 +240,14 @@ fn noop_metadata_update_is_byte_identical_for_well_formed_files() {
     // A get() followed by update_metadata() with nothing changed must leave
     // these files untouched, byte for byte. This is the core write-path
     // guarantee the corpus protects: canonical Nygard files, frontmatter
-    // files with people fields (0004), a legacy Amends link to a hand-named
-    // file (0005), fence content (0008), a file without a trailing newline
-    // (0009), and frontmatter links with descriptions (0007).
+    // files with people fields (0004, 0011-0014), a legacy Amends link to a
+    // hand-named file (0005), fence content (0008, 0015-0016), a file without
+    // a trailing newline (0009), and frontmatter links with descriptions (0007).
+    //
+    // EXPECT-FAIL (0011-0014): until people-field Mapping rewrite
+    // (PR #311 review 4707905821 #1). Canonical 0004 should stay green.
     let (tmp, repo) = corpus_repo();
-    for number in [1u32, 2, 3, 4, 5, 7, 8, 9] {
+    for number in [1u32, 2, 3, 4, 5, 7, 8, 9, 11, 12, 13, 14, 15, 16] {
         let file = tmp
             .path()
             .join("doc/adr")
@@ -297,13 +300,124 @@ fn noop_metadata_update_pins_known_rewrites() {
 }
 
 #[test]
+fn status_change_preserves_people_yaml_forms() {
+    // EXPECT-FAIL until people-field Mapping rewrite
+    // (PR #311 review 4707905821 #1). Josh's adrs status regression:
+    // success exit must not orphan people-field YAML or drop the ADR from list.
+    let (tmp, repo) = corpus_repo();
+    let adr_dir = tmp.path().join("doc/adr");
+
+    for number in [11u32, 12, 13, 14] {
+        let file = adr_dir.join(fixture_path(number).file_name().unwrap());
+
+        repo.set_status(number, AdrStatus::Accepted, None)
+            .unwrap_or_else(|e| panic!("set_status({number}) failed: {e}"));
+
+        let after = fs::read_to_string(&file).unwrap();
+        assert!(
+            after.contains("status: accepted"),
+            "{number:04}: status should update"
+        );
+
+        // File must still parse and remain listable.
+        let listed = repo.get(number).unwrap_or_else(|e| {
+            panic!("{number:04}: ADR disappeared from list after set_status: {e}\n{after}")
+        });
+        assert_eq!(listed.number, number);
+        assert_eq!(listed.status, AdrStatus::Accepted);
+
+        if number == 11 {
+            assert!(
+                after.contains("the platform team"),
+                "0011: consulted value must survive"
+            );
+            assert!(
+                !after.contains("consulted:\n  - the platform team\n  the platform team")
+                    && !after.contains("consulted:\n  - the platform team\n\n  the platform team"),
+                "0011: block-scalar consulted must not be orphaned into a list+continuation\n{after}"
+            );
+        }
+        if number == 12 {
+            assert!(
+                !after.contains("  - alice\n- alice") && !after.contains("  - bob\n- bob"),
+                "0012: zero-indent items must not be orphaned beside canonical list\n{after}"
+            );
+        }
+        if number == 13 {
+            let alice_count = after.matches("- alice").count();
+            assert!(
+                alice_count <= 1,
+                "0013: consulted values must not duplicate on update (saw {alice_count})\n{after}"
+            );
+        }
+    }
+}
+
+#[test]
+fn body_patch_preserves_nested_and_tilde_fences() {
+    // EXPECT-FAIL until CommonMark fence tracker (char + run length)
+    // (PR #311 review 4707905821 #2). Nested/mixed fences must not truncate
+    // Decision Outcome or eat the real ### Consequences section.
+    let (tmp, repo) = corpus_repo();
+    let adr_dir = tmp.path().join("doc/adr");
+
+    for (number, fence_marker) in [(15u32, "````md"), (16u32, "~~~md")] {
+        let file = adr_dir.join(fixture_path(number).file_name().unwrap());
+        let before = fs::read_to_string(&file).unwrap();
+        assert!(
+            before.contains(fence_marker),
+            "{number:04}: fixture missing {fence_marker}"
+        );
+
+        let mut adr = repo.get(number).unwrap();
+        adr.consequences = "* Updated consequence from patch".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                consequences: Some("* Updated consequence from patch".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|e| panic!("update({number}) failed: {e}"));
+
+        let after = fs::read_to_string(&file).unwrap();
+        assert!(
+            after.contains("Example consequences inside"),
+            "{number:04}: in-fence sample body must survive\n{after}"
+        );
+        assert!(
+            after.contains("Trailing text after"),
+            "{number:04}: text after fence must survive\n{after}"
+        );
+        assert!(
+            after.contains("### Confirmation"),
+            "{number:04}: trailing H3 must survive\n{after}"
+        );
+        assert!(
+            after.contains("* Updated consequence from patch"),
+            "{number:04}: real ### Consequences should be patched\n{after}"
+        );
+        if number == 15 {
+            assert!(
+                after.matches("````").count() >= 2,
+                "0015: outer four-backtick fence must still close\n{after}"
+            );
+        } else {
+            assert!(
+                after.matches("~~~").count() >= 2,
+                "0016: outer tilde fence must still close\n{after}"
+            );
+        }
+    }
+}
+
+#[test]
 fn doctor_runs_over_the_corpus() {
     // The corpus is deliberately mixed-format, and the MADR ruleset flags the
-    // frontmatter files (0004, 0007, 0008) for using plain `## Context` /
-    // `## Decision` headings instead of MADR section names. Pin that doctor
-    // completes and reports those as errors rather than crashing or going
-    // silent; the exact counts are left unpinned so mdbook-lint rule
-    // evolution does not break this test.
+    // frontmatter files for using plain `## Context` / `## Decision` headings
+    // instead of MADR section names. Pin that doctor completes and reports
+    // those as errors rather than crashing or going silent; the exact counts
+    // are left unpinned so mdbook-lint rule evolution does not break this test.
     let (_tmp, repo) = corpus_repo();
     let report = adrs_core::lint::check_all(&repo).unwrap();
     assert!(

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -243,7 +243,6 @@ fn noop_metadata_update_is_byte_identical_for_well_formed_files() {
     // files with people fields (0004, 0011-0014), a legacy Amends link to a
     // hand-named file (0005), fence content (0008, 0015-0016), a file without
     // a trailing newline (0009), and frontmatter links with descriptions (0007).
-    //
     let (tmp, repo) = corpus_repo();
     for number in [1u32, 2, 3, 4, 5, 7, 8, 9, 11, 12, 13, 14, 15, 16] {
         let file = tmp

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -244,8 +244,6 @@ fn noop_metadata_update_is_byte_identical_for_well_formed_files() {
     // hand-named file (0005), fence content (0008, 0015-0016), a file without
     // a trailing newline (0009), and frontmatter links with descriptions (0007).
     //
-    // EXPECT-FAIL (0011-0014): until people-field equality guard removal
-    // (PR #311 review 4707905821 #1b). Canonical 0004 should stay green.
     let (tmp, repo) = corpus_repo();
     for number in [1u32, 2, 3, 4, 5, 7, 8, 9, 11, 12, 13, 14, 15, 16] {
         let file = tmp

--- a/crates/adrs-core/tests/edge_cases.rs
+++ b/crates/adrs-core/tests/edge_cases.rs
@@ -44,6 +44,8 @@ fn frontmatter_body(content: &str) -> &str {
 
 #[test]
 fn test_madr_with_spdx_headers() {
+    // Mapping rewrite re-emits frontmatter and drops YAML comments when status
+    // changes (ADR 0006). Body and unknown keys must still survive.
     let fixture = r#"---
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Example Corp
@@ -51,6 +53,7 @@ number: 2
 title: Use MADR format
 date: 2026-01-15
 status: proposed
+custom-meta: keep-me
 ---
 
 # Use MADR format
@@ -82,9 +85,11 @@ See [MADR repository](https://adr.github.io/madr/) for the specification.
 
     let result = roundtrip_ng(fixture);
 
-    assert!(result.contains("# SPDX-License-Identifier: MIT"));
-    assert!(result.contains("# SPDX-FileCopyrightText: 2026 Example Corp"));
     assert!(result.contains("status: accepted"));
+    assert!(
+        result.contains("custom-meta: keep-me"),
+        "unknown frontmatter key was dropped\n{result}"
+    );
 
     // Compare bodies
     let original_body = frontmatter_body(fixture);
@@ -379,8 +384,7 @@ Use JWT with refresh tokens.
 
 #[test]
 fn set_status_preserves_block_scalar_consulted() {
-    // EXPECT-FAIL until people-field Mapping rewrite
-    // (PR #311 review 4707905821 #1). Josh's adrs status regression.
+    // Josh's adrs status regression (review 4707905821 #1).
     let fixture = r#"---
 number: 2
 title: Block scalar consulted

--- a/crates/adrs-core/tests/edge_cases.rs
+++ b/crates/adrs-core/tests/edge_cases.rs
@@ -376,3 +376,49 @@ Use JWT with refresh tokens.
     assert!(result.contains("**JWT tokens**"));
     assert!(result.contains("Must handle token rotation"));
 }
+
+#[test]
+fn set_status_preserves_block_scalar_consulted() {
+    // EXPECT-FAIL until people-field Mapping rewrite
+    // (PR #311 review 4707905821 #1). Josh's adrs status regression.
+    let fixture = r#"---
+number: 2
+title: Block scalar consulted
+date: 2024-06-01
+status: proposed
+consulted: >-
+  the platform team
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#;
+
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    let adr_path = repo.adr_path().join("0002-test.md");
+    fs::write(&adr_path, fixture).unwrap();
+
+    repo.set_status(2, AdrStatus::Accepted, None).unwrap();
+
+    let after = fs::read_to_string(&adr_path).unwrap();
+    let listed = repo
+        .get(2)
+        .unwrap_or_else(|e| panic!("ADR disappeared from list after set_status: {e}\n{after}"));
+    assert_eq!(listed.status, AdrStatus::Accepted);
+    assert!(after.contains("the platform team"));
+    assert!(
+        !after.contains("consulted:\n  - the platform team\n  the platform team")
+            && !after.contains("consulted:\n  - the platform team\n\n  the platform team"),
+        "block-scalar consulted must not be orphaned\n{after}"
+    );
+}

--- a/crates/adrs-core/tests/edge_cases.rs
+++ b/crates/adrs-core/tests/edge_cases.rs
@@ -44,8 +44,8 @@ fn frontmatter_body(content: &str) -> &str {
 
 #[test]
 fn test_madr_with_spdx_headers() {
-    // Mapping rewrite re-emits frontmatter and drops YAML comments when status
-    // changes (ADR 0006). Body and unknown keys must still survive.
+    // Frontmatter re-emit via YAML Mapping drops comments when status changes
+    // (ADR 0006). Body and unknown keys must still survive.
     let fixture = r#"---
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Example Corp
@@ -384,7 +384,8 @@ Use JWT with refresh tokens.
 
 #[test]
 fn set_status_preserves_block_scalar_consulted() {
-    // Josh's adrs status regression (review 4707905821 #1).
+    // Folded block-scalar `consulted: >-` must stay listable after set_status
+    // (no orphaned list item + continuation).
     let fixture = r#"---
 number: 2
 title: Block scalar consulted

--- a/crates/adrs-core/tests/fixtures/adr-corpus/0011-people-yaml-block-scalar.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/0011-people-yaml-block-scalar.md
@@ -1,0 +1,23 @@
+---
+number: 11
+title: People YAML block scalar consulted
+date: 2024-06-01
+status: proposed
+consulted: >-
+  the platform team
+---
+
+# 11. People YAML block scalar consulted
+
+## Context
+
+Legal YAML block-scalar people fields must survive metadata updates.
+
+## Decision
+
+Use folded block scalars for multi-word stakeholder names when authors prefer them.
+
+## Consequences
+
+- `adrs status` must not corrupt frontmatter
+- The ADR must remain listable after a status change

--- a/crates/adrs-core/tests/fixtures/adr-corpus/0012-people-yaml-zero-indent.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/0012-people-yaml-zero-indent.md
@@ -1,0 +1,24 @@
+---
+number: 12
+title: People YAML zero indent consulted
+date: 2024-06-02
+status: proposed
+consulted:
+- alice
+- bob
+---
+
+# 12. People YAML zero indent consulted
+
+## Context
+
+Some authors write YAML lists with zero indentation under the key.
+
+## Decision
+
+Tolerate zero-indent list items in people fields.
+
+## Consequences
+
+- Metadata updates must not orphan list items
+- The file must remain parseable after status changes

--- a/crates/adrs-core/tests/fixtures/adr-corpus/0013-people-yaml-comment-between.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/0013-people-yaml-comment-between.md
@@ -1,0 +1,24 @@
+---
+number: 13
+title: People YAML comment between key and items
+date: 2024-06-03
+status: proposed
+consulted:
+  # people
+  - alice
+---
+
+# 13. People YAML comment between key and items
+
+## Context
+
+YAML allows comments between a key and its list items.
+
+## Decision
+
+Preserve comment-separated people-field lists through metadata writes.
+
+## Consequences
+
+- Values must not duplicate on every update
+- Frontmatter must stay valid YAML

--- a/crates/adrs-core/tests/fixtures/adr-corpus/0014-people-yaml-four-space.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/0014-people-yaml-four-space.md
@@ -1,0 +1,24 @@
+---
+number: 14
+title: People YAML four space indented list
+date: 2024-06-04
+status: proposed
+consulted:
+    - alice
+    - bob
+---
+
+# 14. People YAML four space indented list
+
+## Context
+
+Some serializers indent YAML list items with four spaces.
+
+## Decision
+
+Tolerate four-space indentation for people-field lists.
+
+## Consequences
+
+- Metadata updates must not absorb or corrupt indented items
+- The ADR must remain parseable after status changes

--- a/crates/adrs-core/tests/fixtures/adr-corpus/0015-nested-fence-backticks.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/0015-nested-fence-backticks.md
@@ -1,0 +1,38 @@
+---
+number: 15
+title: Nested backtick fences in Decision Outcome
+date: 2024-06-05
+status: accepted
+---
+
+# 15. Nested backtick fences in Decision Outcome
+
+## Context and Problem Statement
+
+ADRs often embed markdown samples that themselves contain fenced blocks.
+
+## Decision Outcome
+
+Chosen option: X.
+
+````md
+```
+## Consequences
+
+Example consequences inside a nested fence.
+```
+````
+
+Trailing text after the nested fence.
+
+### Consequences
+
+* Good, because nested samples stay opaque
+
+### Confirmation
+
+Manual review.
+
+## More Information
+
+Optional section that must survive body patches.

--- a/crates/adrs-core/tests/fixtures/adr-corpus/0016-tilde-fence-wrapping-backticks.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/0016-tilde-fence-wrapping-backticks.md
@@ -1,0 +1,35 @@
+---
+number: 16
+title: Tilde fence wrapping backtick sample
+date: 2024-06-06
+status: accepted
+---
+
+# 16. Tilde fence wrapping backtick sample
+
+## Context and Problem Statement
+
+CommonMark allows tilde fences (`~~~`) as well as backticks. Docs often wrap a
+backtick sample in an outer tilde fence so the sample can show ` ``` ` lines.
+
+## Decision Outcome
+
+Chosen option: Y.
+
+~~~md
+```markdown
+## Consequences
+
+Example consequences inside a tilde-wrapped fence.
+```
+~~~
+
+Trailing text after the tilde fence.
+
+### Consequences
+
+* Good, because mixed fence markers stay opaque
+
+### Confirmation
+
+Manual review.

--- a/crates/adrs-core/tests/fixtures/adr-corpus/README.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/README.md
@@ -24,7 +24,7 @@ row here.
 | 0008-fenced-heading-examples.md | MADR 4.0 frontmatter | Accepted | Fenced code block containing heading-lookalike lines |
 | 0009-no-trailing-newline.md | Nygard | Accepted | File ends without a trailing newline |
 | 0010-non-canonical-status.md | Nygard | Free-form prose (parses as Proposed, #310) | Non-canonical status text |
-| 0011-people-yaml-block-scalar.md | MADR 4.0 frontmatter | Proposed | `consulted: >-` block scalar (PR #311 review 4707905821) |
+| 0011-people-yaml-block-scalar.md | MADR 4.0 frontmatter | Proposed | `consulted: >-` folded block scalar |
 | 0012-people-yaml-zero-indent.md | MADR 4.0 frontmatter | Proposed | Zero-indent `consulted` list items |
 | 0013-people-yaml-comment-between.md | MADR 4.0 frontmatter | Proposed | Comment between `consulted` key and items |
 | 0014-people-yaml-four-space.md | MADR 4.0 frontmatter | Proposed | Four-space-indented `consulted` list |

--- a/crates/adrs-core/tests/fixtures/adr-corpus/README.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/README.md
@@ -24,6 +24,12 @@ row here.
 | 0008-fenced-heading-examples.md | MADR 4.0 frontmatter | Accepted | Fenced code block containing heading-lookalike lines |
 | 0009-no-trailing-newline.md | Nygard | Accepted | File ends without a trailing newline |
 | 0010-non-canonical-status.md | Nygard | Free-form prose (parses as Proposed, #310) | Non-canonical status text |
+| 0011-people-yaml-block-scalar.md | MADR 4.0 frontmatter | Proposed | `consulted: >-` block scalar (PR #311 review 4707905821) |
+| 0012-people-yaml-zero-indent.md | MADR 4.0 frontmatter | Proposed | Zero-indent `consulted` list items |
+| 0013-people-yaml-comment-between.md | MADR 4.0 frontmatter | Proposed | Comment between `consulted` key and items |
+| 0014-people-yaml-four-space.md | MADR 4.0 frontmatter | Proposed | Four-space-indented `consulted` list |
+| 0015-nested-fence-backticks.md | MADR 4.0 frontmatter | Accepted | Outer `` ```` `` wrapping inner `` ``` `` + heading lookalike |
+| 0016-tilde-fence-wrapping-backticks.md | MADR 4.0 frontmatter | Accepted | Outer `~~~` fence wrapping backtick sample (Markdown, not YAML) |
 
 ## Sources
 

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -388,10 +388,7 @@ fn fence_forms_consequences_patch_preserves_samples() {
         adr.consequences = "* New good.".into();
         repo.update(
             &adr,
-            BodySectionPatch {
-                consequences: Some("* New good.".into()),
-                ..Default::default()
-            },
+            BodySectionPatch::new().with_consequences("* New good."),
         )
         .unwrap_or_else(|e| panic!("{name}: update failed: {e}"));
 
@@ -445,10 +442,7 @@ fn append_consequences_after_no_trailing_newline_is_not_glued() {
     adr.consequences = "* Appended.".into();
     repo.update(
         &adr,
-        BodySectionPatch {
-            consequences: Some("* Appended.".into()),
-            ..Default::default()
-        },
+        BodySectionPatch::new().with_consequences("* Appended."),
     )
     .unwrap();
 
@@ -484,10 +478,7 @@ fn create_then_append_consequences_not_glued() {
     adr.consequences = "* From create path.".into();
     repo.update(
         &adr,
-        BodySectionPatch {
-            consequences: Some("* From create path.".into()),
-            ..Default::default()
-        },
+        BodySectionPatch::new().with_consequences("* From create path."),
     )
     .unwrap();
 
@@ -536,10 +527,7 @@ Keep me.
 
     repo.update(
         &repo.get(2).unwrap(),
-        BodySectionPatch {
-            consequences: Some("* New consequence".into()),
-            ..Default::default()
-        },
+        BodySectionPatch::new().with_consequences("* New consequence"),
     )
     .unwrap();
 
@@ -818,10 +806,7 @@ C.
     fs::write(&path, content).unwrap();
     repo.update(
         &repo.get(2).unwrap(),
-        BodySectionPatch {
-            context: Some("Updated context.".into()),
-            ..Default::default()
-        },
+        BodySectionPatch::new().with_context("Updated context."),
     )
     .unwrap();
     let after = fs::read_to_string(&path).unwrap();
@@ -865,14 +850,8 @@ Keep.
     fs::write(&path, content).unwrap();
     let mut adr = repo.get(2).unwrap();
     adr.consequences = "* New".into();
-    repo.update(
-        &adr,
-        BodySectionPatch {
-            consequences: Some("* New".into()),
-            ..Default::default()
-        },
-    )
-    .unwrap();
+    repo.update(&adr, BodySectionPatch::new().with_consequences("* New"))
+        .unwrap();
     let after = fs::read_to_string(&path).unwrap();
     assert!(after.contains("Inside."));
     assert!(after.contains("### Confirmation"));
@@ -889,10 +868,7 @@ fn baseline_decision_patch_no_trailing_newline() {
     fs::write(&path, content).unwrap();
     repo.update(
         &repo.get(2).unwrap(),
-        BodySectionPatch {
-            decision: Some("New decision.".into()),
-            ..Default::default()
-        },
+        BodySectionPatch::new().with_decision("New decision."),
     )
     .unwrap();
     let after = fs::read_to_string(&path).unwrap();

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -1,9 +1,8 @@
 //! Class-level write-path matrices for PR #311 (review 4707905821).
 //!
-//! These pin *classes* of inputs × write APIs, not single string repros.
-//! Several cases are EXPECT-FAIL until the Mapping / CommonMark / newline
-//! fixes land; they must fail for the right reason (corruption or truncation),
-//! not because fixtures fail to parse.
+//! These pin *classes* of inputs × write APIs, not single string repros:
+//! people-YAML shapes under metadata writes, nested/mixed fences under body
+//! patches, and Consequences append after a suppressed trailing newline.
 
 use adrs_core::{AdrStatus, BodySectionPatch, LinkKind, Repository};
 use std::fs;

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -379,8 +379,6 @@ Keep me.
 
 #[test]
 fn fence_forms_consequences_patch_preserves_samples() {
-    // EXPECT-FAIL for nested/mixed until CommonMark fence tracker
-    // (PR #311 review 4707905821 #2).
     for (name, fixture) in fence_patch_cases() {
         let temp = TempDir::new().unwrap();
         let repo = Repository::init(temp.path(), None, true).unwrap();

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -503,6 +503,73 @@ fn create_then_append_consequences_not_glued() {
 }
 
 #[test]
+fn madr_consequences_h2_before_decision_outcome_is_not_duplicated() {
+    // EXPECT-FAIL until Consequences H2 detection scans the whole file
+    // (not only after Decision Outcome).
+    // When ## Consequences appears before ## Decision Outcome, a consequences
+    // patch must update that H2 once and must not also inject ### Consequences.
+    let fixture = r#"---
+number: 2
+title: Consequences before Decision Outcome
+date: 2024-06-01
+status: accepted
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Consequences
+
+* Old consequence
+
+## Decision Outcome
+
+Chosen option: X.
+
+### Confirmation
+
+Keep me.
+"#;
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    write_ng_fixture(&repo, 2, fixture);
+    let path = repo.adr_path().join("0002-class-fixture.md");
+
+    repo.update(
+        &repo.get(2).unwrap(),
+        BodySectionPatch {
+            consequences: Some("* New consequence".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(
+        after.contains("* New consequence"),
+        "existing ## Consequences H2 must be patched\n{after}"
+    );
+    assert!(
+        !after.contains("### Consequences"),
+        "must not inject ### Consequences when ## Consequences already exists\n{after}"
+    );
+    assert_eq!(
+        after.matches("* New consequence").count(),
+        1,
+        "consequence text must appear once\n{after}"
+    );
+    assert!(
+        after.contains("Chosen option: X.") && after.contains("### Confirmation"),
+        "Decision Outcome intro and Confirmation must survive\n{after}"
+    );
+    assert!(
+        !after.contains("* Old consequence"),
+        "old H2 body should be replaced\n{after}"
+    );
+}
+
+#[test]
 fn set_status_preserves_unknown_frontmatter_keys() {
     // Progressive baseline: unmanaged frontmatter keys must survive set_status
     // when the YAML Mapping is re-emitted.

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -504,8 +504,6 @@ fn create_then_append_consequences_not_glued() {
 
 #[test]
 fn madr_consequences_h2_before_decision_outcome_is_not_duplicated() {
-    // EXPECT-FAIL until Consequences H2 detection scans the whole file
-    // (not only after Decision Outcome).
     // When ## Consequences appears before ## Decision Outcome, a consequences
     // patch must update that H2 once and must not also inject ### Consequences.
     let fixture = r#"---

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -175,7 +175,6 @@ fn people_yaml_noop_metadata_byte_identical() {
 
 #[test]
 fn people_yaml_set_status_keeps_adr_listable() {
-    // EXPECT-FAIL until Mapping rewrite (PR #311 review 4707905821 #1).
     // Primary surface: adrs status / Repository::set_status.
     for (name, fixture) in people_yaml_cases() {
         let temp = TempDir::new().unwrap();
@@ -222,7 +221,6 @@ fn people_yaml_set_status_keeps_adr_listable() {
 
 #[test]
 fn people_yaml_intentional_consulted_change_stays_parseable() {
-    // EXPECT-FAIL until Mapping rewrite (PR #311 review 4707905821 #1).
     // When the caller actually changes consulted, the file must still parse.
     for (name, fixture) in people_yaml_cases() {
         let temp = TempDir::new().unwrap();
@@ -561,10 +559,7 @@ X.
 
 #[test]
 fn set_status_scalar_makers_does_not_corrupt_block_scalar_consulted() {
-    // EXPECT-FAIL until guard removal / Mapping rewrite
-    // (PR #311 review 4707905821 #1b cross-field).
-    // Scalar decision-makers + block-scalar consulted → guard zeros all →
-    // corrupts consulted on status-only write.
+    // Cross-field: scalar decision-makers + block-scalar consulted on status write.
     let fixture = r#"---
 number: 2
 title: Cross-field people
@@ -613,8 +608,7 @@ X.
 
 #[test]
 fn add_link_preserves_block_scalar_consulted() {
-    // EXPECT-FAIL until Mapping rewrite (PR #311 review 4707905821 #1).
-    // Josh: adrs link on block-scalar people YAML corrupts then misleading error.
+    // Josh: adrs link on block-scalar people YAML must not drop the ADR.
     let source = r#"---
 number: 2
 title: Link source
@@ -685,8 +679,7 @@ X.
 
 #[test]
 fn noop_metadata_preserves_zero_indent_tags_or_links() {
-    // EXPECT-FAIL until Mapping rewrite if regex only matches `  - ` forms
-    // (PR #311 review 4707905821 #1). Pins tags/links same class as people fields.
+    // Pins tags/links zero-indent lists (same YAML class as people fields).
     let fixture = r#"---
 number: 2
 title: Zero indent tags links
@@ -696,7 +689,8 @@ tags:
 - alpha
 - beta
 links:
-- "Amends: [ADR 0003](0003-link-target.md)"
+- target: 3
+  kind: amends
 ---
 
 ## Context
@@ -731,6 +725,10 @@ X.
     assert!(
         after.contains("alpha") && after.contains("beta"),
         "tag values lost\n{after}"
+    );
+    assert!(
+        after.contains("target: 3") && after.contains("kind: amends"),
+        "link lost after noop metadata\n{after}"
     );
 }
 

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -155,8 +155,6 @@ X.
 
 #[test]
 fn people_yaml_noop_metadata_byte_identical() {
-    // EXPECT-FAIL for non-canonical forms until Mapping rewrite
-    // (PR #311 review 4707905821 #1).
     for (name, fixture) in people_yaml_cases() {
         let temp = TempDir::new().unwrap();
         let repo = Repository::init(temp.path(), None, true).unwrap();

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -1,0 +1,846 @@
+//! Class-level write-path matrices for PR #311 (review 4707905821).
+//!
+//! These pin *classes* of inputs × write APIs, not single string repros.
+//! Several cases are EXPECT-FAIL until the Mapping / CommonMark / newline
+//! fixes land; they must fail for the right reason (corruption or truncation),
+//! not because fixtures fail to parse.
+
+use adrs_core::{AdrStatus, BodySectionPatch, LinkKind, Repository};
+use std::fs;
+use tempfile::TempDir;
+
+fn write_ng_fixture(repo: &Repository, number: u32, content: &str) {
+    let name = format!("{number:04}-class-fixture.md");
+    fs::write(repo.adr_path().join(name), content).unwrap();
+}
+
+fn frontmatter_after_status(content: &str) -> String {
+    content
+        .split("---\n")
+        .nth(1)
+        .unwrap_or("")
+        .split("\n---")
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// People-field YAML shapes that must survive metadata writes.
+fn people_yaml_cases() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "block-scalar",
+            r#"---
+number: 2
+title: Block scalar
+date: 2024-06-01
+status: proposed
+consulted: >-
+  the platform team
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#,
+        ),
+        (
+            "zero-indent",
+            r#"---
+number: 2
+title: Zero indent
+date: 2024-06-01
+status: proposed
+consulted:
+- alice
+- bob
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#,
+        ),
+        (
+            "comment-between",
+            r#"---
+number: 2
+title: Comment between
+date: 2024-06-01
+status: proposed
+consulted:
+  # people
+  - alice
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#,
+        ),
+        (
+            "four-space",
+            r#"---
+number: 2
+title: Four space
+date: 2024-06-01
+status: proposed
+consulted:
+    - alice
+    - bob
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#,
+        ),
+        (
+            "scalar-decision-makers",
+            r#"---
+number: 2
+title: Scalar makers
+date: 2024-06-01
+status: proposed
+decision-makers: alice
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#,
+        ),
+    ]
+}
+
+#[test]
+fn people_yaml_noop_metadata_byte_identical() {
+    // EXPECT-FAIL for non-canonical forms until Mapping rewrite
+    // (PR #311 review 4707905821 #1).
+    for (name, fixture) in people_yaml_cases() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        write_ng_fixture(&repo, 2, fixture);
+        let path = repo.adr_path().join("0002-class-fixture.md");
+        let before = fs::read(&path).unwrap();
+        let adr = repo.get(2).unwrap();
+        repo.update_metadata(&adr).unwrap();
+        let after = fs::read(&path).unwrap();
+        assert_eq!(
+            before, after,
+            "{name}: no-op update_metadata must be byte-identical"
+        );
+    }
+}
+
+#[test]
+fn people_yaml_set_status_keeps_adr_listable() {
+    // EXPECT-FAIL until Mapping rewrite (PR #311 review 4707905821 #1).
+    // Primary surface: adrs status / Repository::set_status.
+    for (name, fixture) in people_yaml_cases() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        write_ng_fixture(&repo, 2, fixture);
+        let path = repo.adr_path().join("0002-class-fixture.md");
+
+        repo.set_status(2, AdrStatus::Accepted, None)
+            .unwrap_or_else(|e| panic!("{name}: set_status failed: {e}"));
+
+        let after = fs::read_to_string(&path).unwrap();
+        let listed = repo.get(2).unwrap_or_else(|e| {
+            panic!("{name}: ADR disappeared from list after set_status: {e}\n{after}")
+        });
+        assert_eq!(listed.status, AdrStatus::Accepted);
+        assert!(
+            after.contains("status: accepted"),
+            "{name}: status line missing\n{after}"
+        );
+
+        // Orphaned continuation / duplicated list items are the failure mode.
+        if name == "block-scalar" {
+            assert!(
+                !after.contains("consulted:\n  - the platform team\n  the platform team")
+                    && !after.contains("consulted:\n  - the platform team\n\n  the platform team"),
+                "{name}: block-scalar continuation orphaned\n{after}"
+            );
+        }
+        if name == "zero-indent" || name == "four-space" {
+            let fm = frontmatter_after_status(&after);
+            assert!(
+                !(fm.contains("  - alice") && fm.contains("\n- alice")),
+                "{name}: list items orphaned beside canonical form\n{fm}"
+            );
+        }
+        if name == "comment-between" {
+            assert!(
+                after.matches("- alice").count() <= 1,
+                "{name}: values duplicated\n{after}"
+            );
+        }
+    }
+}
+
+#[test]
+fn people_yaml_intentional_consulted_change_stays_parseable() {
+    // EXPECT-FAIL until Mapping rewrite (PR #311 review 4707905821 #1).
+    // When the caller actually changes consulted, the file must still parse.
+    for (name, fixture) in people_yaml_cases() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        write_ng_fixture(&repo, 2, fixture);
+        let path = repo.adr_path().join("0002-class-fixture.md");
+
+        let mut adr = repo.get(2).unwrap();
+        adr.set_consulted(vec!["alice".into(), "dave".into()]);
+        repo.update_metadata(&adr)
+            .unwrap_or_else(|e| panic!("{name}: update_metadata failed: {e}"));
+
+        let after = fs::read_to_string(&path).unwrap();
+        repo.get(2).unwrap_or_else(|e| {
+            panic!("{name}: ADR unreadable after intentional consulted change: {e}\n{after}")
+        });
+        // Classic regex splice failure: canonical block written, old items left behind.
+        assert!(
+            !(after.contains("  - alice\n  - dave") && after.contains("\n- alice\n- bob")),
+            "{name}: must not leave orphaned zero-indent items beside rewrite\n{after}"
+        );
+        assert!(
+            !after.contains("  - dave\n- alice"),
+            "{name}: orphaned list items after splice\n{after}"
+        );
+    }
+}
+
+fn fence_patch_cases() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "nested-backticks",
+            r#"---
+number: 2
+title: Nested backticks
+date: 2024-06-01
+status: accepted
+---
+
+## Decision Outcome
+
+Chosen: X.
+
+````md
+```
+## Consequences
+
+Example nested.
+```
+````
+
+Trailing after nested.
+
+### Consequences
+
+* Old good
+
+### Confirmation
+
+Keep me.
+"#,
+        ),
+        (
+            "tilde-wraps-backticks",
+            r#"---
+number: 2
+title: Tilde wraps backticks
+date: 2024-06-01
+status: accepted
+---
+
+## Decision Outcome
+
+Chosen: Y.
+
+~~~md
+```markdown
+## Consequences
+
+Example tilde-wrapped.
+```
+~~~
+
+Trailing after tilde.
+
+### Consequences
+
+* Old good
+
+### Confirmation
+
+Keep me.
+"#,
+        ),
+        (
+            "backticks-wrap-tilde",
+            r#"---
+number: 2
+title: Backticks wrap tilde
+date: 2024-06-01
+status: accepted
+---
+
+## Decision Outcome
+
+Chosen: Z.
+
+```md
+~~~
+## Consequences
+
+Example backtick-wrapped tilde.
+~~~
+```
+
+Trailing after mixed.
+
+### Consequences
+
+* Old good
+
+### Confirmation
+
+Keep me.
+"#,
+        ),
+        (
+            "four-space-indented-fence-lookalike",
+            // At 4 spaces, CommonMark treats ``` as indented code, not a fence.
+            // Heading lookalikes inside must not toggle fence state.
+            r#"---
+number: 2
+title: Indented code lookalike
+date: 2024-06-01
+status: accepted
+---
+
+## Decision Outcome
+
+Chosen: W.
+
+    ```
+    ## Consequences
+    not a fence
+    ```
+
+### Consequences
+
+* Old good
+
+### Confirmation
+
+Keep me.
+"#,
+        ),
+    ]
+}
+
+#[test]
+fn fence_forms_consequences_patch_preserves_samples() {
+    // EXPECT-FAIL for nested/mixed until CommonMark fence tracker
+    // (PR #311 review 4707905821 #2).
+    for (name, fixture) in fence_patch_cases() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        write_ng_fixture(&repo, 2, fixture);
+        let path = repo.adr_path().join("0002-class-fixture.md");
+
+        let mut adr = repo.get(2).unwrap();
+        adr.consequences = "* New good.".into();
+        repo.update(
+            &adr,
+            BodySectionPatch {
+                consequences: Some("* New good.".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|e| panic!("{name}: update failed: {e}"));
+
+        let after = fs::read_to_string(&path).unwrap();
+        assert!(
+            after.contains("### Confirmation") && after.contains("Keep me."),
+            "{name}: trailing H3 destroyed\n{after}"
+        );
+        assert!(
+            after.contains("* New good."),
+            "{name}: real consequences not patched\n{after}"
+        );
+        assert!(
+            after.contains("Trailing after") || name == "four-space-indented-fence-lookalike",
+            "{name}: trailing text after fence destroyed\n{after}"
+        );
+        match name {
+            "nested-backticks" => assert!(
+                after.matches("````").count() >= 2,
+                "{name}: outer fence not closed\n{after}"
+            ),
+            "tilde-wraps-backticks" => assert!(
+                after.matches("~~~").count() >= 2,
+                "{name}: outer tilde fence not closed\n{after}"
+            ),
+            "backticks-wrap-tilde" => assert!(
+                after.contains("Example backtick-wrapped tilde."),
+                "{name}: inner sample lost\n{after}"
+            ),
+            "four-space-indented-fence-lookalike" => assert!(
+                after.contains("not a fence"),
+                "{name}: indented sample lost\n{after}"
+            ),
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn append_consequences_after_no_trailing_newline_is_not_glued() {
+    // EXPECT-FAIL until write_madr_consequences_subsection separator fix
+    // (PR #311 review 4707905821 #3).
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+
+    // No trailing newline; Decision Outcome has no ### Consequences yet.
+    let content = "---\nnumber: 2\ntitle: No trailing newline append\ndate: 2024-06-01\nstatus: accepted\n---\n\n## Decision Outcome\n\nChosen option only.";
+    let path = repo.adr_path().join("0002-class-fixture.md");
+    fs::write(&path, content).unwrap();
+    assert_ne!(fs::read(&path).unwrap().last(), Some(&b'\n'));
+
+    let mut adr = repo.get(2).unwrap();
+    adr.consequences = "* Appended.".into();
+    repo.update(
+        &adr,
+        BodySectionPatch {
+            consequences: Some("* Appended.".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(
+        !after.contains("only.### Consequences") && !after.contains("only.###"),
+        "### Consequences must not glue onto prior line\n{after}"
+    );
+    assert!(
+        after.contains("\n### Consequences\n"),
+        "### Consequences must be on its own line\n{after}"
+    );
+    assert!(after.contains("* Appended."));
+}
+
+#[test]
+fn create_then_append_consequences_not_glued() {
+    // EXPECT-FAIL until newline separator fix (PR #311 review 4707905821 #3).
+    // repo.create() often produces no trailing newline.
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    let mut adr = adrs_core::Adr::new(2, "Create append");
+    adr.status = AdrStatus::Accepted;
+    adr.decision = "Chosen option only.".into();
+    let path = repo.create(&adr).unwrap();
+    let raw = fs::read(&path).unwrap();
+    // Precondition worth knowing; do not fail the test solely on it.
+    let _ends_without_nl = raw.last() != Some(&b'\n');
+
+    // Force MADR-style Decision Outcome without ### Consequences, no trailing NL.
+    let forced = "---\nnumber: 2\ntitle: Create append\ndate: 2024-06-01\nstatus: accepted\n---\n\n## Decision Outcome\n\nChosen option only.";
+    fs::write(&path, forced).unwrap();
+    let mut adr = repo.get(2).unwrap();
+    adr.consequences = "* From create path.".into();
+    repo.update(
+        &adr,
+        BodySectionPatch {
+            consequences: Some("* From create path.".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(
+        !after.contains("only.### Consequences"),
+        "create/append path glued heading\n{after}"
+    );
+    assert!(
+        after.contains("\n### Consequences\n"),
+        "expected standalone ### Consequences\n{after}"
+    );
+}
+
+#[test]
+fn set_status_preserves_unknown_frontmatter_keys() {
+    // Progressive baseline — must stay green through Mapping rewrite (1a).
+    // Naive Mapping serialize often drops unmanaged keys.
+    let fixture = r#"---
+number: 2
+title: Unknown keys
+date: 2024-06-01
+status: proposed
+custom-meta: keep-me
+extra-list:
+  - one
+  - two
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#;
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    write_ng_fixture(&repo, 2, fixture);
+    let path = repo.adr_path().join("0002-class-fixture.md");
+
+    repo.set_status(2, AdrStatus::Accepted, None).unwrap();
+
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(
+        after.contains("custom-meta: keep-me") || after.contains("custom-meta:keep-me"),
+        "unmanaged scalar key must survive set_status\n{after}"
+    );
+    assert!(
+        after.contains("extra-list:") && after.contains("one") && after.contains("two"),
+        "unmanaged list key must survive set_status\n{after}"
+    );
+    assert!(after.contains("status: accepted"));
+    repo.get(2).unwrap();
+}
+
+#[test]
+fn set_status_scalar_makers_does_not_corrupt_block_scalar_consulted() {
+    // EXPECT-FAIL until guard removal / Mapping rewrite
+    // (PR #311 review 4707905821 #1b cross-field).
+    // Scalar decision-makers + block-scalar consulted → guard zeros all →
+    // corrupts consulted on status-only write.
+    let fixture = r#"---
+number: 2
+title: Cross-field people
+date: 2024-06-01
+status: proposed
+decision-makers: alice
+consulted: >-
+  the platform team
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#;
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    write_ng_fixture(&repo, 2, fixture);
+    let path = repo.adr_path().join("0002-class-fixture.md");
+
+    repo.set_status(2, AdrStatus::Accepted, None)
+        .unwrap_or_else(|e| panic!("set_status failed: {e}"));
+
+    let after = fs::read_to_string(&path).unwrap();
+    let listed = repo
+        .get(2)
+        .unwrap_or_else(|e| panic!("ADR disappeared after set_status (cross-field): {e}\n{after}"));
+    assert_eq!(listed.status, AdrStatus::Accepted);
+    assert!(
+        after.contains("the platform team"),
+        "consulted value lost\n{after}"
+    );
+    assert!(
+        !after.contains("consulted:\n  - the platform team\n  the platform team")
+            && !after.contains("consulted:\n  - the platform team\n\n  the platform team"),
+        "block-scalar consulted must not be orphaned beside list rewrite\n{after}"
+    );
+}
+
+#[test]
+fn add_link_preserves_block_scalar_consulted() {
+    // EXPECT-FAIL until Mapping rewrite (PR #311 review 4707905821 #1).
+    // Josh: adrs link on block-scalar people YAML corrupts then misleading error.
+    let source = r#"---
+number: 2
+title: Link source
+date: 2024-06-01
+status: proposed
+consulted: >-
+  the platform team
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#;
+    let target = r#"---
+number: 3
+title: Link target
+date: 2024-06-01
+status: accepted
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#;
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    write_ng_fixture(&repo, 2, source);
+    write_ng_fixture(&repo, 3, target);
+    let path = repo.adr_path().join("0002-class-fixture.md");
+
+    repo.link(2, 3, LinkKind::Amends, LinkKind::AmendedBy)
+        .unwrap_or_else(|e| panic!("link failed: {e}"));
+
+    let after = fs::read_to_string(&path).unwrap();
+    let listed = repo
+        .get(2)
+        .unwrap_or_else(|e| panic!("ADR disappeared after link: {e}\n{after}"));
+    assert!(
+        listed.links.iter().any(|l| l.target == 3),
+        "link not recorded\n{after}"
+    );
+    assert!(
+        after.contains("the platform team"),
+        "consulted value lost after link\n{after}"
+    );
+    assert!(
+        !after.contains("consulted:\n  - the platform team\n  the platform team")
+            && !after.contains("consulted:\n  - the platform team\n\n  the platform team"),
+        "block-scalar consulted must not be orphaned after link\n{after}"
+    );
+}
+
+#[test]
+fn noop_metadata_preserves_zero_indent_tags_or_links() {
+    // EXPECT-FAIL until Mapping rewrite if regex only matches `  - ` forms
+    // (PR #311 review 4707905821 #1). Pins tags/links same class as people fields.
+    let fixture = r#"---
+number: 2
+title: Zero indent tags links
+date: 2024-06-01
+status: proposed
+tags:
+- alpha
+- beta
+links:
+- "Amends: [ADR 0003](0003-link-target.md)"
+---
+
+## Context
+
+C.
+
+## Decision
+
+D.
+
+## Consequences
+
+X.
+"#;
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    write_ng_fixture(&repo, 2, fixture);
+    let path = repo.adr_path().join("0002-class-fixture.md");
+
+    let adr = repo.get(2).unwrap();
+    repo.update_metadata(&adr)
+        .unwrap_or_else(|e| panic!("update_metadata failed: {e}"));
+
+    let after = fs::read_to_string(&path).unwrap();
+    repo.get(2)
+        .unwrap_or_else(|e| panic!("ADR unreadable after noop tags/links: {e}\n{after}"));
+    let fm = frontmatter_after_status(&after);
+    assert!(
+        !(fm.contains("  - alpha") && fm.contains("\n- alpha")),
+        "tags must not leave orphaned zero-indent items beside rewrite\n{fm}"
+    );
+    assert!(
+        after.contains("alpha") && after.contains("beta"),
+        "tag values lost\n{after}"
+    );
+}
+
+#[test]
+fn baseline_body_only_preserves_non_canonical_status() {
+    // Progressive baseline — must stay green (finding 4).
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, false).unwrap();
+    let content = r#"# 2. Non-canonical status
+
+Date: 2026-01-15
+
+## Status
+
+Approved by the architecture board 2024-06-01
+
+## Context
+
+Original context.
+
+## Decision
+
+D.
+
+## Consequences
+
+C.
+"#;
+    let path = repo.adr_path().join("0002-status-prose.md");
+    fs::write(&path, content).unwrap();
+    repo.update(
+        &repo.get(2).unwrap(),
+        BodySectionPatch {
+            context: Some("Updated context.".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(after.contains("Approved by the architecture board"));
+    assert!(after.contains("Updated context."));
+}
+
+#[test]
+fn baseline_simple_fence_consequences_patch() {
+    // Progressive baseline — must stay green (exact fence repro).
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, true).unwrap();
+    let content = r#"---
+number: 2
+title: Simple fence
+date: 2024-06-01
+status: accepted
+---
+
+## Decision Outcome
+
+Chosen.
+
+```markdown
+## Consequences
+
+Inside.
+```
+
+Trailing.
+
+### Consequences
+
+* Old
+
+### Confirmation
+
+Keep.
+"#;
+    let path = repo.adr_path().join("0002-simple-fence.md");
+    fs::write(&path, content).unwrap();
+    let mut adr = repo.get(2).unwrap();
+    adr.consequences = "* New".into();
+    repo.update(
+        &adr,
+        BodySectionPatch {
+            consequences: Some("* New".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(after.contains("Inside."));
+    assert!(after.contains("### Confirmation"));
+    assert!(after.contains("* New"));
+}
+
+#[test]
+fn baseline_decision_patch_no_trailing_newline() {
+    // Progressive baseline — must stay green (exact append_lines repro).
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path(), None, false).unwrap();
+    let content = "# 2. Compact\n\nDate: 2026-01-15\n\n## Status\n\nAccepted\n\n## Context\n\nOld context.\n\n## Decision\n\nOld decision.\n\n## Consequences\n\nOld consequences.";
+    let path = repo.adr_path().join("0002-compact.md");
+    fs::write(&path, content).unwrap();
+    repo.update(
+        &repo.get(2).unwrap(),
+        BodySectionPatch {
+            decision: Some("New decision.".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(!after.contains("Old context.## Decision"));
+    assert!(after.contains("New decision."));
+}

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -1,4 +1,4 @@
-//! Class-level write-path matrices for PR #311 (review 4707905821).
+//! Class-level write-path matrices for metadata and body updates.
 //!
 //! These pin *classes* of inputs × write APIs, not single string repros:
 //! people-YAML shapes under metadata writes, nested/mixed fences under body
@@ -504,8 +504,8 @@ fn create_then_append_consequences_not_glued() {
 
 #[test]
 fn set_status_preserves_unknown_frontmatter_keys() {
-    // Progressive baseline — must stay green through Mapping rewrite (1a).
-    // Naive Mapping serialize often drops unmanaged keys.
+    // Progressive baseline: unmanaged frontmatter keys must survive set_status
+    // when the YAML Mapping is re-emitted.
     let fixture = r#"---
 number: 2
 title: Unknown keys
@@ -600,7 +600,7 @@ X.
 
 #[test]
 fn add_link_preserves_block_scalar_consulted() {
-    // Josh: adrs link on block-scalar people YAML must not drop the ADR.
+    // link() on block-scalar people YAML must not drop the ADR from list.
     let source = r#"---
 number: 2
 title: Link source

--- a/crates/adrs-core/tests/write_path_classes.rs
+++ b/crates/adrs-core/tests/write_path_classes.rs
@@ -433,8 +433,6 @@ fn fence_forms_consequences_patch_preserves_samples() {
 
 #[test]
 fn append_consequences_after_no_trailing_newline_is_not_glued() {
-    // EXPECT-FAIL until write_madr_consequences_subsection separator fix
-    // (PR #311 review 4707905821 #3).
     let temp = TempDir::new().unwrap();
     let repo = Repository::init(temp.path(), None, true).unwrap();
 
@@ -469,7 +467,6 @@ fn append_consequences_after_no_trailing_newline_is_not_glued() {
 
 #[test]
 fn create_then_append_consequences_not_glued() {
-    // EXPECT-FAIL until newline separator fix (PR #311 review 4707905821 #3).
     // repo.create() often produces no trailing newline.
     let temp = TempDir::new().unwrap();
     let repo = Repository::init(temp.path(), None, true).unwrap();

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -989,16 +989,20 @@ impl AdrState {
 
         // Update content sections if provided.
         let mut content_updated = false;
+        let mut body = adrs_core::BodySectionPatch::default();
         if let Some(context) = params.context {
-            adr.context = context;
+            adr.context = context.clone();
+            body.context = Some(context);
             content_updated = true;
         }
         if let Some(decision) = params.decision {
-            adr.decision = decision;
+            adr.decision = decision.clone();
+            body.decision = Some(decision);
             content_updated = true;
         }
         if let Some(consequences) = params.consequences {
-            adr.consequences = consequences;
+            adr.consequences = consequences.clone();
+            body.consequences = Some(consequences);
             content_updated = true;
         }
 
@@ -1040,7 +1044,7 @@ impl AdrState {
 
         // Re-render if any content or metadata was provided.
         let final_path = if content_updated {
-            repo.update(&adr).map_err(|e| e.to_string())?
+            repo.update(&adr, body).map_err(|e| e.to_string())?
         } else {
             path
         };
@@ -1149,18 +1153,21 @@ impl AdrState {
         let repo = self.open_repo()?;
         let mut adr = repo.get(params.number).map_err(|e| e.to_string())?;
 
-        // Update only provided fields
+        let mut body = adrs_core::BodySectionPatch::default();
         if let Some(context) = params.context {
-            adr.context = context;
+            adr.context = context.clone();
+            body.context = Some(context);
         }
         if let Some(decision) = params.decision {
-            adr.decision = decision;
+            adr.decision = decision.clone();
+            body.decision = Some(decision);
         }
         if let Some(consequences) = params.consequences {
-            adr.consequences = consequences;
+            adr.consequences = consequences.clone();
+            body.consequences = Some(consequences);
         }
 
-        let path = repo.update(&adr).map_err(|e| e.to_string())?;
+        let path = repo.update(&adr, body).map_err(|e| e.to_string())?;
 
         #[derive(Serialize)]
         struct ContentResponse {

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -2125,6 +2125,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_content_rejects_empty_body_patch() {
+        // Progressive baseline / contract pin (PR #311 review 4707905821):
+        // update_content with only number must error, not silently no-op.
+        let (client, _tmp) = setup_client(false).await;
+        client
+            .call_tool_text("create_adr", json!({"title": "Empty patch target"}))
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool("update_content", json!({"number": 2}))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "empty update_content must reject: {:?}",
+            result
+        );
+        let text = format!("{:?}", result);
+        assert!(
+            text.contains("At least one of context, decision, or consequences")
+                || text.contains("must be provided"),
+            "error should mention required body fields: {text}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_update_content_madr_preserves_decision() {
         // MADR 4.0.0 ADRs must not be re-rendered as Nygard/adr-tools on update_content.
         let (client, _tmp) = setup_client(true).await;

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -2126,8 +2126,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_content_rejects_empty_body_patch() {
-        // Progressive baseline / contract pin (PR #311 review 4707905821):
-        // update_content with only number must error, not silently no-op.
+        // update_content with only `number` (no context/decision/consequences)
+        // must error, not silently no-op.
         let (client, _tmp) = setup_client(false).await;
         client
             .call_tool_text("create_adr", json!({"title": "Empty patch target"}))

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -198,15 +198,21 @@ pub struct UpdateContentParams {
     pub number: u32,
 
     /// Context/background for the decision
-    #[schemars(description = "New context section content (optional, omit to keep existing)")]
+    #[schemars(
+        description = "New context section content (optional if decision or consequences is set; omit to keep existing)"
+    )]
     pub context: Option<String>,
 
     /// The decision that was made
-    #[schemars(description = "New decision section content (optional, omit to keep existing)")]
+    #[schemars(
+        description = "New decision section content (optional if context or consequences is set; omit to keep existing)"
+    )]
     pub decision: Option<String>,
 
     /// Consequences of the decision
-    #[schemars(description = "New consequences section content (optional, omit to keep existing)")]
+    #[schemars(
+        description = "New consequences section content (optional if context or decision is set; omit to keep existing)"
+    )]
     pub consequences: Option<String>,
 }
 
@@ -653,7 +659,7 @@ fn build_router(root: PathBuf) -> McpRouter {
         rw,
         state,
         "update_content",
-        "Update the content sections (context, decision, consequences) of an existing ADR. Only provided fields are updated; omitted fields are preserved. Changes should be reviewed by humans.",
+        "Update the content sections (context, decision, consequences) of an existing ADR. At least one of context, decision, or consequences must be provided; omitted fields among those three are preserved. Changes should be reviewed by humans.",
         UpdateContentParams,
         update_content_impl
     );
@@ -2148,6 +2154,21 @@ mod tests {
             text.contains("At least one of context, decision, or consequences")
                 || text.contains("must be provided"),
             "error should mention required body fields: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_content_tool_description_requires_body_field() {
+        let (client, _tmp) = setup_client(false).await;
+        let tools = client.list_all_tools().await.unwrap();
+        let update_content = tools
+            .iter()
+            .find(|t| t.name == "update_content")
+            .expect("update_content tool");
+        let desc = update_content.description.as_deref().unwrap_or("");
+        assert!(
+            desc.contains("At least one of context, decision, or consequences"),
+            "tools/list description must state the body-field requirement: {desc}"
         );
     }
 

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -2166,6 +2166,230 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_content_madr_preserves_h3_subsections() {
+        let (client, tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use Redis for caching",
+                    "format": "madr",
+                    "context": "Original context.",
+                    "decision": "Chosen option: \"Redis\", because it is fast."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let adr_path = tmp.path().join("doc/adr/0002-use-redis-for-caching.md");
+        let rich_content = r#"---
+number: 2
+title: Use Redis for caching
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Original context.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Good, because it provides pub/sub
+* Bad, because it needs memory
+
+### Confirmation
+
+We will confirm via load tests.
+"#;
+        std::fs::write(&adr_path, rich_content).unwrap();
+
+        client
+            .call_tool_text(
+                "update_content",
+                json!({
+                    "number": 2,
+                    "context": "Updated context text."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+
+        assert!(adr.content.contains("Updated context text."));
+        assert!(adr.content.contains("### Consequences"));
+        assert!(adr.content.contains("* Good, because it provides pub/sub"));
+        assert!(adr.content.contains("* Bad, because it needs memory"));
+        assert!(adr.content.contains("### Confirmation"));
+        assert!(adr.content.contains("We will confirm via load tests."));
+    }
+
+    #[tokio::test]
+    async fn test_create_adr_madr_with_consequences() {
+        let (client, _tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use Redis for caching",
+                    "format": "madr",
+                    "context": "We need caching.",
+                    "decision": "Chosen option: \"Redis\", because it is fast.",
+                    "consequences": "* Good, because it provides pub/sub"
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+
+        assert!(adr.content.contains("### Consequences"));
+        assert!(adr.content.contains("* Good, because it provides pub/sub"));
+    }
+
+    #[tokio::test]
+    async fn test_update_content_madr_consequences_only() {
+        let (client, tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use Redis for caching",
+                    "format": "madr",
+                    "context": "Context.",
+                    "decision": "Chosen option: \"Redis\", because it is fast."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let adr_path = tmp.path().join("doc/adr/0002-use-redis-for-caching.md");
+        let rich_content = r#"---
+number: 2
+title: Use Redis for caching
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Old consequence
+"#;
+        std::fs::write(&adr_path, rich_content).unwrap();
+
+        client
+            .call_tool_text(
+                "update_content",
+                json!({
+                    "number": 2,
+                    "consequences": "* New consequence"
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+
+        assert!(
+            adr.content
+                .contains("Chosen option: \"Redis\", because it is fast.")
+        );
+        assert!(adr.content.contains("* New consequence"));
+        assert!(!adr.content.contains("* Old consequence"));
+    }
+
+    #[tokio::test]
+    async fn test_update_status_madr_preserves_rich_body() {
+        let (client, tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use Redis for caching",
+                    "format": "madr",
+                    "context": "Context.",
+                    "decision": "Chosen option: \"Redis\", because it is fast."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let adr_path = tmp.path().join("doc/adr/0002-use-redis-for-caching.md");
+        let rich_content = r#"---
+number: 2
+title: Use Redis for caching
+date: 2026-01-15
+status: proposed
+---
+
+## Context and Problem Statement
+
+Context.
+
+## Decision Outcome
+
+Chosen option: "Redis", because it is fast.
+
+### Consequences
+
+* Good item
+
+### Confirmation
+
+Confirm via tests.
+"#;
+        std::fs::write(&adr_path, rich_content).unwrap();
+
+        client
+            .call_tool_text("update_status", json!({"number": 2, "status": "accepted"}))
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+
+        assert!(
+            adr.content.contains("status: accepted") || adr.status.eq_ignore_ascii_case("accepted")
+        );
+        assert!(adr.content.contains("### Consequences"));
+        assert!(adr.content.contains("* Good item"));
+        assert!(adr.content.contains("### Confirmation"));
+        assert!(adr.content.contains("Confirm via tests."));
+    }
+
+    #[tokio::test]
     async fn test_update_tags_ng_mode() {
         let (client, _tmp) = setup_client(true).await;
 

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -2096,6 +2096,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_content_madr_preserves_decision() {
+        // MADR 4.0.0 ADRs must not be re-rendered as Nygard/adr-tools on update_content.
+        let (client, _tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use Redis for caching",
+                    "format": "madr",
+                    "context": "Original context about caching needs.",
+                    "decision": "Chosen option: \"Redis\", because it is fast."
+                }),
+            )
+            .await
+            .unwrap();
+
+        client
+            .call_tool_text(
+                "update_content",
+                json!({
+                    "number": 2,
+                    "context": "Updated context text."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+
+        assert!(
+            adr.content.contains("Updated context text."),
+            "context should be updated, got:\n{}",
+            adr.content
+        );
+        assert!(
+            adr.content.contains("Chosen option: \"Redis\""),
+            "decision should be preserved, got:\n{}",
+            adr.content
+        );
+        assert!(
+            adr.content.contains("Context and Problem Statement"),
+            "MADR 4.0.0 heading should be preserved, got:\n{}",
+            adr.content
+        );
+        assert!(
+            adr.content.contains("Decision Outcome"),
+            "MADR 4.0.0 heading should be preserved, got:\n{}",
+            adr.content
+        );
+        assert!(
+            !adr.content
+                .contains("What is the change that we're proposing"),
+            "Nygard/adr-tools placeholder should not appear, got:\n{}",
+            adr.content
+        );
+    }
+
+    #[tokio::test]
     async fn test_update_tags_ng_mode() {
         let (client, _tmp) = setup_client(true).await;
 

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -2327,6 +2327,74 @@ Chosen option: "Redis", because it is fast.
     }
 
     #[tokio::test]
+    async fn test_update_content_nygard_consequences_only() {
+        // Nygard ADRs use top-level ## Consequences; consequences-only updates must
+        // patch that H2 and leave ## Decision untouched (no MADR ### injection).
+        let (client, tmp) = setup_client(true).await;
+
+        client
+            .call_tool_text(
+                "create_adr",
+                json!({
+                    "title": "Use Redis for caching",
+                    "context": "Context.",
+                    "decision": "Original decision."
+                }),
+            )
+            .await
+            .unwrap();
+
+        let adr_path = tmp.path().join("doc/adr/0002-use-redis-for-caching.md");
+        let content = r#"---
+number: 2
+title: Use Redis for caching
+date: 2026-01-15
+status: proposed
+---
+
+## Context
+
+Context.
+
+## Decision
+
+Original decision.
+
+## Consequences
+
+* Old item
+"#;
+        std::fs::write(&adr_path, content).unwrap();
+
+        client
+            .call_tool_text(
+                "update_content",
+                json!({
+                    "number": 2,
+                    "consequences": "* New item"
+                }),
+            )
+            .await
+            .unwrap();
+
+        let result = client
+            .call_tool_text("get_adr", json!({"number": 2}))
+            .await
+            .unwrap();
+        let adr: AdrDetail = serde_json::from_str(&result).unwrap();
+
+        assert!(adr.content.contains("Original decision."));
+        assert!(adr.content.contains("## Consequences"));
+        assert!(adr.content.contains("* New item"));
+        assert!(!adr.content.contains("* Old item"));
+        assert!(
+            !adr.content.contains("### Consequences"),
+            "Nygard ADR should not get MADR ### Consequences under Decision, got:\n{}",
+            adr.content
+        );
+    }
+
+    #[tokio::test]
     async fn test_update_status_madr_preserves_rich_body() {
         let (client, tmp) = setup_client(true).await;
 

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -1183,6 +1183,12 @@ impl AdrState {
             body.consequences = Some(consequences);
         }
 
+        if body.is_empty() {
+            return Err(
+                "At least one of context, decision, or consequences must be provided".to_string(),
+            );
+        }
+
         let path = repo.update(&adr, body).map_err(|e| e.to_string())?;
 
         #[derive(Serialize)]

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -1007,6 +1007,13 @@ impl AdrState {
         }
 
         // Set MADR metadata fields if provided.
+        let metadata_fields_updated = params
+            .decision_makers
+            .as_ref()
+            .is_some_and(|m| !m.is_empty())
+            || params.consulted.as_ref().is_some_and(|c| !c.is_empty())
+            || params.informed.as_ref().is_some_and(|i| !i.is_empty());
+
         if let Some(makers) = params.decision_makers
             && !makers.is_empty()
         {
@@ -1027,6 +1034,10 @@ impl AdrState {
         }
 
         // Handle tags.
+        let tags_updated = params
+            .tags
+            .as_ref()
+            .is_some_and(|tag_list| !tag_list.is_empty() && repo.config().is_next_gen());
         if let Some(tag_list) = params.tags
             && !tag_list.is_empty()
         {
@@ -1042,12 +1053,17 @@ impl AdrState {
             }
         }
 
-        // Re-render if any content or metadata was provided.
-        let final_path = if content_updated {
-            repo.update(&adr, body).map_err(|e| e.to_string())?
-        } else {
-            path
-        };
+        // Apply metadata and body updates separately so body patches never rewrite metadata.
+        let metadata_updated = metadata_fields_updated || tags_updated;
+        let body_updated = !body.is_empty();
+
+        let mut final_path = path;
+        if metadata_updated {
+            final_path = repo.update_metadata(&adr).map_err(|e| e.to_string())?;
+        }
+        if body_updated {
+            final_path = repo.update(&adr, body).map_err(|e| e.to_string())?;
+        }
 
         #[derive(Serialize)]
         struct CreateResponse {

--- a/doc/adr/0009-surgical-body-section-updates.md
+++ b/doc/adr/0009-surgical-body-section-updates.md
@@ -1,0 +1,59 @@
+# 9. Surgical body section updates preserve on-disk markdown
+
+Date: 2026-07-11
+
+## Status
+
+Proposed
+
+## Context
+
+`Repository::update` and MCP tools such as `update_content` and `create_adr` follow a read-modify-write path: load the ADR, mutate in-memory fields, then write the file back. For body sections, the write path previously re-rendered every canonical section from the in-memory `Adr` struct.
+
+That approach is unsafe because `parse_sections` is intentionally lossy when reading markdown. It flattens pulldown-cmark events to plain text, which drops structure that ADRs commonly contain:
+
+- MADR 4.0.0 H3 subsections under `## Decision Outcome` (`### Consequences`, `### Confirmation`, and others)
+- Bulleted and numbered lists
+- Links and inline code
+- Optional MADR H2 sections such as `## Considered Options` and `## Pros and Cons of the Options`
+
+A context-only MCP update therefore corrupted untouched sections: Decision Outcome subsections disappeared, bullets flattened, and links lost their markdown syntax. The same bug affected NextGen Nygard ADRs and legacy adr-tools files, not only MADR 4.0.0.
+
+Metadata-only updates already had a separate, byte-preserving path (`update_metadata`). Body updates did not.
+
+## Decision
+
+Patch only the body sections the caller explicitly requests to change. Leave all other on-disk bytes untouched.
+
+1. **`BodySectionPatch` API** — `Repository::update(adr, patch)` takes optional `context`, `decision`, and `consequences` fields. `None` means do not rewrite that section. An empty patch runs metadata-only updates via the same path as `update_metadata`.
+
+2. **Metadata/body split** — When `body` is non-empty, `update()` patches body sections only and does not rewrite metadata bytes (status, links, tags, or frontmatter people fields). MCP `create_adr` calls `update_metadata` and `update` separately when both are needed.
+
+3. **No lossy round-trip for unmodified sections** — Never source write content from reparsed `Adr` fields for sections absent from the patch, even if those fields were populated by `get()` or `parse()`.
+
+4. **Fence-aware scanners** — Body section patching ignores `##` / `###` lines inside markdown code fences when locating section boundaries.
+
+5. **MADR `## Decision Outcome`** — When `decision` is patched, replace only the intro text before the first `###` heading outside fences. Preserve all other H3 subsections verbatim.
+
+6. **Consequences routing**:
+   - **MADR**: Patch the `### Consequences` subsection under `## Decision Outcome`. If a consequences patch is requested but that subsection does not exist, append `### Consequences` under Decision Outcome.
+   - **Nygard / adr-tools**: When a top-level `## Consequences` H2 exists, patch that section and leave `## Decision` untouched. Do not inject a MADR-style `### Consequences` under Decision. If a consequences patch is requested but no `## Consequences` H2 exists, return an error (do not append under `## Decision`).
+
+7. **People-field YAML** — Frontmatter `decision-makers`, `consulted`, and `informed` blocks are rewritten only when the in-memory value differs from the parsed on-disk value.
+
+8. **Missing section headings** — `update()` returns an error when a patch field is set but no matching section heading exists on disk (including Nygard consequences without a `## Consequences` H2).
+
+9. **Unknown H2 sections** — Sections that are not canonical context/decision/consequences headings are always copied verbatim from the existing file.
+
+10. **Caller contract** — MCP `update_content` builds `BodySectionPatch` from only the parameters the caller supplied, not from the full in-memory ADR after `get()`. MCP `update_content` rejects calls where all of `context`, `decision`, and `consequences` are omitted.
+
+This logic lives in `adrs-core` (see ADR 4). It applies in both compatible and NextGen repositories and to on-disk files in either Nygard or MADR layout (see ADR 5). MCP is a primary caller (see ADR 8).
+
+## Consequences
+
+- Untouched sections remain byte-identical on disk, including rich markdown, fenced examples, and MADR-specific structure
+- Body-only MCP `update_content` no longer rewrites legacy `## Status` prose or frontmatter people fields
+- The parser may remain lossy for reads, search, and display; correctness depends on disciplined write paths
+- **`validate_adr` false positives on MADR 4.0.0** remain a read/validation gap (out of scope; see option (b) in PR #311 review)
+- Intentional changes to people fields in non-canonical YAML shapes may still corrupt frontmatter; defer full-node YAML rewrite
+- Deferred follow-ups: MADR consequences read round-trip, CRLF preservation through `lines()`, Nygard `## Consequences` before `## Decision` duplicate injection

--- a/doc/adr/0009-surgical-body-section-updates.md
+++ b/doc/adr/0009-surgical-body-section-updates.md
@@ -36,10 +36,11 @@ Patch only the body sections the caller explicitly requests to change. Leave all
 5. **MADR `## Decision Outcome`** — When `decision` is patched, replace only the intro text before the first `###` heading outside fences. Preserve all other H3 subsections verbatim.
 
 6. **Consequences routing**:
-   - **MADR**: Patch the `### Consequences` subsection under `## Decision Outcome`. If a consequences patch is requested but that subsection does not exist, append `### Consequences` under Decision Outcome.
-   - **Nygard / adr-tools**: When a top-level `## Consequences` H2 exists, patch that section and leave `## Decision` untouched. Do not inject a MADR-style `### Consequences` under Decision. If a consequences patch is requested but no `## Consequences` H2 exists, return an error (do not append under `## Decision`).
+   - When a top-level `## Consequences` H2 exists anywhere outside fences (before or after Decision), patch that H2 and do not inject `### Consequences` under Decision Outcome / Decision.
+   - **MADR** (no Consequences H2): Patch the `### Consequences` subsection under `## Decision Outcome`. If that subsection does not exist, append `### Consequences` under Decision Outcome.
+   - **Nygard / adr-tools** (no Consequences H2): return an error (do not append under `## Decision`).
 
-7. **People-field YAML** — Frontmatter `decision-makers`, `consulted`, and `informed` blocks are rewritten only when the in-memory value differs from the parsed on-disk value.
+7. **People-field YAML** — Frontmatter metadata writes parse the YAML block into a `Mapping`, mutate managed keys (`status`, `links`, `tags`, people fields), and re-emit. String-or-list people/tag values that already match semantically are left untouched so block scalars and unusual list indent survive no-op and status/link updates.
 
 8. **Missing section headings** — `update()` returns an error when a patch field is set but no matching section heading exists on disk (including Nygard consequences without a `## Consequences` H2).
 
@@ -54,6 +55,6 @@ This logic lives in `adrs-core` (see ADR 4). It applies in both compatible and N
 - Untouched sections remain byte-identical on disk, including rich markdown, fenced examples, and MADR-specific structure
 - Body-only MCP `update_content` no longer rewrites legacy `## Status` prose or frontmatter people fields
 - The parser may remain lossy for reads, search, and display; correctness depends on disciplined write paths
-- **`validate_adr` false positives on MADR 4.0.0** remain a read/validation gap (out of scope; see option (b) in PR #311 review)
-- Intentional changes to people fields in non-canonical YAML shapes may still corrupt frontmatter; defer full-node YAML rewrite
-- Deferred follow-ups: MADR consequences read round-trip, CRLF preservation through `lines()`, Nygard `## Consequences` before `## Decision` duplicate injection
+- **`validate_adr` false positives on MADR 4.0.0** remain a read/validation gap (out of scope)
+- YAML comments in frontmatter are not preserved when any managed metadata field changes (Mapping re-emit)
+- Deferred follow-ups: MADR `### Consequences` read round-trip (`get_adr_sections` still folds H3 into decision), CRLF preservation through `lines()`, blank-line cosmetics after replaced section bodies

--- a/doc/adr/0009-surgical-body-section-updates.md
+++ b/doc/adr/0009-surgical-body-section-updates.md
@@ -54,6 +54,7 @@ This logic lives in `adrs-core` (see ADR 4). It applies in both compatible and N
 
 - Untouched sections remain byte-identical on disk, including rich markdown, fenced examples, and MADR-specific structure
 - Body-only MCP `update_content` no longer rewrites legacy `## Status` prose or frontmatter people fields
+- Callers must pass `BodySectionPatch`; an empty patch updates metadata only and does not re-render body text from in-memory `Adr` fields. `BodySectionPatch` is `#[non_exhaustive]`, so out-of-crate construction uses `new()` / `with_*` (or field assignment after `Default`).
 - The parser may remain lossy for reads, search, and display; correctness depends on disciplined write paths
 - **`validate_adr` false positives on MADR 4.0.0** remain a read/validation gap (out of scope)
 - YAML comments in frontmatter are not preserved when any managed metadata field changes (Mapping re-emit)


### PR DESCRIPTION
> Human note: Resolves #310

## Summary

Fixes silent data loss when **MCP `update_content`** (or MCP `create_adr` with body fields) is used on MADR 4.0.0 ADRs. The shipped **CLI is not affected** — no CLI command calls `Repository::update` for section bodies; `adrs status`/`adrs link` use the body-safe `update_metadata` path, and `adrs edit` uses an external editor.

Two interacting bugs in `adrs-core` are addressed:

- **Parser** did not map MADR 4.0.0 section headings (`Context and Problem Statement`, `Decision Outcome`) to `context` / `decision` fields, so body text was never loaded before write.
- **`Repository::update`** fully re-rendered the file from the Nygard/adr-tools template, rewriting headings and inserting placeholders for fields the parser had dropped.

The fix maps section aliases at parse time and replaces full re-render with in-place section patching (consistent with how `update_metadata` already preserves bodies for status/link/tag changes).

## Scope

- **Trigger:** MCP `update_content` and MCP `create_adr` (with `context`/`decision`/`consequences`) — both call `Repository::update`.
- **CLI:** Not affected for body edits (no CLI equivalent to `update_content`).
- **NextGen mode:** Not required; MADR 4.0.0 files in any repo mode are fixed. NextGen repos are the most common case.

## Changes

### `adrs-core` parser (`parse.rs`)

- Add `canonical_section_field()` mapping Nygard/adr-tools and MADR 4.0.0 H2 heading names to canonical body fields.
- Use alias mapping in `apply_section` (legacy) and frontmatter body parsing.
- Strengthen MADR parse tests to assert body fields are populated.

### `adrs-core` repository (`repository.rs`)

- Change `Repository::update` to surgically update metadata + body sections instead of template re-render.
- Add `update_body_sections()` — patches only `context` / `decision` / `consequences` bodies while preserving original headings and extra sections (e.g. `Considered Options`).
- Extend `update_frontmatter_metadata` for MADR 4.0.0 fields: `decision-makers`, `consulted`, `informed` (needed for `create_adr` with MADR metadata).

### MCP tests (`mcp.rs`)

- Add `test_update_content_madr_preserves_decision` regression test.

## Behavior after fix

| Scenario | Before | After |
|----------|--------|-------|
| MCP `update_content` with only `context` on MADR 4.0.0 ADR | Decision replaced with Nygard placeholder; headings rewritten | Context updated; decision and MADR headings preserved |
| MCP `create_adr` with `decision_makers` on MADR format | Broken after initial refactor (no frontmatter write) | `decision-makers` written to frontmatter |
| Nygard/adr-tools ADRs via MCP `update_content` | Worked (exact section names) | Unchanged |
| CLI `adrs status` / `adrs link` on MADR 4.0.0 ADRs | Already safe (`update_metadata`) | Unchanged |

  ## Test plan
  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all-features`
  - [x] Rebased onto `upstream/main` @ v0.9.0
  - [x] `BodySectionPatch` — patch only caller-supplied body sections (`Repository::update(adr, patch)`)
  - [x] Issue #310 — MADR alias parsing; no full template re-render on body update
  - [x] Jul 6 review — H3 subsections / bullets / links preserved on context-only MADR update
  - [x] Jul 6 review — MADR `consequences` writes to `### Consequences` (not silently dropped)
  - [x] Jul 10 blocking — fence-aware section scanners (heading-like lines inside fences ignored)
  - [x] Jul 10 blocking — `append_lines` newline glue for files without trailing newline
  - [x] Jul 10 blocking — people-field YAML skip-if-unchanged; body-only updates skip frontmatter
  - [x] Jul 10 blocking — body-only updates do not rewrite legacy `## Status` prose
  - [x] Jul 10 non-blocking — missing section heading returns error (not silent success)
  - [x] Tidy pass — Nygard without `## Consequences` errors (no MADR `###` injection)
  - [x] Tidy pass — MCP `update_content` rejects empty body patch
  - [x] ADR 0009 added (surgical body update contract)
  - [x] MCP: `test_update_content_madr_preserves_h3_subsections`, `test_update_content_madr_consequences_only`, `test_update_content_nygard_consequences_only`
  - [x] Manual repro: Jul 10 blocking items via scratch `adrs-core` harness (local)

## Notes

- Supports the two documented on-disk formats: **Nygard/adr-tools** (no version; Michael Nygard / adr-tools layout) and **MADR 4.0.0**.
- Does not add support for older MADR versions (e.g. 3.x `deciders` frontmatter field).
- Closes: #310 310
