### PR TITLE
feat: configurable doctor rules and warnings-as-errors via adrs.toml

### DIFF
--- a/book/src/commands/doctor.md
+++ b/book/src/commands/doctor.md
@@ -13,6 +13,8 @@ adrs doctor [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--ng` | No-op for `doctor` (prints a note; see below) |
+| `--ignore <RULE>` | Ignore a rule by ID or name (repeatable); merged with `[doctor].ignore` in `adrs.toml` |
+| `--warnings-as-errors` | Exit with status 1 if there are warnings, not just errors |
 | `-C, --cwd <DIR>` | Working directory |
 | `-h, --help` | Print help |
 
@@ -99,6 +101,25 @@ This allows using `doctor` in CI pipelines:
 - name: Check ADR health
   run: adrs doctor
 ```
+
+## Configuration
+
+`doctor` reads a `[doctor]` section from `adrs.toml`:
+
+```toml
+[doctor]
+# Rule IDs or rule names to suppress (matched case-insensitively)
+ignore = ["ADR011"]
+
+# Exit with status 1 if there are warnings, not just errors
+warnings_as_errors = false
+```
+
+`--ignore` flags on the command line merge with (do not replace) `[doctor].ignore`
+from config, so you can suppress an extra rule for a single run without editing
+`adrs.toml`. `--warnings-as-errors` on the command line ORs with
+`[doctor].warnings_as_errors`, so either one being set is enough to make warnings
+fail the check.
 
 ## Pre-commit Hook
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -55,6 +55,18 @@ no_edit = false
 # If omitted, defaults to none (no source_uri fields)
 # base_url = "https://github.com/org/repo/blob/main/doc/adr"
 
+# Doctor command configuration
+[doctor]
+# Rule IDs or rule names to suppress permanently (matched case-insensitively).
+# '--ignore' flags on the command line merge with this list, they do not replace it.
+# If omitted, defaults to an empty list (no rules suppressed)
+# ignore = ["ADR011"]
+
+# When true, 'adrs doctor' exits with status 1 if there are warnings, not just errors.
+# '--warnings-as-errors' on the command line ORs with this setting.
+# If omitted, defaults to false
+# warnings_as_errors = false
+
 # Template configuration
 [templates]
 # Default format: "nygard" or "madr"

--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -49,6 +49,10 @@ pub struct Config {
     /// Export command configuration.
     #[serde(default)]
     pub export: ExportConfig,
+
+    /// Doctor command configuration.
+    #[serde(default)]
+    pub doctor: DoctorConfig,
 }
 
 impl Default for Config {
@@ -61,6 +65,7 @@ impl Default for Config {
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         }
     }
 }
@@ -103,6 +108,7 @@ impl Config {
                 templates: TemplateConfig::default(),
                 generate: GenerateConfig::default(),
                 export: ExportConfig::default(),
+                doctor: DoctorConfig::default(),
             });
         }
 
@@ -178,6 +184,12 @@ impl Config {
         }
         if other.export.base_url.is_some() {
             self.export.base_url = other.export.base_url.clone();
+        }
+        if !other.doctor.ignore.is_empty() {
+            self.doctor.ignore = other.doctor.ignore.clone();
+        }
+        if other.doctor.warnings_as_errors {
+            self.doctor.warnings_as_errors = other.doctor.warnings_as_errors;
         }
     }
 }
@@ -291,6 +303,7 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
                 templates: TemplateConfig::default(),
                 generate: GenerateConfig::default(),
                 export: ExportConfig::default(),
+                doctor: DoctorConfig::default(),
             };
             return Ok(Some((current, config, ConfigSource::Project(legacy_path))));
         }
@@ -399,6 +412,18 @@ pub struct GenerateConfig {
 pub struct ExportConfig {
     /// Default base URL for source_uri in JSON export (used by `adrs export json` if `--base-url` is not given).
     pub base_url: Option<String>,
+}
+
+/// Doctor command configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DoctorConfig {
+    /// Rule IDs or rule names to suppress (e.g. "ADR011", "adr-numbering-sequential").
+    /// Matched case-insensitively against both Issue.rule_id and Issue.rule_name.
+    pub ignore: Vec<String>,
+
+    /// When true, `adrs doctor` exits with status 1 if there are warnings, not just errors.
+    pub warnings_as_errors: bool,
 }
 
 #[cfg(test)]
