### PR TITLE
chore: release v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "fuzzy-matcher",
  "mdbook-lint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.10.0" }
+adrs-core = { path = "crates/adrs-core", version = "0.10.1" }
 
 # Testing
 serial_test = "3.5"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.1] - 2026-07-22
+
+### Bug Fixes
+
+- Preserve line endings and blank-line separators in body patches (closes #339, closes #340)
+- Map MADR H3 Consequences under Decision Outcome to consequences on read (closes #338)
+- Preserve CRLF line endings in legacy-mode metadata writes (closes #344)
+- Separate consecutive list items in parse_sections (closes #346)
+- Detect ADR format from headings so ng-init repos pass doctor (closes #348)
+
+### Features
+
+- Add MCP init_repository tool and start server at unconfigured paths (closes #349)
+
+
 ## [0.10.0] - 2026-07-16
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.1] - 2026-07-22
+
+### Bug Fixes
+
+- Map MADR H3 Consequences under Decision Outcome to consequences on read (closes #338)
+- Reject POSIX-style absolute adr_dir on all platforms in init_repository
+
+### Features
+
+- Add MCP init_repository tool and start server at unconfigured paths (closes #349)
+- Add --deciders/--consulted/--informed flags to adrs new (closes #85)
+
+
 ## [0.10.0] - 2026-07-16
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `adrs`: 0.10.0 -> 0.10.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.10.1] - 2026-07-22

### Bug Fixes

- Preserve line endings and blank-line separators in body patches (closes #339, closes #340)
- Map MADR H3 Consequences under Decision Outcome to consequences on read (closes #338)
- Preserve CRLF line endings in legacy-mode metadata writes (closes #344)
- Separate consecutive list items in parse_sections (closes #346)
- Detect ADR format from headings so ng-init repos pass doctor (closes #348)

### Features

- Add MCP init_repository tool and start server at unconfigured paths (closes #349)
</blockquote>

## `adrs`

<blockquote>

## [0.10.1] - 2026-07-22

### Bug Fixes

- Map MADR H3 Consequences under Decision Outcome to consequences on read (closes #338)
- Reject POSIX-style absolute adr_dir on all platforms in init_repository

### Features

- Add MCP init_repository tool and start server at unconfigured paths (closes #349)
- Add --deciders/--consulted/--informed flags to adrs new (closes #85)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).