### PR TITLE
docs: fix drift found by v0.9.0 release readiness audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ A command-line tool for creating and managing [Architecture Decision Records](ht
 
 - **adr-tools compatible** - works with existing ADR repositories
 - **Multiple formats** - supports Nygard (classic) and [MADR 4.0.0](https://adr.github.io/madr/) formats
-- **Template variants** - full, minimal, and bare templates
+- **Template variants** - full, minimal, bare, and bare-minimal templates
 - **Tags support** - categorize ADRs with tags (NextGen mode)
 - **Full-text search** - search ADR titles and content
-- **Repository health checks** - `doctor` command finds issues
+- **Repository health checks** - `doctor` command with configurable rules (`[doctor]` in adrs.toml) and a pre-commit hook
 - **Config discovery** - automatically finds ADR directory from subdirectories
 - **Import/Export** - JSON-ADR format with federation support
 - **MCP server** - AI agent integration via Model Context Protocol
@@ -38,7 +38,7 @@ cargo install adrs
 ### Docker
 
 ```sh
-docker run --rm -v $(pwd):/work ghcr.io/joshrotenberg/adrs init
+docker run --rm -v $(pwd):/workspace -w /workspace ghcr.io/joshrotenberg/adrs init
 ```
 
 ### Binary releases
@@ -81,6 +81,7 @@ Commands:
   import       Import ADRs from different formats
   template     Manage ADR templates
   completions  Generate shell completions
+  mcp          Start MCP server for AI agent integration (included by default)
   cheatsheet   Show quick reference for common workflows
 
 Options:
@@ -151,7 +152,7 @@ adrs generate book && cd book && mdbook serve
 adrs export json > decisions.json
 
 # Import from another repository
-adrs import decisions.json --renumber
+adrs import json decisions.json --renumber
 ```
 
 ## MCP Server (AI Integration)
@@ -172,7 +173,7 @@ Add to Claude Desktop config (`claude_desktop_config.json`):
 }
 ```
 
-The MCP server provides 15 tools for reading, creating, and managing ADRs.
+The MCP server provides tools for reading, creating, and managing ADRs.
 
 ## Library
 
@@ -180,7 +181,7 @@ The MCP server provides 15 tools for reading, creating, and managing ADRs.
 
 ```toml
 [dependencies]
-adrs-core = "0.7"
+adrs-core = "0.9"
 ```
 
 ```rust

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,11 @@ how to verify a complete release, and how to recover from failures.
 Releases are fully automated via two tools:
 
 1. **release-plz** -- opens a "Release PR" on every push to `main` that bumps
-   `Cargo.toml` versions and updates `CHANGELOG.md` based on conventional
-   commits. Merging that PR triggers step 2.
+   `Cargo.toml` versions and updates each crate's `CHANGELOG.md`
+   (`crates/adrs/CHANGELOG.md`, `crates/adrs-core/CHANGELOG.md`) based on
+   conventional commits. The root `CHANGELOG.md` is just a pointer to those
+   two files and is not updated by release-plz. Merging that PR triggers
+   step 2.
 
 2. **cargo-dist** -- when `release-plz` merges its PR it also pushes a version
    tag (e.g. `v0.7.4`). The tag triggers `.github/workflows/release.yml`, which
@@ -61,12 +64,15 @@ cargo-dist builds for five targets (configured in `dist-workspace.toml`):
 
 A complete release produces the following artifacts attached to the GitHub Release:
 
-- Five platform tarballs (one per target above): `adrs-v<VERSION>-<target>.tar.gz`
-- One SHA256 checksum file: `adrs-v<VERSION>-<target>.tar.gz.sha256` per tarball
-  (or a single `dist-manifest.json` containing all checksums)
+- Five platform archives (one per target above), unversioned names: `adrs-<target>.tar.xz`
+  for the four Linux/macOS targets, `adrs-x86_64-pc-windows-msvc.zip` for Windows
+- One SHA256 checksum file per archive: `<archive-name>.sha256`
+- A combined checksum file: `sha256.sum`
 - Shell installer: `adrs-installer.sh`
 - PowerShell installer: `adrs-installer.ps1`
 - Homebrew formula: committed to `joshrotenberg/homebrew-brew` as `Formula/adrs.rb`
+  (also attached to the release as `adrs.rb`)
+- Source archive and checksum: `source.tar.gz`, `source.tar.gz.sha256`
 - `dist-manifest.json`: the dist manifest for the release
 
 To verify:
@@ -82,8 +88,10 @@ gh release view v<VERSION> --repo joshrotenberg/adrs --json assets --jq '[.asset
 gh api repos/joshrotenberg/homebrew-brew/commits --jq '.[0].commit.message'
 ```
 
-Expected: the release should have at least 12-14 assets (5 tarballs + 5 checksums
-+ 2 installers + `dist-manifest.json`).
+`verify-release` (`.github/workflows/release.yml`) fails the release if there
+are fewer than 14 assets (5 archives + 5 checksums + 2 installers +
+`sha256.sum` + `dist-manifest.json`). A typical release has 17 assets, once
+the Homebrew formula and source archive are included.
 
 ## Required secrets
 
@@ -155,10 +163,11 @@ the PR in place on each push to `main`. Common issues:
 
 ### PR has a merge conflict
 
-release-plz manages `Cargo.toml` version fields and `CHANGELOG.md`. If
-another PR touching those files merges while the release-plz PR is open,
-close the release-plz PR and let release-plz open a fresh one on the next
-push to `main` (or trigger `release-plz.yml` via `workflow_dispatch`).
+release-plz manages `Cargo.toml` version fields and the per-crate
+`CHANGELOG.md` files. If another PR touching those files merges while the
+release-plz PR is open, close the release-plz PR and let release-plz open a
+fresh one on the next push to `main` (or trigger `release-plz.yml` via
+`workflow_dispatch`).
 
 ### Clippy or CI failure blocking the release PR
 
@@ -174,7 +183,8 @@ release PR and its resolution.
 If you need to release without release-plz (e.g. emergency patch):
 
 1. Update `version` in `Cargo.toml` (workspace root and all crate `Cargo.toml` files).
-2. Update `CHANGELOG.md` manually.
+2. Update the per-crate `CHANGELOG.md` files manually (`crates/adrs/CHANGELOG.md`,
+   `crates/adrs-core/CHANGELOG.md`).
 3. Commit and push to `main`.
 4. Push the tag manually:
 

--- a/book/src/commands/doctor.md
+++ b/book/src/commands/doctor.md
@@ -49,16 +49,7 @@ adrs doctor
 Output:
 
 ```
-Checking ADR repository health...
-
-[OK] File naming: All 5 ADRs follow naming convention
-[OK] Duplicate numbers: No duplicates found
-[OK] Numbering gaps: Numbers are sequential
-[OK] Broken links: All links are valid
-[OK] Superseded status: All superseded ADRs have links
-[OK] Parse errors: All ADRs parsed successfully
-
-Health check passed!
+No issues found. Your ADR repository is healthy!
 ```
 
 ### Repository with Issues
@@ -70,32 +61,33 @@ adrs doctor
 Output:
 
 ```
-Checking ADR repository health...
+error: [ADR012] doc/adr/0003-duplicate.md: Duplicate ADR number 2. Also used in: doc/adr/0002-use-postgresql.md
+warning: [ADR009] Filename number (0003) does not match title number (2) [doc/adr/0003-duplicate.md:1]
 
-[OK] File naming: All 5 ADRs follow naming convention
-[WARN] Numbering gaps: Gap after ADR 3 (next is 5)
-[ERROR] Broken links: ADR 4 links to non-existent ADR 99
-[WARN] Superseded status: ADR 2 is superseded but has no "Superseded by" link
-
-Health check found 3 issue(s)
+Found 1 error(s), 1 warning(s), 0 info(s)
 ```
+
+Each line has the form `<severity>: [<rule ID>] <message> [<location>]`. Rule
+IDs like `ADR009` and `ADR012` map to the checks below.
 
 ## Severity Levels
 
 | Level | Description |
 |-------|-------------|
-| OK | Check passed |
-| WARN | Potential issue, but not critical |
-| ERROR | Problem that should be fixed |
+| info | Informational, no action needed |
+| warning | Potential issue, but not critical |
+| error | Problem that should be fixed |
 
 ## Exit Codes
 
 | Code | Description |
 |------|-------------|
-| 0 | All checks passed |
-| 1 | One or more checks failed |
+| 0 | No issues, or only warnings/info (default) |
+| 1 | One or more errors, or warnings with `--warnings-as-errors` / `warnings_as_errors = true` |
 
-This allows using `doctor` in CI pipelines:
+By default, warnings alone do not fail the check; only errors do. Pass
+`--warnings-as-errors` (or set `warnings_as_errors = true` in `[doctor]`) to
+also fail on warnings. This allows using `doctor` in CI pipelines:
 
 ```yaml
 - name: Check ADR health
@@ -130,7 +122,7 @@ file changes. Add it to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/joshrotenberg/adrs
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
       - id: adrs-doctor
 ```

--- a/book/src/commands/export.md
+++ b/book/src/commands/export.md
@@ -31,7 +31,7 @@ adrs export json -d path/to/adrs  # Export from directory (no repo needed)
   "generated_at": "2024-01-15T10:30:00Z",
   "tool": {
     "name": "adrs",
-    "version": "0.7.4"
+    "version": "0.9.0"
   },
   "repository": {
     "adr_directory": "doc/adr"

--- a/book/src/commands/init.md
+++ b/book/src/commands/init.md
@@ -26,7 +26,9 @@ adrs init [OPTIONS] [DIRECTORY]
 
 The `init` command creates:
 
-1. A `.adr-dir` file in the current directory containing the ADR directory path
+1. A configuration file in the current directory: `.adr-dir` (containing the
+   ADR directory path) in compatible mode, or `adrs.toml` in NextGen mode
+   (`--ng`)
 2. The ADR directory (creates parent directories if needed)
 3. An initial ADR: `0001-record-architecture-decisions.md`
 
@@ -73,15 +75,18 @@ Creates the full directory path.
 adrs init --ng
 ```
 
-Creates the initial ADR with YAML frontmatter:
+Writes `adrs.toml` instead of `.adr-dir`, and creates the initial ADR with
+YAML frontmatter:
 
 ```markdown
 ---
-status: accepted
+number: 1
+title: Record architecture decisions
 date: 2024-01-15
+status: accepted
 ---
 
-# Record Architecture Decisions
+# 1. Record architecture decisions
 
 ...
 ```

--- a/book/src/commands/new.md
+++ b/book/src/commands/new.md
@@ -19,7 +19,7 @@ adrs new [OPTIONS] <TITLE>
 | Option | Description |
 |--------|-------------|
 | `-f, --format <FORMAT>` | Template format: `nygard` or `madr` (default: `nygard`) |
-| `-v, --variant <VARIANT>` | Template variant: `full`, `minimal`, or `bare` (default: `full`) |
+| `-v, --variant <VARIANT>` | Template variant: `full`, `minimal`, `bare`, or `bare-minimal` (default: `full`) |
 | `--template <PATH>` | Path to a custom template file (overrides `--format`/`--variant` and config) |
 | `--status <STATUS>` | Initial status (default: `default_status` from config, else `Proposed`) |
 | `-s, --supersedes <N>` | ADR number this supersedes |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -72,7 +72,7 @@ no_edit = false
 # Default format: "nygard" or "madr"
 format = "nygard"
 
-# Default variant: "full", "minimal", or "bare"
+# Default variant: "full", "minimal", "bare", or "bare-minimal"
 variant = "full"
 
 # Path to custom template file (optional)

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -28,10 +28,10 @@ Download the appropriate binary from the [releases page](https://github.com/josh
 
 | Platform | Architecture | Download |
 |----------|--------------|----------|
-| Linux | x86_64 | `adrs-x86_64-unknown-linux-gnu.tar.gz` |
-| Linux | aarch64 | `adrs-aarch64-unknown-linux-gnu.tar.gz` |
-| macOS | x86_64 (Intel) | `adrs-x86_64-apple-darwin.tar.gz` |
-| macOS | aarch64 (Apple Silicon) | `adrs-aarch64-apple-darwin.tar.gz` |
+| Linux | x86_64 | `adrs-x86_64-unknown-linux-gnu.tar.xz` |
+| Linux | aarch64 | `adrs-aarch64-unknown-linux-gnu.tar.xz` |
+| macOS | x86_64 (Intel) | `adrs-x86_64-apple-darwin.tar.xz` |
+| macOS | aarch64 (Apple Silicon) | `adrs-aarch64-apple-darwin.tar.xz` |
 | Windows | x86_64 | `adrs-x86_64-pc-windows-msvc.zip` |
 
 ## From Source

--- a/book/src/library.md
+++ b/book/src/library.md
@@ -8,7 +8,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-adrs-core = "0.7"
+adrs-core = "0.9"
 ```
 
 ## Basic Usage
@@ -23,8 +23,8 @@ fn main() -> anyhow::Result<()> {
     // Open existing repository
     let repo = Repository::open(Path::new("."))?;
     
-    // Or create with defaults if it doesn't exist
-    let repo = Repository::open_or_default(Path::new("."))?;
+    // Or create with defaults if it doesn't exist (returns Self, not Result)
+    let repo = Repository::open_or_default(Path::new("."));
     
     Ok(())
 }
@@ -34,6 +34,7 @@ fn main() -> anyhow::Result<()> {
 
 ```rust
 use adrs_core::Repository;
+use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
     let repo = Repository::open(Path::new("."))?;
@@ -49,7 +50,8 @@ fn main() -> anyhow::Result<()> {
 ### Creating an ADR
 
 ```rust
-use adrs_core::{Repository, Adr, AdrStatus};
+use adrs_core::{Repository, Adr};
+use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
     let repo = Repository::open(Path::new("."))?;
@@ -70,6 +72,7 @@ fn main() -> anyhow::Result<()> {
 
 ```rust
 use adrs_core::Repository;
+use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
     let repo = Repository::open(Path::new("."))?;
@@ -88,6 +91,7 @@ fn main() -> anyhow::Result<()> {
 
 ```rust
 use adrs_core::{Repository, LinkKind};
+use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
     let repo = Repository::open(Path::new("."))?;
@@ -139,14 +143,23 @@ let config = Config {
 
 ### Using Built-in Templates
 
+`TemplateEngine` is a builder: start with `new()`, then chain `with_format`
+and `with_variant`. `render` takes the `Adr`, the repository `Config` (used
+for things like MADR field toggles), and a map of link titles keyed by ADR
+number.
+
 ```rust
-use adrs_core::{TemplateEngine, TemplateFormat, TemplateVariant, Adr};
+use adrs_core::{Adr, Config, TemplateEngine, TemplateFormat, TemplateVariant};
+use std::collections::HashMap;
 
 fn main() -> anyhow::Result<()> {
-    let engine = TemplateEngine::new(TemplateFormat::Madr, TemplateVariant::Minimal);
+    let engine = TemplateEngine::new()
+        .with_format(TemplateFormat::Madr)
+        .with_variant(TemplateVariant::Minimal);
     
     let adr = Adr::new(1, "My Decision".to_string());
-    let content = engine.render(&adr)?;
+    let config = Config::default();
+    let content = engine.render(&adr, &config, &HashMap::new())?;
     
     println!("{}", content);
     
@@ -157,14 +170,19 @@ fn main() -> anyhow::Result<()> {
 ### Custom Templates
 
 ```rust
-use adrs_core::{TemplateEngine, Adr};
+use adrs_core::{Adr, Config, TemplateEngine};
+use std::collections::HashMap;
 use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
-    let engine = TemplateEngine::from_file(Path::new("templates/custom.md"))?;
+    let engine = TemplateEngine::new()
+        .with_custom_template_file(Path::new("templates/custom.md"))?;
     
     let adr = Adr::new(1, "My Decision".to_string());
-    let content = engine.render(&adr)?;
+    let config = Config::default();
+    let content = engine.render(&adr, &config, &HashMap::new())?;
+    
+    println!("{}", content);
     
     Ok(())
 }
@@ -223,7 +241,8 @@ None significant.
 "#;
 
     let parser = Parser::new();
-    let adr = parser.parse(content, Some(1))?;
+    let adr = parser.parse(content)?;
+    println!("{}: {}", adr.number, adr.title);
     
     Ok(())
 }
@@ -283,12 +302,13 @@ The library uses `thiserror` for error types:
 
 ```rust
 use adrs_core::{Repository, Error};
+use std::path::Path;
 
 fn main() {
     match Repository::open(Path::new(".")) {
         Ok(repo) => { /* use repo */ }
-        Err(Error::NotFound(path)) => {
-            eprintln!("ADR repository not found at {}", path.display());
+        Err(Error::AdrDirNotFound) => {
+            eprintln!("ADR repository not found. Run 'adrs init' to create one.");
         }
         Err(e) => {
             eprintln!("Error: {}", e);

--- a/book/src/mcp.md
+++ b/book/src/mcp.md
@@ -71,7 +71,7 @@ The MCP server provides 17 tools organized by function:
 
 | Tool | Description |
 |------|-------------|
-| `create_adr` | Create a new ADR (always 'proposed' status) |
+| `create_adr` | Create a new ADR (uses the repository's configured default status; proposed if not configured) |
 | `update_status` | Change an ADR's status |
 | `link_adrs` | Create bidirectional links between ADRs |
 | `update_content` | Update ADR sections (context, decision, consequences) |
@@ -135,7 +135,9 @@ Search ADRs for matching text.
 
 ### create_adr
 
-Create a new ADR. Always creates with 'proposed' status for human review.
+Create a new ADR. Uses the repository's configured default status (proposed
+if not configured); the created ADR still requires human review before
+acceptance.
 
 **Parameters:**
 - `title` (required): ADR title
@@ -144,7 +146,7 @@ Create a new ADR. Always creates with 'proposed' status for human review.
 - `consequences` (optional): Consequences section content
 - `supersedes` (optional): ADR number this supersedes
 - `format` (optional): Template format -- `nygard` (default) or `madr` for MADR 4.0.0 format
-- `variant` (optional): Template variant -- `full` (default), `minimal`, or `bare`
+- `variant` (optional): Template variant -- `full` (default), `minimal`, `bare`, or `bare-minimal`
 - `decision_makers` (optional): List of people who made the decision (most useful with MADR format)
 - `consulted` (optional): List of people consulted for input (most useful with MADR format)
 - `informed` (optional): List of people kept informed (most useful with MADR format)
@@ -248,7 +250,8 @@ Claude will use `compare_adrs` to show the differences.
 
 ## Best Practices
 
-1. **Human Review**: All ADRs created by AI are set to 'proposed' status. Review before accepting.
+1. **Human Review**: ADRs created by AI use the repository's configured
+   default status (proposed if not configured). Review before accepting.
 
 2. **Provide Context**: Give Claude context about your architecture when asking it to create ADRs.
 

--- a/book/src/templates.md
+++ b/book/src/templates.md
@@ -18,7 +18,7 @@ Each format has four variants:
 | Variant | Description |
 |---------|-------------|
 | `full` | Complete template with all sections and guidance comments |
-| `minimal` | Essential sections only, no guidance |
+| `minimal` | Essential sections only; some formats (e.g. MADR) still include placeholder guidance text |
 | `bare` | All sections, but empty (no guidance) |
 | `bare-minimal` | Core sections only, empty content |
 

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -34,11 +34,13 @@ pub fn new(
 
     // Parse template variant: CLI arg > config > default
     let template_variant = if let Some(ref var) = variant {
-        var.parse::<TemplateVariant>()
-            .context("Invalid template variant. Use 'full', 'minimal', or 'bare'.")?
+        var.parse::<TemplateVariant>().context(
+            "Invalid template variant. Use 'full', 'minimal', 'bare', or 'bare-minimal'.",
+        )?
     } else if let Some(ref var) = config.templates.variant {
-        var.parse::<TemplateVariant>()
-            .context("Invalid template variant in config. Use 'full', 'minimal', or 'bare'.")?
+        var.parse::<TemplateVariant>().context(
+            "Invalid template variant in config. Use 'full', 'minimal', 'bare', or 'bare-minimal'.",
+        )?
     } else {
         TemplateVariant::default()
     };

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -58,17 +58,18 @@ ENVIRONMENT VARIABLES:
 
 CONFIGURATION:
   adrs.toml is discovered by walking up from the current directory. A global config
-  is also read from $XDG_CONFIG_HOME/adrs/adrs.toml (~/.config/adrs/adrs.toml on
-  Linux/macOS, %APPDATA%/adrs/adrs.toml on Windows), and ~/.adrs.toml as a fallback.
+  is also read from $XDG_CONFIG_HOME/adrs/config.toml (~/.config/adrs/config.toml on
+  Linux/macOS, %APPDATA%/adrs/config.toml on Windows).
 
   Compatible mode (default): metadata stored in the markdown body (adr-tools compatible).
   NextGen mode (--ng):       YAML frontmatter with extended fields (tags, deciders).
 
   Template format and variant can be set in adrs.toml:
-    format = \"madr\"     # nygard (default) or madr
-    variant = \"full\"    # full (default), minimal, or bare
     default_status = \"accepted\" # proposed (default), accepted, deprecated, superseded, or custom
     no_edit = true              # skip editor for new ADRs (default: false)
+    [templates]
+    format = \"madr\"     # nygard (default) or madr
+    variant = \"full\"    # full (default), minimal, bare, or bare-minimal
     [generate]
     toc_prefix = \"./\"          # default prefix for 'generate toc' links (default: empty)
     [export]
@@ -146,7 +147,7 @@ LINK FORMAT:
         #[arg(short, long, value_name = "FORMAT")]
         format: Option<String>,
 
-        /// Template variant: full, minimal, bare [default: full]
+        /// Template variant: full, minimal, bare, bare-minimal [default: full]
         #[arg(short, long, value_name = "VARIANT")]
         variant: Option<String>,
 
@@ -390,10 +391,11 @@ FISH:
     #[command(after_long_help = "\
 Starts an MCP (Model Context Protocol) server on stdio for AI agent integration.
 
-TOOLS PROVIDED (15):
+TOOLS PROVIDED (17):
   Read-only:
     list_adrs, get_adr, search_adrs, get_repository_info, get_related_adrs,
-    validate_adr, get_adr_sections, compare_adrs, suggest_tags
+    validate_adr, get_adr_sections, compare_adrs, suggest_tags, run_doctor,
+    export_adrs
   Write:
     create_adr, update_status, update_content, update_tags, link_adrs,
     bulk_update_status

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -965,7 +965,10 @@ impl AdrState {
 
         let template_variant = match &params.variant {
             Some(v) => v.parse::<TemplateVariant>().map_err(|_| {
-                format!("Invalid variant '{}'. Use 'full', 'minimal', or 'bare'.", v)
+                format!(
+                    "Invalid variant '{}'. Use 'full', 'minimal', 'bare', or 'bare-minimal'.",
+                    v
+                )
             })?,
             None => TemplateVariant::default(),
         };


### PR DESCRIPTION
Pre-release documentation and help-text fixes from the v0.9.0 release readiness audit (37 confirmed findings across README, book, CLI help, changelog, and release machinery; every finding was independently re-verified against the built binary on main).

## Plan

README.md:
- Fix the Docker quick command (mounts /work but the image WORKDIR is /workspace; init output is lost): use `-v $(pwd):/workspace -w /workspace`
- Fix the import example (`adrs import decisions.json --renumber` fails; needs the `json` subcommand)
- MCP tool count 15 -> drop the hardcoded number (server exposes 17)
- Library snippet `adrs-core = "0.7"` -> `"0.9"`
- Add `mcp` to the Usage commands block
- Mention configurable doctor rules and the pre-commit hook in the features list

book/src:
- commands/doctor.md: pre-commit example `rev: v0.8.0` -> `v0.9.0` (v0.9.0 is the first tag containing .pre-commit-hooks.yaml); replace invented example outputs with real captured output; correct the exit-code statement (warnings exit 0 by default, 1 with warnings_as_errors)
- library.md: `adrs-core = "0.7"` -> `"0.9"`; rewrite the six non-compiling code samples against the real API
- mcp.md: create_adr uses the repository's configured default_status, not always proposed
- installation.md: manual-download table .tar.gz -> .tar.xz
- init.md: note --ng writes adrs.toml (not .adr-dir); align the frontmatter example with real output
- templates.md/configuration.md/new.md: fix the minimal variant description; add bare-minimal where variants are enumerated
- export.md: bump stale sample tool version

crates/adrs/src/main.rs (help text only):
- mcp serve help: 17 tools, add run_doctor and export_adrs to the list
- CONFIGURATION block: correct the global config path, drop the nonexistent ~/.adrs.toml fallback, show format/variant under [templates]

RELEASING.md: per-crate changelog paths; unversioned .tar.xz/.zip artifact names.

All examples validated against the built binary before pushing. Product bugs found by the same audit are filed separately (#329 generate -C output path, #330 bare-minimal template fails doctor) and are not part of this PR.