### PR TITLE
fix: nygard bare-minimal template output passes adrs doctor

### DIFF
--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -519,6 +519,43 @@ Some consequences.
     }
 
     #[test]
+    fn test_nygard_bare_minimal_template_passes_doctor() {
+        // Regression for #330: a file produced by the Nygard bare-minimal
+        // template must not trip any doctor error (it previously emitted no
+        // `Date:` line and failed with ADR003). Empty-section ADR014 warnings
+        // are inherent to the variant and are not errors.
+        use crate::{Adr, Config, Repository, Template, TemplateFormat, TemplateVariant};
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+
+        let template =
+            Template::builtin_with_variant(TemplateFormat::Nygard, TemplateVariant::BareMinimal);
+        let adr = Adr::new(2, "Bare minimal regression");
+        let rendered = template
+            .render(&adr, &Config::default(), &std::collections::HashMap::new())
+            .unwrap();
+        let path = repo.adr_path().join("0002-bare-minimal-regression.md");
+        std::fs::write(&path, rendered).unwrap();
+
+        let report = check_all(&repo).unwrap();
+        let file_errors: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.severity == IssueSeverity::Error)
+            .filter(|i| {
+                i.path
+                    .as_ref()
+                    .is_some_and(|p| p.to_string_lossy().contains("0002-bare-minimal-regression"))
+            })
+            .collect();
+        assert!(
+            file_errors.is_empty(),
+            "nygard bare-minimal output should have no doctor errors, got: {file_errors:?}"
+        );
+    }
+
+    #[test]
     fn test_check_all_reports_parse_errors() {
         use crate::Repository;
 

--- a/crates/adrs-core/src/template.rs
+++ b/crates/adrs-core/src/template.rs
@@ -489,6 +489,8 @@ Date: {{ date }}
 /// Nygard bare-minimal template - fewest sections, empty content.
 const NYGARD_BARE_MINIMAL_TEMPLATE: &str = r#"# {{ number }}. {{ title }}
 
+Date: {{ date }}
+
 ## Status
 
 {{ status }}
@@ -1262,15 +1264,16 @@ mod tests {
         let config = Config::default();
         let output = template.render(&adr, &config, &no_link_titles()).unwrap();
 
-        // Should have basic structure without Date line
+        // Should have basic structure including the Date line (#330: without
+        // it, `adrs doctor` flags the file with ADR003).
         assert!(output.contains("# 1. Nygard Bare Minimal"));
+        assert!(output.contains("Date:"));
         assert!(output.contains("## Status"));
         assert!(output.contains("## Context"));
         assert!(output.contains("## Decision"));
         assert!(output.contains("## Consequences"));
-        // No frontmatter, no date
+        // No frontmatter (compatible-mode layout).
         assert!(!output.contains("---"));
-        assert!(!output.contains("Date:"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #330.

## Problem

`adrs new --variant bare-minimal` (Nygard format) generates a file with no `Date:` line, so `adrs doctor` immediately flags it:

```
error: [ADR003] Nygard format ADR is missing 'Date:' line
Found 1 error(s), 3 warning(s), 0 info(s)   # exit 1
```

The tool's own template fails the tool's own doctor. The three `ADR014` empty-section warnings are inherent to bare-minimal (empty content is the point) and correctly stay warnings; the blocking issue is the missing `Date:` line, which every other Nygard variant (full, bare) already includes.

## Fix

Add `Date: {{ date }}` to `NYGARD_BARE_MINIMAL_TEMPLATE`, matching the other Nygard templates. A `Date:` line is a Nygard structural element (adr-tools includes it) and, since the compatible-mode parser now reads it (#324), it round-trips correctly.

## Tests

- Update `test_nygard_bare_minimal_template` to assert the `Date:` line is present (still asserts no frontmatter).
- Add a lint-level regression test: render the Nygard bare-minimal template into a repo and assert `check_all` reports no errors for the file (no `ADR003`), so this dogfooding gap cannot silently return.

## Out of scope

The MADR bare-minimal variant is a separate case: it mirrors the official upstream MADR bare-minimal template (no frontmatter), which `adrs doctor` misclassifies as Nygard and flags with several errors. That is a design question (upstream fidelity vs doctor detection), tracked separately rather than folded into this fix.