### PR TITLE
chore(deps): update serial_test to 3.5, removing scc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,15 +1817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schemars"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,12 +1846,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "self_cell"
@@ -1981,23 +1966,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = ["full"] }
 adrs-core = { path = "crates/adrs-core", version = "0.9.0" }
 
 # Testing
-serial_test = "3"
+serial_test = "3.5"
 assert_cmd = "2"
 assert_fs = "1"
 predicates = "3"


### PR DESCRIPTION
Closes #334.

RUSTSEC-2026-0205 flags `scc` 2.4.0 (unsound `Array::insert` exception safety, potential double-free). `scc` enters the tree only through `serial_test` 3.2.0, a dev-dependency; the shipped binary is unaffected.

`serial_test` 3.5.0 dropped its `scc` dependency, so bumping the workspace dev-dependency to `3.5` and updating the lockfile removes the advisory's subject from the tree entirely (`cargo tree -i scc` now matches nothing).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (743 pass, unchanged)