### PR TITLE
feat: supply pre-commit hook for adrs doctor

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: adrs-doctor
+  name: adrs doctor
+  description: Check ADR repository health (naming, numbering, links, superseded status).
+  entry: adrs doctor
+  language: system
+  files: \.md$
+  pass_filenames: false

--- a/book/src/commands/doctor.md
+++ b/book/src/commands/doctor.md
@@ -100,6 +100,34 @@ This allows using `doctor` in CI pipelines:
   run: adrs doctor
 ```
 
+## Pre-commit Hook
+
+`adrs` ships a [pre-commit](https://pre-commit.com) hook (also compatible
+with [prek](https://prek.j178.dev)) that runs `doctor` whenever a markdown
+file changes. Add it to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/joshrotenberg/adrs
+    rev: v0.8.0
+    hooks:
+      - id: adrs-doctor
+```
+
+The hook uses `language: system`, so it expects `adrs` to already be on
+`PATH`. See [Installation](../installation.md) for ways to install it
+(`cargo install adrs`, a release binary, Homebrew, etc.).
+
+The hook triggers on any staged `.md` file but always checks the whole
+repository, since `doctor`'s checks (numbering, links, superseded status)
+are repository-wide. If your ADRs live outside the default directory, scope
+the trigger further with `files:` in your own config, e.g.:
+
+```yaml
+      - id: adrs-doctor
+        files: ^doc/adr/.*\.md$
+```
+
 ## Related
 
 - [list](./list.md) - List ADRs


### PR DESCRIPTION
Closes #315

## Plan

Add a `.pre-commit-hooks.yaml` manifest at the repo root so `adrs doctor` can
be run as a pre-commit (and prek) hook in consumer repos, plus a short docs
section showing how to wire it up.

### Hook definition (`.pre-commit-hooks.yaml`)

```yaml
- id: adrs-doctor
  name: adrs doctor
  description: Check ADR repository health (naming, numbering, links, superseded status).
  entry: adrs doctor
  language: system
  files: \.md$
  pass_filenames: false
```

### Why `language: system` and not `language: rust`

Researched this before picking a language. pre-commit's `language: rust`
installer always runs `cargo install --bins --root <envdir> --path .` with
the hook repo's root as cwd (confirmed by reading
`pre_commit/languages/rust.py` upstream). `adrs`'s root `Cargo.toml` is a
virtual workspace manifest (`[workspace]` only, no `[package]`) with the
binary living in `crates/adrs`. Cargo's `--path` flag requires the target
path to contain a package manifest, not a virtual one, and errors
immediately with `error: found a virtual manifest ... instead of a package
manifest` -- confirmed empirically against this repo and reproduced in an
isolated minimal workspace, `default-members` does not change this.

Checked how other Rust-workspace CLIs with `.pre-commit-hooks.yaml` handle
this: `crate-ci/typos` and `crate-ci/committed` are both virtual workspaces
that ship a `*-src` hook with `language: rust`, but neither project actually
uses its own `*-src` hook in its own `.pre-commit-config.yaml` -- they use
the `language: python` (pip-installed prebuilt wheel) variant instead. That
suggests the `rust`-language source-install hook is not reliably functional
for virtual-workspace repos under vanilla `pre-commit`. `prek`'s own docs
confirm this gap explicitly: its Rust language page notes "`prek` supports
installing packages from virtual workspaces" as a `prek`-only enhancement
(https://github.com/j178/prek/issues/1180), i.e. upstream `pre-commit` does
not support it.

Given that, `language: system` is the safer, more portable choice: it works
identically under both `pre-commit` and `prek`, matches the convention used
by `doublify/pre-commit-rust` (the community's `cargo fmt`/`clippy`/`check`
hooks, all `language: system`), and doesn't compile `adrs` from source on
every consumer's machine. The tradeoff is that consumers must already have
`adrs` on `PATH` (`cargo install adrs`, a release binary, Homebrew, etc.) --
documented in the new docs section below.

### `files: \.md$`

`adrs doctor` always checks the whole repository (no filename args, hence
`pass_filenames: false`), so the `files:` pattern only gates *whether* the
hook runs at all, not what it operates on. Scoping to `\.md$` avoids running
the health check on commits that don't touch any markdown. Repos with a
non-default ADR directory can narrow this further in their own
`.pre-commit-config.yaml` (e.g. `files: ^doc/adr/.*\.md$`).

### Docs

Add a "Pre-commit hook" section to `book/src/commands/doctor.md` (next to
the existing CI-pipeline example) showing the consumer-side
`.pre-commit-config.yaml` snippet:

```yaml
repos:
  - repo: https://github.com/joshrotenberg/adrs
    rev: v0.8.0
    hooks:
      - id: adrs-doctor
```

### Validation

- `pre-commit validate-manifest .pre-commit-hooks.yaml` (or equivalent) to
  confirm the YAML is well-formed against the hook schema.
- `pre-commit try-repo` (and `prek try-repo` if available) from a scratch
  consumer repo containing a `doc/adr/` directory, with a built `adrs`
  binary on `PATH`, to confirm the hook actually installs and runs `adrs
  doctor` against a real repo. Results reported in this PR / final summary.

### Constraints

- No source changes to `adrs`/`adrs-core` -- this is a hook manifest + docs
  addition only.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D
  warnings`, and `cargo test` must stay green (no code touched, so this is
  a no-op check, but run anyway per project convention).