@@ -645,6 +670,7 @@ mode = "nextgen"
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -666,6 +692,7 @@ mode = "nextgen"
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -692,6 +719,7 @@ mode = "nextgen"
             },
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         };
 
         config.save(temp.path()).unwrap();
@@ -712,6 +740,7 @@ mode = "nextgen"
             templates: TemplateConfig::default(),
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -736,6 +765,7 @@ mode = "nextgen"
             },
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -1076,6 +1106,7 @@ mode = "nextgen"
             },
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         };
 
         base.merge(&other);
@@ -1325,6 +1356,7 @@ custom = "templates/my-adr.md"
             },
             generate: GenerateConfig::default(),
             export: ExportConfig::default(),
+            doctor: DoctorConfig::default(),
         };
 
         original.save(temp.path()).unwrap();
@@ -1594,5 +1626,132 @@ base_url = "https://github.com/org/repo/blob/main/doc/adr"
             Some("https://github.com/org/repo/blob/main/doc/adr".to_string()),
             "export.base_url should survive a save/load round-trip"
         );
+    }
+
+    // ========== DoctorConfig / ignore, warnings_as_errors Tests ==========
+
+    #[test]
+    fn test_doctor_config_default() {
+        let config = DoctorConfig::default();
+        assert!(config.ignore.is_empty());
+        assert!(!config.warnings_as_errors);
+    }
+
+    #[test]
+    fn test_doctor_ignore_from_toml() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+
+[doctor]
+ignore = ["ADR011", "MD013"]
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert_eq!(
+            config.doctor.ignore,
+            vec!["ADR011".to_string(), "MD013".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_doctor_warnings_as_errors_from_toml() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+
+[doctor]
+warnings_as_errors = true
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert!(config.doctor.warnings_as_errors);
+    }
+
+    #[test]
+    fn test_doctor_config_absent_defaults() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("adrs.toml"), "adr_dir = \"doc/adr\"\n").unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert!(config.doctor.ignore.is_empty());
+        assert!(!config.doctor.warnings_as_errors);
+    }
+
+    #[test]
+    fn test_config_merge_doctor_ignore() {
+        let mut base = Config::default();
+        let other = Config {
+            doctor: DoctorConfig {
+                ignore: vec!["ADR011".to_string()],
+                warnings_as_errors: false,
+            },
+            ..Default::default()
+        };
+
+        base.merge(&other);
+        assert_eq!(base.doctor.ignore, vec!["ADR011".to_string()]);
+
+        // An empty ignore list in `other` must not clobber an existing base list.
+        let mut base = Config {
+            doctor: DoctorConfig {
+                ignore: vec!["ADR011".to_string()],
+                warnings_as_errors: false,
+            },
+            ..Default::default()
+        };
+        let other = Config::default(); // doctor.ignore is empty
+
+        base.merge(&other);
+        assert_eq!(
+            base.doctor.ignore,
+            vec!["ADR011".to_string()],
+            "merge with empty doctor.ignore should not overwrite existing value"
+        );
+    }
+
+    #[test]
+    fn test_config_merge_doctor_warnings_as_errors() {
+        // merge: other.warnings_as_errors=false should NOT overwrite base.warnings_as_errors=true
+        let mut base = Config {
+            doctor: DoctorConfig {
+                ignore: vec![],
+                warnings_as_errors: true,
+            },
+            ..Default::default()
+        };
+        let other = Config::default(); // warnings_as_errors = false
+        base.merge(&other);
+        assert!(
+            base.doctor.warnings_as_errors,
+            "merge with warnings_as_errors=false should not overwrite true"
+        );
+    }
+
+    #[test]
+    fn test_doctor_config_save_load_roundtrip() {
+        let temp = TempDir::new().unwrap();
+        let original = Config {
+            mode: ConfigMode::NextGen,
+            doctor: DoctorConfig {
+                ignore: vec!["ADR011".to_string()],
+                warnings_as_errors: true,
+            },
+            ..Default::default()
+        };
+
+        original.save(temp.path()).unwrap();
+        let loaded = Config::load(temp.path()).unwrap();
+
+        assert_eq!(loaded.doctor.ignore, vec!["ADR011".to_string()]);
+        assert!(loaded.doctor.warnings_as_errors);
     }
 }

