### PR TITLE
chore: migrate homebrew distribution to homebrew-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,57 +298,11 @@ jobs:
             gh release create "$TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
           fi
 
-  publish-homebrew-formula:
-    needs:
-      - plan
-      - host
-    runs-on: "ubuntu-22.04"
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PLAN: ${{ needs.plan.outputs.val }}
-      GITHUB_USER: "axo bot"
-      GITHUB_EMAIL: "admin+bot@axo.dev"
-    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: true
-          repository: "joshrotenberg/homebrew-brew"
-          # Manual edit: use COMMITTER_TOKEN (the PAT with tap repo access).
-          # HOMEBREW_TAP_TOKEN is the cargo-dist default but is not configured
-          # in this repo. This line was restored from v0.7.4 after the cargo-dist
-          # 0.32 regen in #275 broke it. ci is in dist allow-dirty so this
-          # edit persists across regeneration, but double-check if upgrading
-          # cargo-dist again (see #294).
-          token: ${{ secrets.COMMITTER_TOKEN }}
-      # So we have access to the formula
-      - name: Fetch homebrew formulae
-        uses: actions/download-artifact@v8
-        with:
-          pattern: artifacts-*
-          path: Formula/
-          merge-multiple: true
-      # This is extra complex because you can make your Formula name not match your app name
-      # so we need to find releases with a *.rb file, and publish with that filename.
-      - name: Commit formula files
-        run: |
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_EMAIL}"
-
-          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
-            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
-            name=$(echo "$filename" | sed "s/\.rb$//")
-            version=$(echo "$release" | jq .app_version --raw-output)
-
-            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-            brew update
-            # We avoid reformatting user-provided data such as the app description and homepage.
-            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
-
-            git add "Formula/${filename}"
-            git commit -m "${name} ${version}"
-          done
-          git push
+  # Note (manual edit; ci is in dist allow-dirty): the publish-homebrew-formula
+  # job that pushed Formula/adrs.rb to joshrotenberg/homebrew-brew was removed
+  # when adrs moved to homebrew-core (Homebrew/homebrew-core#290715). New
+  # releases are picked up there automatically by BrewTestBot; manual fallback
+  # is `brew bump-formula-pr adrs`. The tap redirects via tap_migrations.json.
 
   # Custom job (manual addition; ci is in dist allow-dirty): safety net. If any
   # artifact build OR the host (upload/release) job fails, draft the release so
@@ -425,12 +379,11 @@ jobs:
     needs:
       - plan
       - host
