### PR TITLE
fix: preserve link descriptions and hrefs in metadata writer

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -299,11 +299,28 @@ impl Repository {
             if let Ok(target_adr) = self.get(link.target) {
                 map.insert(
                     link.target,
-                    (target_adr.title.clone(), target_adr.filename()),
+                    (target_adr.title.clone(), Self::link_href(&target_adr)),
                 );
             }
         }
         map
+    }
+
+    /// The href to use when rendering a link to `target_adr`.
+    ///
+    /// Prefers the target's actual on-disk filename over a filename
+    /// re-derived from its title. The two can diverge (hand-named files,
+    /// files renamed after a title edit), and re-deriving produces hrefs
+    /// that point at files that don't exist (#325). Falls back to the
+    /// title-derived filename only when the target has no resolvable path.
+    fn link_href(target_adr: &Adr) -> String {
+        target_adr
+            .path
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .and_then(|f| f.to_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| target_adr.filename())
     }
 
     /// Create a new ADR.
@@ -634,6 +651,9 @@ impl Repository {
                 "  - target: {}\n    kind: {}\n",
                 link.target, kind_str
             ));
+            if let Some(description) = &link.description {
+                s.push_str(&format!("    description: {}\n", description));
+            }
         }
         s
     }
@@ -1986,5 +2006,123 @@ decision-makers: mschoettle
 
         let adr = adrs.iter().find(|a| a.number == 2).unwrap();
         assert_eq!(adr.decision_makers, vec!["mschoettle"]);
+    }
+
+    // ========== Link metadata round-trip Tests (#323, #325) ==========
+
+    #[test]
+    fn test_update_metadata_preserves_link_descriptions() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Linked ADR
+date: 2026-01-15
+status: proposed
+links:
+  - target: 1
+    kind: relatesto
+    description: Explains the connection
+---
+
+## Context
+
+Context.
+"#;
+        let adr_path = repo.adr_path().join("0002-linked-adr.md");
+        fs::write(&adr_path, content).unwrap();
+
+        let adr = repo.get(2).unwrap();
+        assert_eq!(
+            adr.links[0].description.as_deref(),
+            Some("Explains the connection")
+        );
+
+        // No-op update_metadata must not drop the description.
+        repo.update_metadata(&adr).unwrap();
+        let result = fs::read_to_string(&adr_path).unwrap();
+        assert!(result.contains("kind: relatesto"));
+        assert!(result.contains("description: Explains the connection"));
+    }
+
+    #[test]
+    fn test_update_metadata_kebab_case_kind_round_trips_verbatim() {
+        // KNOWN-QUIRK (#323, deferred): kebab-case `kind: relates-to` deserializes
+        // as LinkKind::Custom("relates-to") rather than LinkKind::RelatesTo (see
+        // the note on LinkKind). update_metadata must at least not silently
+        // rewrite it to the canonical "relatesto" spelling on write-back.
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+
+        let content = r#"---
+number: 2
+title: Linked ADR
+date: 2026-01-15
+status: proposed
+links:
+  - target: 1
+    kind: relates-to
+---
+
+## Context
+
+Context.
+"#;
+        let adr_path = repo.adr_path().join("0002-linked-adr.md");
+        fs::write(&adr_path, content).unwrap();
+
+        let adr = repo.get(2).unwrap();
+        assert_eq!(adr.links[0].kind, LinkKind::Custom("relates-to".into()));
+
+        repo.update_metadata(&adr).unwrap();
+        let result = fs::read_to_string(&adr_path).unwrap();
+        assert!(result.contains("kind: relates-to"));
+    }
+
+    #[test]
+    fn test_resolve_link_titles_uses_actual_filename_for_hand_named_target() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        // Target's on-disk filename deliberately differs from a slug of its title.
+        let target_content = "# 2. Use Rust for backend services\n\nDate: 2026-01-15\n\n## Status\n\nAccepted\n\n## Context\n\nContext.\n";
+        fs::write(
+            repo.adr_path().join("0002-use-rust-for-backend.md"),
+            target_content,
+        )
+        .unwrap();
+
+        let mut source = repo.get(1).unwrap();
+        source.add_link(AdrLink::new(2, LinkKind::Amends));
+
+        let titles = repo.resolve_link_titles(&source);
+        let (title, filename) = titles.get(&2).unwrap();
+        assert_eq!(title, "Use Rust for backend services");
+        assert_eq!(filename, "0002-use-rust-for-backend.md");
+    }
+
+    #[test]
+    fn test_link_href_prefers_actual_path_over_slugified_title() {
+        let target = Adr {
+            path: Some(PathBuf::from("/repo/doc/adr/0003-use-rust-for-backend.md")),
+            ..Adr::new(3, "Use Rust for backend services")
+        };
+        assert_eq!(
+            Repository::link_href(&target),
+            "0003-use-rust-for-backend.md"
+        );
+    }
+
+    #[test]
+    fn test_link_href_falls_back_to_slugified_title_when_path_missing() {
+        let target = Adr {
+            path: None,
+            ..Adr::new(3, "Use Rust for backend services")
+        };
+        assert_eq!(
+            Repository::link_href(&target),
+            "0003-use-rust-for-backend-services.md"
+        );
     }
 }

