### PR TITLE
feat: add MCP init_repository tool and start server at unconfigured paths (closes #349)

### DIFF
--- a/book/src/mcp.md
+++ b/book/src/mcp.md
@@ -50,9 +50,27 @@ Then configure Claude with:
 }
 ```
 
+## Empty-state bootstrap
+
+Agents typically register the MCP server with a static command and working
+directory, then start it on demand. That directory may not be an ADR repository
+yet.
+
+The server starts even when its bound directory is not initialized. Before
+initialization:
+
+- repository-dependent tools return a structured "repository not initialized"
+  error and the server stays alive; and
+- the `init_repository` tool is available to create the repository in place.
+
+Call `init_repository` (optionally with `nextgen: true` and/or a custom
+`adr_dir`) to bootstrap the repository, then use the other tools in the same
+session without restarting the server. Initialization operates only on the
+bound root and refuses to overwrite an existing repository.
+
 ## Available Tools
 
-The MCP server provides 17 tools organized by function:
+The MCP server provides 18 tools organized by function:
 
 ### Read Operations
 
@@ -71,6 +89,7 @@ The MCP server provides 17 tools organized by function:
 
 | Tool | Description |
 |------|-------------|
+| `init_repository` | Initialize an ADR repository at the server's bound directory (compatible or NextGen mode) |
 | `create_adr` | Create a new ADR (uses the repository's configured default status; proposed if not configured) |
 | `update_status` | Change an ADR's status |
 | `link_adrs` | Create bidirectional links between ADRs |
@@ -132,6 +151,27 @@ Search ADRs for matching text.
 - `case_sensitive` (optional): Perform case-sensitive search (default: false)
 
 **Returns:** List of matching ADRs with match snippets showing which section matched and context around the match.
+
+### init_repository
+
+Initialize an ADR repository at the directory the server is bound to (its
+current working directory, or the path given with `-C`). This lets a client
+bootstrap a first-run repository without an interactive `adrs init` step. See
+[Empty-state bootstrap](#empty-state-bootstrap) below.
+
+The tool operates only on the bound root. It does not create parent
+directories, does not accept a per-call path, and refuses to overwrite an
+existing configuration or ADR collection.
+
+**Parameters:**
+- `nextgen` (optional): Initialize in NextGen mode (`adrs.toml`, YAML
+  frontmatter). Defaults to `false` (compatible mode, `.adr-dir`). Equivalent
+  to `adrs --ng init`.
+- `adr_dir` (optional): ADR directory relative to the root (default `doc/adr`).
+  Must be relative and stay within the root.
+
+**Returns:** The `mode`, `root`, `config_path`, `adr_directory`,
+`adr_directory_path`, and `initial_adr_path`.
 
 ### create_adr
 

--- a/crates/adrs-core/src/lib.rs
+++ b/crates/adrs-core/src/lib.rs
@@ -92,7 +92,9 @@ mod repository;
 mod template;
 mod types;
 
-pub use config::{Config, ConfigMode, ConfigSource, DiscoveredConfig, discover};
+pub use config::{
+    CONFIG_FILE, Config, ConfigMode, ConfigSource, DiscoveredConfig, LEGACY_CONFIG_FILE, discover,
+};
 pub use error::{Error, Result};
 pub use export::{
     ConsideredOption, ImportOptions, ImportResult, JSON_ADR_SCHEMA, JSON_ADR_VERSION, JsonAdr,

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -858,27 +858,27 @@ fn main() -> Result<()> {
         #[cfg(all(feature = "mcp", not(feature = "mcp-http")))]
         Commands::Mcp { command } => match command {
             McpCommands::Serve {} => {
-                let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+                let root = resolve_mcp_root(&start_dir);
                 tokio::runtime::Runtime::new()
                     .context("Failed to create tokio runtime")?
-                    .block_on(mcp::serve_stdio(discovered.root))
+                    .block_on(mcp::serve_stdio(root))
                     .context("MCP server error")
             }
         },
         #[cfg(feature = "mcp-http")]
         Commands::Mcp { command } => match command {
             McpCommands::Serve { http } => {
-                let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
+                let root = resolve_mcp_root(&start_dir);
                 let runtime =
                     tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
 
                 if let Some(addr) = http {
                     runtime
-                        .block_on(mcp::serve_http(discovered.root, addr))
+                        .block_on(mcp::serve_http(root, addr))
                         .context("MCP HTTP server error")
                 } else {
                     runtime
-                        .block_on(mcp::serve_stdio(discovered.root))
+                        .block_on(mcp::serve_stdio(root))
                         .context("MCP server error")
                 }
             }
@@ -959,6 +959,20 @@ fn resolve_cli_path(working_dir: Option<&std::path::Path>, path: PathBuf) -> Pat
         Some(dir) if path.is_relative() => dir.join(path),
         _ => path,
     }
+}
+
+/// Resolve the root directory the MCP server binds to.
+///
+/// Unlike the other commands, `mcp serve` must start even when the directory is
+/// not yet an ADR repository, so that a client can bootstrap one through the
+/// `init_repository` tool. When discovery finds a repository we bind its root;
+/// otherwise we bind the start directory as-is and let repository-dependent
+/// tools return structured "not initialized" errors without exiting.
+#[cfg(feature = "mcp")]
+fn resolve_mcp_root(start_dir: &std::path::Path) -> PathBuf {
+    discover(start_dir)
+        .map(|discovered| discovered.root)
+        .unwrap_or_else(|_| start_dir.to_path_buf())
 }
 
 /// Discover config or return a helpful error.

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -1021,7 +1021,12 @@ impl AdrState {
             }
             Some(dir) => {
                 let path = PathBuf::from(dir);
-                if path.is_absolute() {
+                // Reject absolute paths on any platform. `Path::is_absolute` is
+                // platform-specific (on Windows a POSIX-style "/etc" is not
+                // absolute without a drive prefix), so also reject a leading
+                // path separator regardless of the host OS.
+                let starts_with_separator = dir.starts_with('/') || dir.starts_with('\\');
+                if path.is_absolute() || starts_with_separator {
                     return Err(format!(
                         "adr_dir must be a relative path within the repository root, got absolute path: {dir}"
                     ));
@@ -3698,12 +3703,17 @@ Confirm via tests.
 
     #[tokio::test]
     async fn test_init_repository_rejects_absolute_adr_dir() {
-        let (client, _tmp) = setup_uninitialized_client().await;
-        let result = client
-            .call_tool("init_repository", json!({"adr_dir": "/etc/adr"}))
-            .await
-            .unwrap();
-        assert!(result.is_error, "absolute adr_dir must be rejected");
+        // POSIX-style absolute paths ("/etc") and paths with a leading
+        // separator ("\\etc") must be rejected on every platform, even where
+        // `Path::is_absolute` does not treat them as absolute (Windows).
+        for dir in ["/etc/adr", "\\etc\\adr"] {
+            let (client, _tmp) = setup_uninitialized_client().await;
+            let result = client
+                .call_tool("init_repository", json!({ "adr_dir": dir }))
+                .await
+                .unwrap();
+            assert!(result.is_error, "absolute adr_dir must be rejected: {dir}");
+        }
     }
 
     #[tokio::test]

--- a/crates/adrs/src/mcp.rs
+++ b/crates/adrs/src/mcp.rs
@@ -291,6 +291,23 @@ pub struct SuggestTagsParams {
     pub max_tags: Option<usize>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct InitRepositoryParams {
+    /// Initialize in NextGen mode (adrs.toml config, YAML frontmatter) instead
+    /// of compatible mode (.adr-dir config). Equivalent to `adrs --ng init`.
+    #[serde(default)]
+    #[schemars(
+        description = "Initialize in NextGen mode (adrs.toml, YAML frontmatter) instead of compatible mode (.adr-dir). Defaults to false."
+    )]
+    pub nextgen: bool,
+
+    /// ADR directory relative to the repository root. Defaults to "doc/adr".
+    #[schemars(
+        description = "ADR directory relative to the repository root (default: doc/adr). Must be a relative path that stays within the root."
+    )]
+    pub adr_dir: Option<String>,
+}
+
 // Response types
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -628,6 +645,15 @@ fn build_router(root: PathBuf) -> McpRouter {
     );
 
     // Write tools
+    let init_repository = adr_tool!(
+        rw,
+        state,
+        "init_repository",
+        "Initialize an ADR repository at the directory the server is bound to (its current working directory or -C path). Use this when repository tools report the repository is not initialized. Set nextgen=true for NextGen mode (adrs.toml, YAML frontmatter); omit or false for compatible mode (.adr-dir). Optionally set adr_dir (relative to the root, default doc/adr). Operates only on the bound root, refuses to overwrite an existing repository, and does not create parent directories. Returns the mode, config path, ADR directory, and initial ADR path.",
+        InitRepositoryParams,
+        init_repository_impl
+    );
+
     let create_adr = adr_tool!(
         rw,
         state,
@@ -698,6 +724,7 @@ fn build_router(root: PathBuf) -> McpRouter {
         .tool(run_doctor)
         .tool(export_adrs)
         // Write tools
+        .tool(init_repository)
         .tool(create_adr)
         .tool(update_status)
         .tool(link_adrs)
@@ -958,6 +985,101 @@ impl AdrState {
         }
 
         serde_json::to_string_pretty(&results).map_err(|e| e.to_string())
+    }
+
+    fn init_repository_impl(&self, params: InitRepositoryParams) -> Result<String, String> {
+        let root = self.root.as_path();
+
+        // Never create arbitrary parent directories: the bound root must already
+        // exist as a directory.
+        if !root.exists() {
+            return Err(format!(
+                "Repository root does not exist: {}. Create the directory before initializing.",
+                root.display()
+            ));
+        }
+        if !root.is_dir() {
+            return Err(format!(
+                "Repository root is not a directory: {}",
+                root.display()
+            ));
+        }
+
+        // Refuse to overwrite an existing configuration or ADR collection.
+        // Repeated initialization is rejected without changing existing files.
+        if Repository::open(root).is_ok() {
+            return Err(format!(
+                "An ADR repository already exists at {}. Initialization was not performed.",
+                root.display()
+            ));
+        }
+
+        // Validate the ADR directory: it must stay within the bound root.
+        let adr_dir = match params.adr_dir.as_deref() {
+            Some(dir) if dir.trim().is_empty() => {
+                return Err("adr_dir must not be empty.".to_string());
+            }
+            Some(dir) => {
+                let path = PathBuf::from(dir);
+                if path.is_absolute() {
+                    return Err(format!(
+                        "adr_dir must be a relative path within the repository root, got absolute path: {dir}"
+                    ));
+                }
+                if path
+                    .components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+                {
+                    return Err(format!(
+                        "adr_dir must not escape the repository root: {dir}"
+                    ));
+                }
+                Some(path)
+            }
+            None => None,
+        };
+
+        let repo = Repository::init(root, adr_dir, params.nextgen).map_err(|e| e.to_string())?;
+        let config = repo.config();
+
+        let config_path = if config.is_next_gen() {
+            root.join(adrs_core::CONFIG_FILE)
+        } else {
+            root.join(adrs_core::LEGACY_CONFIG_FILE)
+        };
+
+        // The initial ADR (lowest number) present after initialization, if any.
+        let adr_path = repo.adr_path();
+        let initial_adr_path = repo
+            .list()
+            .ok()
+            .and_then(|adrs| adrs.into_iter().min_by_key(|a| a.number))
+            .map(|adr| adr_path.join(adr.filename()).display().to_string());
+
+        #[derive(Serialize)]
+        struct InitResult {
+            mode: String,
+            root: String,
+            config_path: String,
+            adr_directory: String,
+            adr_directory_path: String,
+            initial_adr_path: Option<String>,
+        }
+
+        let result = InitResult {
+            mode: if config.is_next_gen() {
+                "nextgen".to_string()
+            } else {
+                "compatible".to_string()
+            },
+            root: root.display().to_string(),
+            config_path: config_path.display().to_string(),
+            adr_directory: config.adr_dir.display().to_string(),
+            adr_directory_path: adr_path.display().to_string(),
+            initial_adr_path,
+        };
+
+        serde_json::to_string_pretty(&result).map_err(|e| e.to_string())
     }
 
     fn create_adr_impl(&self, params: CreateAdrParams) -> Result<String, String> {
@@ -1896,12 +2018,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_tools_returns_all_17() {
+    async fn test_list_tools_returns_all_18() {
         let (client, _tmp) = setup_client(false).await;
         let tools = client.list_all_tools().await.unwrap();
-        assert_eq!(tools.len(), 17, "expected 17 tools, got {}", tools.len());
+        assert_eq!(tools.len(), 18, "expected 18 tools, got {}", tools.len());
 
         let names: Vec<_> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"init_repository"));
         assert!(names.contains(&"list_adrs"));
         assert!(names.contains(&"get_adr"));
         assert!(names.contains(&"search_adrs"));
@@ -3384,5 +3507,231 @@ Confirm via tests.
             adr2.get("decision").is_none() || adr2["decision"].is_null(),
             "decision should be absent in metadata_only mode"
         );
+    }
+
+    // ========== Empty-state bootstrap tests (#349) ==========
+
+    /// Helper: create an MCP client bound to an existing but *uninitialized*
+    /// directory (no `Repository::init` call), mirroring `mcp serve` started at
+    /// an unconfigured path.
+    async fn setup_uninitialized_client() -> (McpClient, tempfile::TempDir) {
+        let temp = tempfile::tempdir().unwrap();
+        let router = build_router(temp.path().to_path_buf());
+        let transport = ChannelTransport::new(router);
+        let client = McpClient::connect(transport).await.unwrap();
+        client.initialize("test-client", "1.0.0").await.unwrap();
+        (client, temp)
+    }
+
+    #[tokio::test]
+    async fn test_uninitialized_server_advertises_init_tool() {
+        let (client, _tmp) = setup_uninitialized_client().await;
+        let tools = client.list_all_tools().await.unwrap();
+        assert_eq!(tools.len(), 18, "expected 18 tools, got {}", tools.len());
+        let names: Vec<_> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(
+            names.contains(&"init_repository"),
+            "init_repository must be available before initialization"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_repository_tools_error_before_init_without_terminating() {
+        let (client, _tmp) = setup_uninitialized_client().await;
+
+        // A repository-dependent tool returns a structured error, not a crash.
+        let result = client.call_tool("list_adrs", json!({})).await.unwrap();
+        assert!(
+            result.is_error,
+            "list_adrs should error before initialization"
+        );
+
+        // The server is still alive and responsive after the failed call.
+        client.ping().await.unwrap();
+
+        // And it can still be initialized in the same session.
+        let init = client
+            .call_tool("init_repository", json!({}))
+            .await
+            .unwrap();
+        assert!(
+            !init.is_error,
+            "init_repository should succeed on empty dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_repository_compatible_mode() {
+        let (client, temp) = setup_uninitialized_client().await;
+
+        let result = client
+            .call_tool_text("init_repository", json!({}))
+            .await
+            .unwrap();
+        let init: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(init["mode"], "compatible");
+        assert_eq!(init["adr_directory"], "doc/adr");
+        assert!(
+            init["config_path"].as_str().unwrap().ends_with(".adr-dir"),
+            "compatible mode writes .adr-dir, got {}",
+            init["config_path"]
+        );
+        assert!(temp.path().join(".adr-dir").exists());
+
+        // The initial ADR exists and repository tools now work in the same session.
+        let initial = init["initial_adr_path"].as_str().unwrap();
+        assert!(
+            std::path::Path::new(initial).exists(),
+            "initial ADR path should exist: {initial}"
+        );
+
+        let adrs: Vec<AdrSummary> =
+            serde_json::from_str(&client.call_tool_text("list_adrs", json!({})).await.unwrap())
+                .unwrap();
+        assert_eq!(adrs.len(), 1);
+        assert_eq!(adrs[0].number, 1);
+    }
+
+    #[tokio::test]
+    async fn test_init_repository_nextgen_mode() {
+        let (client, temp) = setup_uninitialized_client().await;
+
+        let result = client
+            .call_tool_text("init_repository", json!({"nextgen": true}))
+            .await
+            .unwrap();
+        let init: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(init["mode"], "nextgen");
+        assert!(
+            init["config_path"].as_str().unwrap().ends_with("adrs.toml"),
+            "nextgen mode writes adrs.toml, got {}",
+            init["config_path"]
+        );
+        assert!(temp.path().join("adrs.toml").exists());
+
+        // get_repository_info agrees the session is now nextgen.
+        let info: serde_json::Value = serde_json::from_str(
+            &client
+                .call_tool_text("get_repository_info", json!({}))
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(info["mode"], "nextgen");
+    }
+
+    #[tokio::test]
+    async fn test_init_repository_custom_adr_dir() {
+        let (client, temp) = setup_uninitialized_client().await;
+
+        let result = client
+            .call_tool_text("init_repository", json!({"adr_dir": "docs/decisions"}))
+            .await
+            .unwrap();
+        let init: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(init["adr_directory"], "docs/decisions");
+        assert!(temp.path().join("docs/decisions").is_dir());
+    }
+
+    #[tokio::test]
+    async fn test_init_repository_rejects_repeat() {
+        let (client, temp) = setup_uninitialized_client().await;
+
+        client
+            .call_tool_text("init_repository", json!({}))
+            .await
+            .unwrap();
+
+        let config_before = std::fs::read_to_string(temp.path().join(".adr-dir")).unwrap();
+
+        // A second initialization is rejected and changes nothing.
+        let repeat = client
+            .call_tool("init_repository", json!({"nextgen": true}))
+            .await
+            .unwrap();
+        assert!(repeat.is_error, "repeated init should be rejected");
+
+        assert!(
+            !temp.path().join("adrs.toml").exists(),
+            "rejected repeat must not write a new config"
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join(".adr-dir")).unwrap(),
+            config_before,
+            "rejected repeat must not modify existing config"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_repository_rejects_repeat_on_preinitialized() {
+        // A server bound to an already-initialized repo must refuse init.
+        let (client, _tmp) = setup_client(false).await;
+        let result = client
+            .call_tool("init_repository", json!({}))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "init on an existing repository should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_repository_rejects_parent_traversal() {
+        let (client, temp) = setup_uninitialized_client().await;
+        let result = client
+            .call_tool("init_repository", json!({"adr_dir": "../escape"}))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "adr_dir escaping the root must be rejected"
+        );
+        assert!(
+            !temp.path().join(".adr-dir").exists(),
+            "rejected init must not write config"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_repository_rejects_absolute_adr_dir() {
+        let (client, _tmp) = setup_uninitialized_client().await;
+        let result = client
+            .call_tool("init_repository", json!({"adr_dir": "/etc/adr"}))
+            .await
+            .unwrap();
+        assert!(result.is_error, "absolute adr_dir must be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_full_session_works_after_init() {
+        let (client, _tmp) = setup_uninitialized_client().await;
+
+        client
+            .call_tool_text("init_repository", json!({}))
+            .await
+            .unwrap();
+
+        // Create and read back an ADR without restarting the server.
+        let created: serde_json::Value = serde_json::from_str(
+            &client
+                .call_tool_text("create_adr", json!({"title": "Use PostgreSQL"}))
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(created["number"], 2);
+
+        let adr: AdrDetail = serde_json::from_str(
+            &client
+                .call_tool_text("get_adr", json!({"number": 2}))
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(adr.title, "Use PostgreSQL");
     }
 }


### PR DESCRIPTION
Closes #349.

## Problem

The MCP server could not provide a first-run workflow. `adrs mcp serve` exited before the transport started when its directory was not an ADR repository. Even when started with `-C` at an unconfigured path, the server stayed alive but exposed no tool to initialize a repository, so an agent using a static MCP registration (fixed command, args, and working directory) had no way to recover.

## Changes

- `mcp serve` now binds the discovered repository root, or the start directory when no repository is found, instead of hard-exiting. Repository-dependent tools continue to return structured "not initialized" errors without terminating the server. A new `resolve_mcp_root` helper replaces the pre-serve `discover_or_error` call for the serve path only; all other commands keep their existing behavior.
- New `init_repository` write tool initializes the bound root in compatible or NextGen mode with an optional `adr_dir`. It:
  - operates only on the root the server was bound to (no per-call path);
  - rejects an absolute or parent-escaping `adr_dir`;
  - refuses to overwrite an existing configuration or ADR collection (repeat init is rejected without changing files);
  - does not create parent directories (rejects a nonexistent root); and
  - returns `mode`, `root`, `config_path`, `adr_directory`, `adr_directory_path`, and `initial_adr_path`.
- Re-export `CONFIG_FILE` and `LEGACY_CONFIG_FILE` from `adrs-core`.
- Document the empty-state bootstrap flow and the new tool in `book/src/mcp.md`.

## Tests

Added integration tests (via the in-process MCP client) covering: unconfigured startup advertising `init_repository`, structured errors before init with continued operation and successful in-session init, compatible and NextGen modes, custom `adr_dir`, repeat-init rejection (both fresh and pre-initialized), parent-traversal and absolute-path rejection, and a full create/read session after init. Updated the tool-count assertion from 17 to 18.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features` with `RUSTFLAGS=-D warnings`
- `cargo test --all-features` (all pass)
- `cargo check -p adrs-core --all-features --locked` and `cargo check -p adrs --all-features --locked` (MSRV command shape)
- `mdbook build` for the book gate
- CLI smoke: `adrs -C <empty-dir> mcp serve` now starts (exit 0 on stdin EOF) instead of exiting 1 with "No ADR repository found".

## Scope

Limited to MCP empty-state behavior and bootstrap of the single root bound at startup, as the issue specifies. It does not add per-call repository selection or multi-directory support.