--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -98,7 +98,10 @@ pub use export::{
     JsonAdrBulkExport, JsonAdrLink, JsonAdrSingle, RepositoryInfo, ToolInfo, export_adr,
     export_directory, export_directory_with_warnings, export_repository, import_to_directory,
 };
-pub use lint::{Issue, IssueSeverity, LintReport, check_all, check_repository, lint_adr, lint_all};
+pub use lint::{
+    Issue, IssueSeverity, LintReport, check_all, check_all_filtered, check_repository, lint_adr,
+    lint_all,
+};
 pub use parse::Parser;
 pub use repository::Repository;
 pub use template::{Template, TemplateEngine, TemplateFormat, TemplateVariant};

--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -314,11 +314,17 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
     Ok(report)
 }
 
-/// Run all checks: per-file lint + repository-level checks.
+/// Run all checks and filter out issues matching ignored rule IDs/names.
 ///
-/// Also reports files that look like ADRs (digit-prefixed `.md` files in the
-/// ADR directory) but could not be parsed (e.g., invalid YAML frontmatter).
-pub fn check_all(repo: &Repository) -> Result<LintReport> {
+/// Ignored rules are `repo.config().doctor.ignore` unioned with `extra_ignore`
+/// (e.g. CLI `--ignore` flags for a single invocation). Matching is
+/// case-insensitive against both `Issue.rule_id` and `Issue.rule_name`.
+///
+/// Returns the filtered report and the count of issues that were suppressed.
+pub fn check_all_filtered(
+    repo: &Repository,
+    extra_ignore: &[String],
+) -> Result<(LintReport, usize)> {
     let mut report = LintReport::new();
 
     // Use list_with_errors to capture parse failures
@@ -351,7 +357,36 @@ pub fn check_all(repo: &Repository) -> Result<LintReport> {
     report.issues.extend(repo_report.issues);
 
     report.sort();
-    Ok(report)
+
+    let ignore_set: std::collections::HashSet<String> = repo
+        .config()
+        .doctor
+        .ignore
+        .iter()
+        .chain(extra_ignore.iter())
+        .map(|s| s.to_lowercase())
+        .collect();
+
+    if ignore_set.is_empty() {
+        return Ok((report, 0));
+    }
+
+    let before = report.issues.len();
+    report.issues.retain(|issue| {
+        !ignore_set.contains(&issue.rule_id.to_lowercase())
+            && !ignore_set.contains(&issue.rule_name.to_lowercase())
+    });
+    let suppressed = before - report.issues.len();
+
+    Ok((report, suppressed))
+}
+
+/// Run all checks: per-file lint + repository-level checks.
+///
+/// Also reports files that look like ADRs (digit-prefixed `.md` files in the
+/// ADR directory) but could not be parsed (e.g., invalid YAML frontmatter).
+pub fn check_all(repo: &Repository) -> Result<LintReport> {
+    check_all_filtered(repo, &[]).map(|(report, _)| report)
 }
 
 #[cfg(test)]
@@ -679,6 +714,118 @@ Some consequences.
         assert_eq!(
             adr011, 0,
             "Single valid ADR should have no sequential-gap issue"
+        );
+    }
+
+    // ========== check_all_filtered / [doctor].ignore (issue #316) ==========
+
+    #[test]
+    fn test_check_all_filtered_suppresses_ignored_rule() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        // init creates ADR #1 automatically; write #2 and #4 to create a gap at #3,
+        // which trips ADR011 (Warning severity, confirmed via
+        // test_check_repository_sequential_gap_adr011).
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr(2, "Second", "Accepted", ""),
+        )
+        .unwrap();
+        std::fs::write(
+            adr_dir.join("0004-fourth.md"),
+            make_nygard_adr(4, "Fourth", "Accepted", ""),
+        )
+        .unwrap();
+
+        // Unfiltered: check_repository still reports ADR011.
+        let unfiltered = check_repository(&repo).unwrap();
+        let unfiltered_adr011 = unfiltered
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR011")
+            .count();
+        assert!(
+            unfiltered_adr011 > 0,
+            "expected check_repository to report ADR011 before filtering"
+        );
+
+        // Write adrs.toml with a lowercase ignore entry, then re-open the repository
+        // so the config is loaded from disk (Repository::init keeps the in-memory
+        // config it built at creation time).
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\n\n[doctor]\nignore = [\"adr011\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+        assert_eq!(repo.config().doctor.ignore, vec!["adr011".to_string()]);
+
+        // check_all (and check_all_filtered) should no longer contain ADR011,
+        // proving case-insensitive matching against the real rule_id "ADR011".
+        let filtered = check_all(&repo).unwrap();
+        let filtered_adr011 = filtered
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR011")
+            .count();
+        assert_eq!(
+            filtered_adr011, 0,
+            "check_all should suppress ADR011 issues per [doctor].ignore"
+        );
+
+        // check_repository (unfiltered) should still report ADR011 -- filtering
+        // is check_all-level only.
+        let still_unfiltered = check_repository(&repo).unwrap();
+        assert!(
+            still_unfiltered
+                .issues
+                .iter()
+                .any(|i| i.rule_id == "ADR011"),
+            "check_repository should remain unfiltered"
+        );
+    }
+
+    #[test]
+    fn test_check_all_filtered_returns_suppressed_count() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr(2, "Second", "Accepted", ""),
+        )
+        .unwrap();
+        std::fs::write(
+            adr_dir.join("0004-fourth.md"),
+            make_nygard_adr(4, "Fourth", "Accepted", ""),
+        )
+        .unwrap();
+
+        let unfiltered = check_all(&repo).unwrap();
+        let unfiltered_adr011 = unfiltered
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR011")
+            .count();
+        assert!(unfiltered_adr011 > 0);
+
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\n\n[doctor]\nignore = [\"ADR011\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (filtered, suppressed_count) = check_all_filtered(&repo, &[]).unwrap();
+        assert_eq!(suppressed_count, unfiltered_adr011);
+        assert!(
+            filtered.issues.iter().all(|i| i.rule_id != "ADR011"),
+            "filtered report should not contain ADR011"
         );
     }
 }