--- a/crates/adrs-core/src/types.rs
+++ b/crates/adrs-core/src/types.rs
@@ -242,6 +242,18 @@ impl AdrLink {
 }
 
 /// The kind of link between ADRs.
+///
+/// Note (#323): kebab-case frontmatter forms like `kind: relates-to` do not
+/// match the `#[serde(rename_all = "lowercase")]` names below (`relatesto`,
+/// `supersededby`, `amendedby`) and deserialize into `Custom` instead of the
+/// canonical variant. Mapping those forms onto the canonical variants via
+/// serde `alias`es would be straightforward, but the writer serializes
+/// canonical variants back out through the same `rename_all` (e.g.
+/// `RelatesTo` -> `"relatesto"`), so accepting `relates-to` as `RelatesTo`
+/// on read would silently rewrite it to `relatesto` on the next metadata
+/// write. That conflicts with the corpus's byte-identity goal for fixture
+/// 0007, so the kind-mapping fix is deferred; only the link-description
+/// round-trip is fixed here.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LinkKind {

--- a/crates/adrs-core/tests/adr_corpus.rs
+++ b/crates/adrs-core/tests/adr_corpus.rs
@@ -240,10 +240,11 @@ fn noop_metadata_update_is_byte_identical_for_well_formed_files() {
     // A get() followed by update_metadata() with nothing changed must leave
     // these files untouched, byte for byte. This is the core write-path
     // guarantee the corpus protects: canonical Nygard files, frontmatter
-    // files with people fields (0004), fence content (0008), and a file
-    // without a trailing newline (0009).
+    // files with people fields (0004), a legacy Amends link to a hand-named
+    // file (0005), fence content (0008), a file without a trailing newline
+    // (0009), and frontmatter links with descriptions (0007).
     let (tmp, repo) = corpus_repo();
-    for number in [1u32, 2, 3, 4, 8, 9] {
+    for number in [1u32, 2, 3, 4, 5, 7, 8, 9] {
         let file = tmp
             .path()
             .join("doc/adr")
@@ -271,17 +272,6 @@ fn noop_metadata_update_pins_known_rewrites() {
             .join(fixture_path(n).file_name().unwrap())
     };
 
-    // KNOWN-LOSSY (#325): 0005's Amends link href (`0003-use-rust-for-backend.md`,
-    // the file's real name) is regenerated from the target's title, producing
-    // a link to a file that does not exist.
-    let adr = repo.get(5).unwrap();
-    repo.update_metadata(&adr).unwrap();
-    let after = fs::read_to_string(file(5)).unwrap();
-    assert!(
-        after.contains("(0003-use-rust-for-backend-services.md)"),
-        "link hrefs are preserved now; tighten this pin and close #325"
-    );
-
     // KNOWN-LOSSY: 0006's explicit `Deprecated` status is materialized as
     // `Superseded` (the parse-side quirk written back to disk). The H1 and
     // body prose still mention "Deprecated", so assert on the Status section.
@@ -292,16 +282,6 @@ fn noop_metadata_update_pins_known_rewrites() {
     assert!(
         !after.contains("## Status\n\nDeprecated"),
         "0006 keeps its Deprecated status now; tighten this pin"
-    );
-
-    // KNOWN-LOSSY (#323): frontmatter link descriptions are dropped by the
-    // metadata writer.
-    let adr = repo.get(7).unwrap();
-    repo.update_metadata(&adr).unwrap();
-    let after = fs::read_to_string(file(7)).unwrap();
-    assert!(
-        !after.contains("Database choice affects token storage"),
-        "link descriptions survive update_metadata now; tighten this pin and close #323"
     );
 
     // KNOWN-LOSSY (#310): non-canonical status prose is rewritten to the

--- a/crates/adrs-core/tests/fixtures/adr-corpus/README.md
+++ b/crates/adrs-core/tests/fixtures/adr-corpus/README.md
@@ -16,11 +16,11 @@ row here.
 |------|--------|--------|----------|
 | 0001-record-architecture-decisions.md | Nygard | Accepted | Basic ADR |
 | 0002-use-postgresql-for-persistence.md | Nygard | Accepted | Supersedes link |
-| 0003-use-rust-for-backend.md | Nygard | Proposed | Multi-line consequences; filename deliberately differs from slugified title (#325) |
+| 0003-use-rust-for-backend.md | Nygard | Proposed | Multi-line consequences; filename deliberately differs from slugified title |
 | 0004-use-madr-format.md | MADR 4.0 | Accepted | YAML frontmatter, decision-makers, consulted, informed |
-| 0005-api-versioning-strategy.md | Nygard | Accepted | Amends link to a hand-named file (#325) |
+| 0005-api-versioning-strategy.md | Nygard | Accepted | Amends link to a hand-named file |
 | 0006-deprecated-xml-api.md | Nygard | Deprecated (parses as Superseded) | Superseded by link overrides declared status |
-| 0007-authentication-mechanism.md | MADR 4.0 | Accepted | Structured frontmatter links with descriptions (#323) |
+| 0007-authentication-mechanism.md | MADR 4.0 | Accepted | Structured frontmatter links with descriptions |
 | 0008-fenced-heading-examples.md | MADR 4.0 frontmatter | Accepted | Fenced code block containing heading-lookalike lines |
 | 0009-no-trailing-newline.md | Nygard | Accepted | File ends without a trailing newline |
 | 0010-non-canonical-status.md | Nygard | Free-form prose (parses as Proposed, #310) | Non-canonical status text |


### PR DESCRIPTION
## Problem

`Repository::update_metadata` (and the shared link-rendering helper it uses)
loses information on a no-op touch:

1. **#323** -- frontmatter `links:` entries with a `description:` field lose
   the description when `format_links_yaml` rewrites the block. Every
   `adrs status`, `adrs link`, and MCP metadata operation silently drops
   descriptions on the first touch of a file that has them.
2. **#325** -- legacy (Nygard) link lines are regenerated as
   `[N. Title](NNNN-slugified-title.md)` from the target ADR's *title*
   instead of its actual on-disk filename. If a target file was hand-named
   or renamed after a title edit, the rewritten href points at a file that
   does not exist.

Both bugs are pinned today by the corpus harness (`adr_corpus.rs`,
`noop_metadata_update_pins_known_rewrites`) added in #322.

## Plan

- `format_links_yaml` (repository.rs): emit `description:` after `kind:`
  when `AdrLink.description` is `Some`, matching the on-disk 2-space
  indented layout already used for `target`/`kind`.
- `resolve_link_titles` (repository.rs): resolve the href from the target
  ADR's actual `path` (file name on disk) instead of `Adr::filename()`
  (slug of title), falling back to the slug-derived name only when the
  target has no resolvable path. This helper is shared by `create`,
  `update`, and `update_legacy_metadata`, so the fix applies uniformly.
- Corpus test tightening in `adr_corpus.rs`:
  - remove the 0005 and 0007 pins from `noop_metadata_update_pins_known_rewrites`
  - add 5 and 7 to the byte-identical list in
    `noop_metadata_update_is_byte_identical_for_well_formed_files`
  - leave the 0006 and 0010 pins untouched (belong to #310 / PR #311)
- Update the corpus README table rows for 0003/0005/0007 to drop the
  #323/#325 references.
- Add focused unit tests in `repository.rs` for: description round-trip,
  href resolution for a hand-named target file, and href fallback when
  the target cannot be resolved.

### Kind mapping wart (deferred)

#323 also notes that frontmatter `kind: relates-to` (kebab-case)
deserializes as `LinkKind::Custom("relates-to")` rather than
`LinkKind::RelatesTo`. Mapping kebab-case forms to canonical variants via
serde `alias` is mechanically simple, but it changes what the *writer*
emits for that field on round-trip: today `Custom("relates-to")` echoes
the exact source string back (`"relates-to"`), which is what makes fixture
0007 byte-identical. If `relates-to` instead resolved to the canonical
`RelatesTo` variant, the writer would normalize it to `"relatesto"`
(`#[serde(rename_all = "lowercase")]`), breaking byte-identity for 0007.
Given the byte-identity goal for 0007 takes priority, this fix is
deferred; a comment is left at the `LinkKind` deserialization site
referencing #323.

Closes #323. Closes #325.
