### PR TITLE
chore: release v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.9.0" }
+adrs-core = { path = "crates/adrs-core", version = "0.10.0" }
 
 # Testing
 serial_test = "3.5"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2026-07-16
+
+### Bug Fixes
+
+- Preserve MADR 4.0.0 content when updating ADR body sections
+- Patch only changed body sections on MADR 4.0.0 update
+- Route Nygard consequences patches to ## Consequences H2
+- Preserve markdown on body-only Repository::update
+- Tighten consequences routing and reject empty update_content
+- Rewrite frontmatter metadata via YAML Mapping
+- Remove brittle people-field YAML equality guard
+- Track fenced code with CommonMark char and run length
+- Separate appended MADR Consequences after suppressed newline
+- Detect Consequences H2 anywhere outside fences
+- Describe adr-tools as shell implementation in init ADR #0001
+- Normalize rendered templates to end with exactly one newline (closes #320)
+
+### Documentation
+
+- Clarify BodySectionPatch migration and refresh ADR 0009
+
+### Features
+
+- Update init ADR #0001 seed with markdown links and trailing newline
+
+### Miscellaneous
+
+- Migrate homebrew distribution to homebrew-core
+
+### Testing
+
+- Expand BodySectionPatch preservation coverage for issue #310
+- Pin write-path classes for people YAML, fences, and newlines
+- Absorb corpus people-YAML fixtures for status and link write paths
+- Use descriptive comments for write-path pins
+- Pin MADR Consequences H2 before Decision Outcome
+
+
 ## [0.9.0] - 2026-07-10
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2026-07-16
+
+### Bug Fixes
+
+- Preserve MADR 4.0.0 content when updating ADR body sections
+- Patch only changed body sections on MADR 4.0.0 update
+- Route Nygard consequences patches to ## Consequences H2
+- Preserve markdown on body-only Repository::update
+- Tighten consequences routing and reject empty update_content
+- Document update_content requiring a body field
+
+### Features
+
+- Update init ADR #0001 seed with markdown links and trailing newline
+
+### Miscellaneous
+
+- Migrate homebrew distribution to homebrew-core
+
+### Testing
+
+- Expand BodySectionPatch preservation coverage for issue #310
+- Pin write-path classes for people YAML, fences, and newlines
+- Use descriptive comments for write-path pins
+
+
 ## [0.9.0] - 2026-07-10
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `adrs`: 0.9.0 -> 0.10.0

### ⚠ `adrs-core` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  adrs_core::Repository::update takes 1 parameters in /tmp/.tmpJo86K6/adrs-core/src/repository.rs:433, but now takes 2 parameters in /tmp/.tmpRuN9BV/adrs/crates/adrs-core/src/repository.rs:493
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.10.0] - 2026-07-16

### Bug Fixes

- Preserve MADR 4.0.0 content when updating ADR body sections
- Patch only changed body sections on MADR 4.0.0 update
- Route Nygard consequences patches to ## Consequences H2
- Preserve markdown on body-only Repository::update
- Tighten consequences routing and reject empty update_content
- Rewrite frontmatter metadata via YAML Mapping
- Remove brittle people-field YAML equality guard
- Track fenced code with CommonMark char and run length
- Separate appended MADR Consequences after suppressed newline
- Detect Consequences H2 anywhere outside fences
- Describe adr-tools as shell implementation in init ADR #0001
- Normalize rendered templates to end with exactly one newline (closes #320)

### Documentation

- Clarify BodySectionPatch migration and refresh ADR 0009

### Features

- Update init ADR #0001 seed with markdown links and trailing newline

### Miscellaneous

- Migrate homebrew distribution to homebrew-core

### Testing

- Expand BodySectionPatch preservation coverage for issue #310
- Pin write-path classes for people YAML, fences, and newlines
- Absorb corpus people-YAML fixtures for status and link write paths
- Use descriptive comments for write-path pins
- Pin MADR Consequences H2 before Decision Outcome
</blockquote>

## `adrs`

<blockquote>

## [0.10.0] - 2026-07-16

### Bug Fixes

- Preserve MADR 4.0.0 content when updating ADR body sections
- Patch only changed body sections on MADR 4.0.0 update
- Route Nygard consequences patches to ## Consequences H2
- Preserve markdown on body-only Repository::update
- Tighten consequences routing and reject empty update_content
- Document update_content requiring a body field

### Features

- Update init ADR #0001 seed with markdown links and trailing newline

### Miscellaneous

- Migrate homebrew distribution to homebrew-core

### Testing

- Expand BodySectionPatch preservation coverage for issue #310
- Pin write-path classes for people YAML, fences, and newlines
- Use descriptive comments for write-path pins
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).