### PR TITLE
feat: add --deciders/--consulted/--informed flags to adrs new (closes #85)

### DIFF
--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -18,6 +18,9 @@ pub fn new(
     template: Option<PathBuf>,
     status: Option<String>,
     tags: Option<Vec<String>>,
+    deciders: Option<Vec<String>>,
+    consulted: Option<Vec<String>>,
+    informed: Option<Vec<String>>,
     no_edit: bool,
     config: &Config,
 ) -> Result<()> {
@@ -111,6 +114,32 @@ pub fn new(
             adr.set_tags(tag_list);
             repo.update_metadata(&adr)
                 .context("Failed to update ADR tags")?;
+        }
+    }
+
+    // Set MADR participant fields if specified (requires ng mode for YAML frontmatter).
+    if deciders.is_some() || consulted.is_some() || informed.is_some() {
+        if !is_ng {
+            anyhow::bail!(
+                "--deciders/--consulted/--informed require --ng mode (YAML frontmatter). Use: adrs --ng new --deciders ... or set mode = \"ng\" in adrs.toml"
+            );
+        }
+        let mut changed = false;
+        if let Some(list) = deciders {
+            adr.set_decision_makers(list);
+            changed = true;
+        }
+        if let Some(list) = consulted {
+            adr.set_consulted(list);
+            changed = true;
+        }
+        if let Some(list) = informed {
+            adr.set_informed(list);
+            changed = true;
+        }
+        if changed {
+            repo.update_metadata(&adr)
+                .context("Failed to update ADR participants")?;
         }
     }
 

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -163,6 +163,18 @@ LINK FORMAT:
         #[arg(short = 't', long, value_name = "TAGS", value_delimiter = ',')]
         tags: Option<Vec<String>>,
 
+        /// Decision makers (comma-separated, requires --ng)
+        #[arg(long, value_name = "NAMES", value_delimiter = ',')]
+        deciders: Option<Vec<String>>,
+
+        /// People consulted before the decision (comma-separated, requires --ng)
+        #[arg(long, value_name = "NAMES", value_delimiter = ',')]
+        consulted: Option<Vec<String>>,
+
+        /// People informed after the decision (comma-separated, requires --ng)
+        #[arg(long, value_name = "NAMES", value_delimiter = ',')]
+        informed: Option<Vec<String>>,
+
         /// Create ADR without opening editor (for scripting/CI)
         #[arg(long)]
         no_edit: bool,
@@ -657,6 +669,9 @@ fn main() -> Result<()> {
             template,
             status,
             tags,
+            deciders,
+            consulted,
+            informed,
             no_edit,
         } => {
             let discovered = discover_or_error(&start_dir, cli.working_dir.is_some())?;
@@ -671,6 +686,9 @@ fn main() -> Result<()> {
                 template.map(|t| resolve_cli_path(cli.working_dir.as_deref(), t)),
                 status,
                 tags,
+                deciders,
+                consulted,
+                informed,
                 no_edit,
                 &discovered.config,
             )

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1842,6 +1842,76 @@ fn test_smoke_nextgen_workflow() {
     temp.close().unwrap();
 }
 
+/// `new --deciders/--consulted/--informed` writes MADR participant frontmatter in ng mode.
+#[test]
+fn test_new_madr_participant_flags() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "init"])
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "--ng",
+            "new",
+            "--no-edit",
+            "--deciders",
+            "Alice, Bob",
+            "--consulted",
+            "Security Team",
+            "--informed",
+            "Engineering",
+            "Use OAuth2",
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(temp.path().join("doc/adr/0002-use-oauth2.md")).unwrap();
+    assert!(content.starts_with("---"));
+    assert!(content.contains("decision-makers:"));
+    assert!(content.contains("Alice"));
+    assert!(content.contains("Bob"));
+    assert!(content.contains("consulted:"));
+    assert!(content.contains("Security Team"));
+    assert!(content.contains("informed:"));
+    assert!(content.contains("Engineering"));
+
+    // Decider filter finds the ADR.
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "list", "--decider", "Alice"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0002-use-oauth2.md"));
+
+    temp.close().unwrap();
+}
+
+/// The MADR participant flags require ng mode and error clearly in legacy mode.
+#[test]
+fn test_new_madr_participant_flags_require_ng() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["init"])
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "--deciders", "Alice", "Use OAuth2"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--ng mode"));
+
+    temp.close().unwrap();
+}
+
 // ============================================================================
 // -C Relative Path Resolution
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds `--deciders`, `--consulted`, and `--informed` flags to `adrs new`, exposing the MADR participant metadata fields on the CLI. Closes #85.

The core, MCP, and template layers already supported `decision-makers`, `consulted`, and `informed` end-to-end; only the `new` CLI surface was missing.

## Behavior

```
adrs --ng new --deciders "Alice, Bob" --consulted "Security Team" --informed "Engineering" "Use OAuth2"
```

writes:

```yaml
---
status: proposed
decision-makers:
  - Alice
  - Bob
consulted:
  - Security Team
informed:
  - Engineering
---
```

- Flags accept comma-separated names (`value_delimiter = ','`), matching the existing `--tags` flag.
- They require `--ng` mode (YAML frontmatter). In legacy mode they error with a message pointing at `--ng`, again mirroring `--tags`.
- Wired through `set_decision_makers` / `set_consulted` / `set_informed`, written via `update_metadata`.

## Tests

- `test_new_madr_participant_flags`: ng-mode creation writes all three fields and the ADR is found by `list --decider`.
- `test_new_madr_participant_flags_require_ng`: legacy mode fails with an `--ng mode` error.

## Checks

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --all-features`, and `cargo check --all-features --locked` (both crates) all pass locally.