### PR TITLE
fix: resolve relative CLI paths against the -C working directory

### DIFF
--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -666,7 +666,7 @@ fn main() -> Result<()> {
                 link,
                 format,
                 variant,
-                template,
+                template.map(|t| resolve_cli_path(cli.working_dir.as_deref(), t)),
                 status,
                 tags,
                 no_edit,
@@ -738,8 +738,8 @@ fn main() -> Result<()> {
                 } => commands::generate_toc(
                     &discovered.root,
                     ordered,
-                    intro,
-                    outro,
+                    intro.map(|p| resolve_cli_path(cli.working_dir.as_deref(), p)),
+                    outro.map(|p| resolve_cli_path(cli.working_dir.as_deref(), p)),
                     prefix,
                     discovered.config.generate.toc_prefix,
                 ),
@@ -750,7 +750,12 @@ fn main() -> Result<()> {
                     output,
                     title,
                     description,
-                } => commands::generate_book(&discovered.root, &output, title, description),
+                } => commands::generate_book(
+                    &discovered.root,
+                    &resolve_cli_path(cli.working_dir.as_deref(), output),
+                    title,
+                    description,
+                ),
             }
         }
         Commands::Export { command } => match command {
@@ -761,6 +766,7 @@ fn main() -> Result<()> {
                 metadata_only,
                 base_url,
             } => {
+                let dir = dir.map(|d| resolve_cli_path(cli.working_dir.as_deref(), d));
                 if let Some(ref dir_path) = dir {
                     // Export from arbitrary directory - no repo needed, no config available
                     commands::export_json(
@@ -796,6 +802,13 @@ fn main() -> Result<()> {
                 dry_run,
                 ng,
             } => {
+                // "-" means stdin; leave it alone.
+                let file = if file.to_str() == Some("-") {
+                    file
+                } else {
+                    resolve_cli_path(cli.working_dir.as_deref(), file)
+                };
+                let dir = dir.map(|d| resolve_cli_path(cli.working_dir.as_deref(), d));
                 if let Some(ref dir_path) = dir {
                     // Import to arbitrary directory - no repo needed
                     commands::import_json(
@@ -931,6 +944,19 @@ For detailed help: adrs <command> --help
 Documentation: https://joshrotenberg.com/adrs/
 "#
     );
+}
+
+/// Resolve a user-supplied CLI path against the `-C` working directory.
+///
+/// `-C` means "run from a different directory", so relative paths given on
+/// the command line resolve against that directory rather than the process
+/// cwd. Absolute paths, and all paths when `-C` is not given, are returned
+/// unchanged.
+fn resolve_cli_path(working_dir: Option<&std::path::Path>, path: PathBuf) -> PathBuf {
+    match working_dir {
+        Some(dir) if path.is_relative() => dir.join(path),
+        _ => path,
+    }
 }
 
 /// Discover config or return a helpful error.

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1836,3 +1836,198 @@ fn test_smoke_nextgen_workflow() {
 
     temp.close().unwrap();
 }
+
+// ============================================================================
+// -C Relative Path Resolution
+// ============================================================================
+
+#[test]
+fn test_generate_book_with_cwd_flag_relative_output() {
+    // Regression test: `adrs -C <dir> generate book` must write its output
+    // relative to the -C directory, not the process cwd, and must not
+    // clobber an existing book/ in the process cwd.
+    let repo = assert_fs::TempDir::new().unwrap();
+    let elsewhere = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(repo.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Pre-existing book/ in the process cwd that must survive untouched
+    let sentinel = "# pre-existing book.toml, do not overwrite\n";
+    elsewhere.child("book/src").create_dir_all().unwrap();
+    elsewhere
+        .child("book/book.toml")
+        .write_str(sentinel)
+        .unwrap();
+
+    adrs()
+        .current_dir(elsewhere.path())
+        .args(["-C", repo.path().to_str().unwrap(), "generate", "book"])
+        .assert()
+        .success();
+
+    // Output lands in the -C directory
+    repo.child("book/book.toml")
+        .assert(predicate::path::exists());
+    repo.child("book/src/SUMMARY.md")
+        .assert(predicate::path::exists());
+    repo.child("book/src/0001-record-architecture-decisions.md")
+        .assert(predicate::path::exists());
+
+    // The process cwd's book/ is untouched
+    elsewhere.child("book/book.toml").assert(sentinel);
+    elsewhere
+        .child("book/src/SUMMARY.md")
+        .assert(predicate::path::missing());
+
+    repo.close().unwrap();
+    elsewhere.close().unwrap();
+}
+
+#[test]
+fn test_import_json_with_cwd_flag_relative_paths() {
+    // Both the JSON file argument and --dir must resolve against the -C
+    // directory, not the process cwd.
+    let workdir = assert_fs::TempDir::new().unwrap();
+    let elsewhere = assert_fs::TempDir::new().unwrap();
+
+    // Build a source repo and export it to JSON inside workdir
+    adrs()
+        .current_dir(workdir.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    let export_out = adrs()
+        .current_dir(workdir.path())
+        .args(["export", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    workdir
+        .child("adrs.json")
+        .write_binary(&export_out)
+        .unwrap();
+
+    // Run from elsewhere with -C and relative file + --dir arguments
+    adrs()
+        .current_dir(elsewhere.path())
+        .args([
+            "-C",
+            workdir.path().to_str().unwrap(),
+            "import",
+            "json",
+            "--dir",
+            "imported",
+            "adrs.json",
+        ])
+        .assert()
+        .success();
+
+    workdir
+        .child("imported/0001-record-architecture-decisions.md")
+        .assert(predicate::path::exists());
+    elsewhere
+        .child("imported")
+        .assert(predicate::path::missing());
+
+    workdir.close().unwrap();
+    elsewhere.close().unwrap();
+}
+
+#[test]
+fn test_export_json_with_cwd_flag_relative_dir() {
+    // A relative --dir must resolve against the -C directory.
+    let workdir = assert_fs::TempDir::new().unwrap();
+    let elsewhere = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(workdir.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(elsewhere.path())
+        .args([
+            "-C",
+            workdir.path().to_str().unwrap(),
+            "export",
+            "json",
+            "--dir",
+            "doc/adr",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Record architecture decisions"));
+
+    workdir.close().unwrap();
+    elsewhere.close().unwrap();
+}
+
+#[test]
+fn test_generate_toc_with_cwd_flag_relative_intro() {
+    // A relative --intro file must resolve against the -C directory.
+    let workdir = assert_fs::TempDir::new().unwrap();
+    let elsewhere = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(workdir.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    workdir
+        .child("intro.md")
+        .write_str("Intro from workdir\n")
+        .unwrap();
+
+    adrs()
+        .current_dir(elsewhere.path())
+        .args([
+            "-C",
+            workdir.path().to_str().unwrap(),
+            "generate",
+            "toc",
+            "--intro",
+            "intro.md",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Intro from workdir"));
+
+    workdir.close().unwrap();
+    elsewhere.close().unwrap();
+}
+
+#[test]
+fn test_generate_book_relative_output_without_cwd_flag() {
+    // Without -C, a relative --output still resolves against the process
+    // cwd and prints the path as given.
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["generate", "book", "--output", "mybook"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("mybook"));
+
+    temp.child("mybook/book.toml")
+        .assert(predicate::path::exists());
+    temp.child("mybook/src/SUMMARY.md")
+        .assert(predicate::path::exists());
+
+    temp.close().unwrap();
+}


### PR DESCRIPTION
## Problem

`adrs generate book -C <dir>` reads ADRs from the `-C` directory but writes its output (default `book/`) relative to the process cwd. Running `adrs -C /some/other/adr-repo generate book` from a repo root silently overwrites that repo's own `book/book.toml` and `book/src/SUMMARY.md` with content from the other repo.

Cause: the `GenerateCommands::Book` arm in `crates/adrs/src/main.rs` passes the raw `output` PathBuf to `generate_book`, which then calls `fs::create_dir_all`/`fs::write` on the relative path, resolving against the process cwd instead of the `-C` working directory.

The same class of bug affects every other user-supplied relative path when `-C` is given:

- `import json --dir` (write) and its `FILE` argument (read)
- `export json --dir` (read)
- `new --template` (read)
- `generate toc --intro` / `--outro` (read)

`init DIRECTORY` is unaffected: it already joins against the start directory.

## Fix

Add a helper in `main.rs` that resolves a relative CLI path against the `-C` working directory, matching `-C`'s documented semantics ("Run from a different directory"). Absolute paths pass through unchanged. When `-C` is not given, paths are untouched, so behavior without `-C` is bit-for-bit identical (including printed output paths). The `-` stdin sentinel for `import json` is exempt.

## Steps

1. Add `resolve_cli_path` helper in `main.rs`, apply at the affected call sites.
2. Regression tests in `crates/adrs/tests/cli.rs`: `-C` plus relative `generate book --output` writes into the `-C` dir and does not clobber a `book/` in the process cwd; same for `import json --dir`; read-side coverage for `export json --dir`.
3. `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.

## Acceptance

From any cwd, `adrs -C <dir> <cmd>` with relative path arguments behaves identically to `cd <dir> && adrs <cmd>`.