--- a/crates/adrs/src/commands/doctor.rs
+++ b/crates/adrs/src/commands/doctor.rs
@@ -1,6 +1,6 @@
 //! Doctor command implementation.
 
-use adrs_core::{IssueSeverity, Repository, check_all};
+use adrs_core::{IssueSeverity, Repository, check_all_filtered};
 use anyhow::{Context, Result};
 use std::path::Path;
 
@@ -12,7 +12,11 @@ use std::path::Path;
 /// linting: the lint rules detect each ADR's format (Nygard or MADR) from the
 /// file itself, so the repository mode does not change which checks run. When
 /// `--ng` is passed we say so rather than ignoring it silently (see issue #306).
-pub fn doctor(root: &Path, ng: bool) -> Result<()> {
+///
+/// `ignore` is merged with `[doctor].ignore` from `adrs.toml` (see
+/// `check_all_filtered`). `warnings_as_errors` is OR'd with
+/// `[doctor].warnings_as_errors` from config (issue #316).
+pub fn doctor(root: &Path, ng: bool, ignore: Vec<String>, warnings_as_errors: bool) -> Result<()> {
     if ng {
         eprintln!(
             "note: --ng has no effect on 'doctor'; lint rules detect each ADR's format automatically"
@@ -22,10 +26,15 @@ pub fn doctor(root: &Path, ng: bool) -> Result<()> {
     let repo =
         Repository::open(root).context("Failed to open repository. Have you run 'adrs init'?")?;
 
-    let report = check_all(&repo).context("Failed to run health checks")?;
+    let (report, suppressed_count) =
+        check_all_filtered(&repo, &ignore).context("Failed to run health checks")?;
+    let warnings_as_errors = warnings_as_errors || repo.config().doctor.warnings_as_errors;
 
     if report.issues.is_empty() {
         println!("No issues found. Your ADR repository is healthy!");
+        if suppressed_count > 0 {
+            println!("{} issue(s) suppressed by ignore rules", suppressed_count);
+        }
         return Ok(());
     }
 
@@ -60,8 +69,11 @@ pub fn doctor(root: &Path, ng: bool) -> Result<()> {
         "Found {} error(s), {} warning(s), {} info(s)",
         error_count, warning_count, info_count
     );
+    if suppressed_count > 0 {
+        println!("{} issue(s) suppressed by ignore rules", suppressed_count);
+    }
 
-    if report.has_errors() {
+    if report.has_errors() || (warnings_as_errors && report.has_warnings()) {
         std::process::exit(1);
     }
 

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -73,6 +73,9 @@ CONFIGURATION:
     toc_prefix = \"./\"          # default prefix for 'generate toc' links (default: empty)
     [export]
     base_url = \"https://github.com/org/repo/blob/main/doc/adr\"  # default base URL for 'export json' (default: none)
+    [doctor]
+    ignore = [\"ADR011\"]          # rule IDs/names to suppress (default: none)
+    warnings_as_errors = false   # exit 1 on warnings too (default: false)
 
 Version:       ", env!("CARGO_PKG_VERSION"), "
 Documentation: https://joshrotenberg.com/adrs/"))]
@@ -304,7 +307,9 @@ Note: Use --by with 'superseded' to create a link to the replacing ADR.")]
     /// Check repository health
     #[command(after_long_help = "\
 EXAMPLES:
-  adrs doctor                  Run all health checks
+  adrs doctor                                Run all health checks
+  adrs doctor --ignore ADR011                Suppress a specific rule for this run
+  adrs doctor --warnings-as-errors           Exit 1 on warnings too, not just errors
 
 WHAT IT CHECKS:
   Per-file lint rules (title format, required sections, dates) and
@@ -313,8 +318,23 @@ WHAT IT CHECKS:
 NOTE ON --ng:
   The global --ng flag has no effect on 'doctor'. Lint rules detect each ADR's
   format (Nygard or MADR) from the file itself, so the repository mode does not
-  change which checks run. Passing --ng prints a note to that effect.")]
-    Doctor,
+  change which checks run. Passing --ng prints a note to that effect.
+
+CONFIGURATION:
+  [doctor].ignore in adrs.toml lists rule IDs/names to suppress permanently;
+  --ignore flags on the command line merge with (do not replace) that list.
+  [doctor].warnings_as_errors in adrs.toml, or --warnings-as-errors on the
+  command line, makes 'adrs doctor' exit with status 1 when there are
+  warnings, not just errors.")]
+    Doctor {
+        /// Ignore a rule by ID or name (repeatable); merged with [doctor].ignore in adrs.toml
+        #[arg(long, value_name = "RULE")]
+        ignore: Vec<String>,
+
+        /// Exit with status 1 if there are warnings, not just errors
+        #[arg(long)]
+        warnings_as_errors: bool,
+    },
 
     /// Generate documentation
     Generate {
@@ -700,9 +720,12 @@ fn main() -> Result<()> {
             let discovered = discover(&start_dir).ok();
             commands::config_with_discovery(&start_dir, discovered)
         }
-        Commands::Doctor => {
+        Commands::Doctor {
+            ignore,
+            warnings_as_errors,
+        } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
-            commands::doctor(&discovered.root, cli.ng)
+            commands::doctor(&discovered.root, cli.ng, ignore, warnings_as_errors)
         }
         Commands::Generate { command } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1548,6 +1548,158 @@ fn test_doctor_without_ng_flag_prints_no_note() {
     temp.close().unwrap();
 }
 
+// Tests for [doctor].ignore / --ignore and warnings-as-errors config (issue #316)
+
+/// Nygard-format ADR content that trips only warning-severity collection rules
+/// when used to create a numbering gap (mirrors adrs-core's lint.rs test helper).
+fn nygard_adr(number: u32, title: &str) -> String {
+    format!(
+        "# {number}. {title}\n\nDate: 2024-01-01\n\n## Status\n\nAccepted\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\nSome consequences.\n"
+    )
+}
+
+#[test]
+fn test_doctor_config_ignore_suppresses_diagnostic() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Create a numbering gap (ADR #1 already exists from init; add #2 and #4,
+    // skipping #3) to trip the ADR011 sequential-gap warning.
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        nygard_adr(2, "Second"),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("doc/adr/0004-fourth.md"),
+        nygard_adr(4, "Fourth"),
+    )
+    .unwrap();
+
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\n\n[doctor]\nignore = [\"ADR011\"]\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ADR011").not())
+        .stdout(predicate::str::contains("suppressed by ignore rules"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_doctor_warnings_as_errors_flag_exits_1_on_warnings_only() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Numbering gap trips only ADR011 (Warning), no errors.
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        nygard_adr(2, "Second"),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("doc/adr/0004-fourth.md"),
+        nygard_adr(4, "Fourth"),
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["doctor", "--warnings-as-errors"])
+        .assert()
+        .failure()
+        .code(1);
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_doctor_config_warnings_as_errors_exits_1_without_flag() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        nygard_adr(2, "Second"),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("doc/adr/0004-fourth.md"),
+        nygard_adr(4, "Fourth"),
+    )
+    .unwrap();
+
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\n\n[doctor]\nwarnings_as_errors = true\n",
+    )
+    .unwrap();
+
+    // Plain `adrs doctor`, no --warnings-as-errors flag.
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .failure()
+        .code(1);
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_doctor_ignore_flag_works_without_config() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Numbering gap is the only issue in this repo; no adrs.toml is written.
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        nygard_adr(2, "Second"),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("doc/adr/0004-fourth.md"),
+        nygard_adr(4, "Fourth"),
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["doctor", "--ignore", "ADR011"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ADR011").not());
+
+    temp.close().unwrap();
+}
+
 /// Smoke test for MCP feature availability (default since 0.6.1)
 #[test]
 #[cfg(feature = "mcp")]


### PR DESCRIPTION
Closes #316

## Plan

Add a `[doctor]` section to `adrs.toml` plus matching CLI flags so `adrs doctor` rules
can be ignored/disabled and warnings can optionally be treated as errors.

### 1. Config (`crates/adrs-core/src/config.rs`)

- New `DoctorConfig` struct, following the `GenerateConfig`/`ExportConfig` idiom:
  - `ignore: Vec<String>` -- rule IDs or rule names to suppress (e.g. `"ADR011"`,
    `"adr-numbering-sequential"`), matched case-insensitively.
  - `warnings_as_errors: bool` -- when true, `adrs doctor` exits 1 on warnings alone.
- `pub doctor: DoctorConfig` added to `Config`, `Default` impl updated.
- `Config::merge`: `ignore` -- other's list wins when non-empty (mirrors the
  Option-field precedent elsewhere in `merge`); `warnings_as_errors` -- other's
  `true` wins, `false` does not clobber an existing `true` (mirrors `no_edit`).

```toml
[doctor]
ignore = ["ADR011", "MD013"]
warnings_as_errors = true
```

### 2. Core filtering (`crates/adrs-core/src/lint.rs`)

- `Repository::config()` already exists (public, additive) -- no repository change needed.
- New `pub fn check_all_filtered(repo, extra_ignore: &[String]) -> Result<(LintReport, usize)>`
  runs the full `check_all` checks, then filters out issues whose `rule_id` or
  `rule_name` case-insensitively match `repo.config().doctor.ignore` unioned with
  `extra_ignore`. Returns the filtered report plus a suppressed-issue count.
- `check_all(repo)` becomes a thin wrapper: `check_all_filtered(repo, &[]).map(|(r, _)| r)`.
  Signature unchanged -- still public API, still unfiltered-signature-compatible.
- `lint_adr` / `lint_all` stay unfiltered (per-file linting, no repo config in scope).
- MCP's `run_doctor_impl` calls `check_all` directly, so it picks up config-level
  ignore filtering automatically -- verified, no MCP code change required.

### 3. CLI (`crates/adrs/src/commands/doctor.rs`, `crates/adrs/src/main.rs`)

- `adrs doctor --ignore <RULE>` (repeatable) merges with `[doctor].ignore` for that
  run via `check_all_filtered`.
- `adrs doctor --warnings-as-errors` forces the behavior on for that run regardless
  of config; `[doctor].warnings_as_errors = true` does the same without the flag.
- Exit code 1 when `report.has_errors()` OR (warnings-as-errors active AND
  `report.has_warnings()`).
- When any issues were suppressed, print `N issue(s) suppressed by ignore rules` so
  the filtering is visible.
- Doctor subcommand help epilog and the top-level `CONFIGURATION` help block updated
  to document `[doctor]`.

### 4. Docs

- `book/src/configuration.md`: add `[doctor]` section to the example `adrs.toml`.
- `book/src/commands/doctor.md`: document `--ignore` / `--warnings-as-errors` and the
  `[doctor]` config section.

### 5. Tests

- `config.rs`: parse `[doctor]` TOML, default empty/false, save/load roundtrip in
  NextGen mode.
- `lint.rs`: repo with a known-warning ADR, assert the issue disappears when ignored
  via config, matched case-insensitively on `rule_id`.
- `crates/adrs/tests/cli.rs`:
  - `adrs.toml` `[doctor].ignore` suppresses a diagnostic.
  - `--warnings-as-errors` makes a warnings-only repo exit 1.
  - `[doctor].warnings_as_errors = true` does the same without the flag.
  - `--ignore` flag works without any config file.
