### PR TITLE
fix: normalize rendered templates to end with exactly one newline

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -1833,7 +1833,7 @@ default_status = "draft"
         let (_, path) = repo.new_adr("Custom Test").unwrap();
         let content = fs::read_to_string(path).unwrap();
 
-        assert_eq!(content, "# ADR 2: Custom Test");
+        assert_eq!(content, "# ADR 2: Custom Test\n");
     }
 
     // ========== Accessor Tests ==========

--- a/crates/adrs-core/src/template.rs
+++ b/crates/adrs-core/src/template.rs
@@ -237,6 +237,15 @@ impl Template {
             })
             .map_err(|e| Error::TemplateError(e.to_string()))?;
 
+        // Normalize the ending to exactly one newline (#320). minijinja strips
+        // the template source's final newline, so without this the rendered
+        // ending depends on the template and on whether its last expression is
+        // empty: MADR full/minimal rendered with no trailing newline, Nygard
+        // minimal with two when the last section was empty. Normalizing here
+        // covers custom templates as well.
+        let mut output = output.trim_end().to_string();
+        output.push('\n');
+
         Ok(output)
     }
 }
@@ -1287,6 +1296,43 @@ mod tests {
         assert_eq!(full.content, explicit_full.content);
     }
 
+    #[test]
+    fn test_every_builtin_render_ends_with_exactly_one_newline() {
+        // Regression for #320: rendered output must end with exactly one
+        // newline for every builtin, with both empty and populated body
+        // fields (minijinja's trailing-newline strip made the ending depend
+        // on the template and on whether the final expression was empty).
+        let formats = [TemplateFormat::Nygard, TemplateFormat::Madr];
+        let variants = [
+            TemplateVariant::Full,
+            TemplateVariant::Minimal,
+            TemplateVariant::Bare,
+            TemplateVariant::BareMinimal,
+        ];
+        let empty = Adr::new(1, "Empty fields");
+        let mut populated = Adr::new(2, "Populated fields");
+        populated.context = "Some context.".into();
+        populated.decision = "Some decision.".into();
+        populated.consequences = "Some consequences.".into();
+
+        for format in formats {
+            for variant in variants {
+                let template = Template::builtin_with_variant(format, variant);
+                for adr in [&empty, &populated] {
+                    let output = template
+                        .render(adr, &Config::default(), &no_link_titles())
+                        .unwrap();
+                    assert!(
+                        output.ends_with('\n') && !output.ends_with("\n\n"),
+                        "{format}-{variant} (adr {}) must end with exactly one newline, got tail {:?}",
+                        adr.number,
+                        &output[output.len().saturating_sub(12)..]
+                    );
+                }
+            }
+        }
+    }
+
     // ========== Template Engine Tests ==========
 
     #[test]
@@ -1368,7 +1414,7 @@ mod tests {
         let config = Config::default();
 
         let output = engine.render(&adr, &config, &no_link_titles()).unwrap();
-        assert_eq!(output, "ADR 42: Custom ADR");
+        assert_eq!(output, "ADR 42: Custom ADR\n");
     }
 
     // ========== Custom Template Tests ==========
@@ -1417,14 +1463,14 @@ Links: {% for link in links %}{{ link.kind }} {{ link.target }}{% endfor %}"#,
         let output = custom
             .render(&adr, &compat_config, &no_link_titles())
             .unwrap();
-        assert_eq!(output, "Compatible Mode");
+        assert_eq!(output, "Compatible Mode\n");
 
         let ng_config = Config {
             mode: ConfigMode::NextGen,
             ..Default::default()
         };
         let output = custom.render(&adr, &ng_config, &no_link_titles()).unwrap();
-        assert_eq!(output, "NextGen Mode");
+        assert_eq!(output, "NextGen Mode\n");
     }
 
     #[test]
@@ -1561,7 +1607,7 @@ Links: {% for link in links %}{{ link.kind }} {{ link.target }}{% endfor %}"#,
         let config = Config::default();
         let output = template.render(&adr, &config, &no_link_titles()).unwrap();
 
-        assert_eq!(output, "0001");
+        assert_eq!(output, "0001\n");
     }
 
     #[test]
@@ -1571,7 +1617,7 @@ Links: {% for link in links %}{{ link.kind }} {{ link.target }}{% endfor %}"#,
         let config = Config::default();
         let output = template.render(&adr, &config, &no_link_titles()).unwrap();
 
-        assert_eq!(output, "000001");
+        assert_eq!(output, "000001\n");
     }
     // ========== Template accessor tests (issue #235) ==========
 


### PR DESCRIPTION
Closes #320.

## Problem

`adrs new --format madr` (and `--variant minimal`) wrote files without a trailing newline. Probing all eight builtins on main showed the deeper issue: minijinja strips the template source's final newline, so the rendered ending depends on the template and on whether its last expression is empty:

| Template | Ending |
|----------|--------|
| nygard-full | one newline (fixed by #304) |
| nygard-minimal | two newlines when last section empty, none when populated |
| nygard-bare, nygard-bare-minimal | one newline |
| madr-full, madr-minimal | none |
| madr-bare, madr-bare-minimal | one newline |

Files without trailing newlines are exactly the input class that made the #311 write path hazardous (corpus fixture 0009 exists because of it), and they produce `\ No newline at end of file` noise in every consumer's diffs.

## Fix

Normalize once in `Template::render`: trim trailing whitespace, append exactly one newline. Per-template source patches (the #304 approach) cannot fix the empty-expression asymmetry, and render-side normalization covers user-supplied custom templates too.

## Tests

- New regression test renders every builtin (2 formats x 4 variants) with both empty and populated body fields and asserts each ends with exactly one newline.
- Five exact-output assertions on custom mini-templates updated to the new contract (`"0001"` becomes `"0001\n"`, etc.).
- End-to-end: `adrs new --format madr` output now ends `0x0a`; doctor clean.
- Full suite: 745 pass.