### PR TITLE
chore(deps): update anyhow and plist to resolve RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_cmd"
@@ -1510,9 +1510,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -1639,9 +1639,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Summary

Lockfile-only update resolving all four current RUSTSEC advisories against the dependency tree.

| Advisory | Crate | Locked | Patched in | Update |
|----------|-------|--------|------------|--------|
| RUSTSEC-2026-0190 | anyhow | 1.0.95 | >= 1.0.103 | 1.0.103 |
| RUSTSEC-2026-0194 | quick-xml | 0.38.4 | >= 0.41.0 | 0.41.0 |
| RUSTSEC-2026-0195 | quick-xml | 0.38.4 | >= 0.41.0 | 0.41.0 |
| RUSTSEC-2026-0204 | crossbeam-epoch | 0.9.18 | >= 0.9.20 | 0.9.20 |

## Details

- anyhow is a direct workspace dependency (`anyhow = "1"`).
- quick-xml is transitive: `mdbook-lint-core -> comrak -> syntect -> plist -> quick-xml`. plist 1.10.0 raises its quick-xml requirement to `^0.41.0` and syntect allows `plist ^1.3`, so updating plist moves quick-xml to 0.41.0. No manifest changes needed.
- crossbeam-epoch (RUSTSEC-2026-0204, published 2026-07-06, after the audit bot filed the issues above) is a dev-dependency chain: `assert_fs -> globwalk -> ignore -> crossbeam-deque -> crossbeam-epoch`. This advisory currently fails the Audit workflow on every branch, including main.

Remaining audit output after this PR is informational only: bincode 1.3.3 unmaintained (RUSTSEC-2025-0141, tracked in #259 discussion), yaml-rust unmaintained (RUSTSEC-2024-0320), and scc 2.4.0 unsound (RUSTSEC-2026-0205, via dev-dependency serial_test; fix requires an scc 3.x major bump upstream). None of these fail the audit job.

## Validation

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --all-features`: 650 tests pass

Closes #312
Closes #313
Closes #314