-      - publish-homebrew-formula
       - verify-release
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" and "verify-release" however must succeed, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && needs.verify-release.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && needs.verify-release.result == 'success' }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A command-line tool for creating and managing [Architecture Decision Records](ht
 ### Homebrew (macOS/Linux)
 
 ```sh
-brew install joshrotenberg/brew/adrs
+brew install adrs
 ```
 
 ### Cargo

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,7 +40,6 @@ release.yml jobs:
                    uploads to the existing release instead of failing (#283).
   verify-release -- confirms the published release has its full asset set + a valid
                    checksum; re-drafts and fails if incomplete (#285)
-  publish-homebrew-formula -- pushes the .rb formula to joshrotenberg/homebrew-brew
   announce      -- no-op placeholder; runs only after verify-release succeeds
   cleanup-on-failure -- drafts the release if any build OR host job fails (#242, #281)
 ```
@@ -70,10 +69,14 @@ A complete release produces the following artifacts attached to the GitHub Relea
 - A combined checksum file: `sha256.sum`
 - Shell installer: `adrs-installer.sh`
 - PowerShell installer: `adrs-installer.ps1`
-- Homebrew formula: committed to `joshrotenberg/homebrew-brew` as `Formula/adrs.rb`
-  (also attached to the release as `adrs.rb`)
 - Source archive and checksum: `source.tar.gz`, `source.tar.gz.sha256`
 - `dist-manifest.json`: the dist manifest for the release
+
+Homebrew is handled outside this pipeline: adrs lives in homebrew-core
+(Homebrew/homebrew-core#290715). BrewTestBot picks up new GitHub releases
+automatically (v0.9.0 was bumped within about five hours); if a bump does not
+appear, run `brew bump-formula-pr adrs`. The old personal tap redirects to
+homebrew-core via `tap_migrations.json` in `joshrotenberg/homebrew-brew`.
 
 To verify:
 
@@ -84,14 +87,15 @@ gh release view v<VERSION> --repo joshrotenberg/adrs
 # List all attached assets
 gh release view v<VERSION> --repo joshrotenberg/adrs --json assets --jq '[.assets[].name] | sort'
 
-# Verify Homebrew formula was updated
-gh api repos/joshrotenberg/homebrew-brew/commits --jq '.[0].commit.message'
+# Verify the homebrew-core formula was autobumped (may take a few hours)
+gh api 'repos/Homebrew/homebrew-core/commits?path=Formula/a/adrs.rb&per_page=1' --jq '.[0].commit.message'
 ```
 
 `verify-release` (`.github/workflows/release.yml`) fails the release if there
 are fewer than 14 assets (5 archives + 5 checksums + 2 installers +
-`sha256.sum` + `dist-manifest.json`). A typical release has 17 assets, once
-the Homebrew formula and source archive are included.
+`sha256.sum` + `dist-manifest.json`). A typical release has 16 assets, once
+the source archive and its checksum are included. (Releases up to v0.9.0 also
+attached `adrs.rb`, for 17; the formula moved to homebrew-core.)
 
 ## Required secrets
 
@@ -99,7 +103,7 @@ The release workflow requires two secrets configured in the repository settings:
 
 | Secret | Purpose |
 |--------|---------|
-| `COMMITTER_TOKEN` | A GitHub PAT with `repo` scope. Used by release-plz to push the version tag (GITHUB_TOKEN actions don't trigger other workflows) and by publish-homebrew-formula to push to `joshrotenberg/homebrew-brew`. |
+| `COMMITTER_TOKEN` | A GitHub PAT with `repo` scope. Used by release-plz to push the version tag (GITHUB_TOKEN actions don't trigger other workflows). |
 | `CARGO_REGISTRY_TOKEN` | An API token from crates.io. Used by release-plz to publish updated crates (`adrs-core` and `adrs`) to crates.io. |
 
 Both secrets must be set at `https://github.com/joshrotenberg/adrs/settings/secrets/actions`.

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -33,7 +33,7 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/joshrotenberg/adrs
 Using Homebrew:
 
 ```sh
-brew install joshrotenberg/brew/adrs
+brew install adrs
 ```
 
 Using Cargo:

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -19,7 +19,7 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/joshrotenberg/adrs
 ### Homebrew (macOS/Linux)
 
 ```sh
-brew install joshrotenberg/brew/adrs
+brew install adrs
 ```
 
 ### Manual Download

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,11 +8,9 @@ cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell", "homebrew"]
-# A GitHub repo to push Homebrew formulas to
-tap = "joshrotenberg/homebrew-brew"
-# Publish jobs to run in CI
-publish-jobs = ["homebrew"]
+# (homebrew removed: adrs is in homebrew-core as of 0.8.0, autobumped by
+# BrewTestBot; the personal tap redirects via tap_migrations.json)
+installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Skip checking whether the specified configuration files are up to date


### PR DESCRIPTION
adrs was accepted into homebrew-core (Homebrew/homebrew-core#290715, merged 2026-07-01 at 0.8.0; BrewTestBot autobumped to 0.9.0 within hours of the v0.9.0 release). The formula in the personal tap is being retired via joshrotenberg/homebrew-brew#7, which adds a `tap_migrations.json` redirect to `homebrew/core`.

## Plan

1. `dist-workspace.toml`: drop the `homebrew` installer, the `tap`, and the `homebrew` publish job so future releases stop pushing `Formula/adrs.rb` to the tap. Without this, the next release would recreate the formula in the tap alongside the migration entry, which is a broken state for brew.
2. Regenerate `.github/workflows/release.yml` with `dist generate` (local dist 0.32.0 matches the pinned `cargo-dist-version`), removing the `publish-homebrew-formula` job and its references from `announce`.
3. Install docs: `brew install joshrotenberg/brew/adrs` becomes `brew install adrs` in README.md, book/src/README.md, and book/src/installation.md.
4. RELEASING.md: remove the tap publish step from the pipeline description and artifact list, note that homebrew-core is autobumped by BrewTestBot (with `brew bump-formula-pr adrs` as the manual fallback), adjust the expected asset count, and trim the `COMMITTER_TOKEN` description to its remaining release-plz use.

## Ordering note

This must land before joshrotenberg/homebrew-brew#7 merges, so no release can push the formula back after the migration entry exists.