### PR TITLE
fix: init respects configured adr_dir and existing config (closes #358)

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -116,9 +116,28 @@ impl Repository {
     }
 
     /// Initialize a new repository at the given root.
+    ///
+    /// If a config file (`adrs.toml` or `.adr-dir`) already exists at `root`
+    /// and its configured `adr_dir` already matches the resolved directory,
+    /// the file is left untouched -- including settings this function does
+    /// not otherwise know about, such as `default_status`, `templates`,
+    /// `generate`, `export`, and `doctor`. Otherwise a fresh config is
+    /// written for the resolved directory and mode, as before.
     pub fn init(root: impl Into<PathBuf>, adr_dir: Option<PathBuf>, ng: bool) -> Result<Self> {
         let root = root.into();
         let adr_dir = adr_dir.unwrap_or_else(|| PathBuf::from(crate::config::DEFAULT_ADR_DIR));
+
+        let legacy_path = root.join(crate::config::LEGACY_CONFIG_FILE);
+        let toml_path = root.join(crate::config::CONFIG_FILE);
+
+        // Reuse an existing config file if it already points at the resolved
+        // directory, so we don't silently discard settings it carries.
+        let existing_config = if legacy_path.exists() || toml_path.exists() {
+            Config::load(&root).ok().filter(|c| c.adr_dir == adr_dir)
+        } else {
+            None
+        };
+
         let adr_path = root.join(&adr_dir);
 
         // Check if directory exists and count existing ADRs
@@ -130,17 +149,35 @@ impl Repository {
             0
         };
 
-        // Create config
-        let config = Config {
-            adr_dir,
-            mode: if ng {
-                ConfigMode::NextGen
-            } else {
-                ConfigMode::Compatible
-            },
-            ..Default::default()
+        let config = match existing_config {
+            Some(existing) => existing,
+            None => {
+                // Create config
+                let config = Config {
+                    adr_dir,
+                    mode: if ng {
+                        ConfigMode::NextGen
+                    } else {
+                        ConfigMode::Compatible
+                    },
+                    ..Default::default()
+                };
+                // Config::load() always prefers adrs.toml over .adr-dir, so
+                // a stale sibling in the other format could silently shadow
+                // the file we're about to write. Remove it so only one
+                // config file is authoritative after init.
+                let stale = if config.is_next_gen() {
+                    &legacy_path
+                } else {
+                    &toml_path
+                };
+                if stale.exists() {
+                    fs::remove_file(stale)?;
+                }
+                config.save(&root)?;
+                config
+            }
         };
-        config.save(&root)?;
 
         let template_engine = Self::engine_from_config(&config);
 

--- a/crates/adrs/src/commands/init.rs
+++ b/crates/adrs/src/commands/init.rs
@@ -1,15 +1,34 @@
 //! Initialize command.
 
-use adrs_core::Repository;
+use adrs_core::{Config, Repository, discover};
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::path::PathBuf;
 
-pub fn init(root: &Path, directory: PathBuf, ng: bool) -> Result<()> {
-    let repo = Repository::init(root, Some(directory.clone()), ng).with_context(|| {
+/// Resolve the root to initialize in and the ADR directory to use.
+///
+/// An explicit `directory` argument always wins. Otherwise the ADR
+/// directory is resolved through the same config discovery every other
+/// command uses (`adrs.toml`, then `.adr-dir`, then `ADR_DIRECTORY`, then
+/// the global config), falling back to `doc/adr` only when nothing is
+/// configured.
+fn resolve_init_target(root: &Path, directory: Option<PathBuf>) -> (PathBuf, PathBuf) {
+    match directory {
+        Some(dir) => (root.to_path_buf(), dir),
+        None => match discover(root) {
+            Ok(discovered) => (discovered.root, discovered.config.adr_dir),
+            Err(_) => (root.to_path_buf(), Config::default().adr_dir),
+        },
+    }
+}
+
+pub fn init(root: &Path, directory: Option<PathBuf>, ng: bool) -> Result<()> {
+    let (init_root, adr_dir) = resolve_init_target(root, directory);
+
+    let repo = Repository::init(&init_root, Some(adr_dir.clone()), ng).with_context(|| {
         format!(
             "Failed to initialize ADR repository in {}",
-            directory.display()
+            adr_dir.display()
         )
     })?;
 

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -109,9 +109,8 @@ EXAMPLES:
 Creates the ADR directory and an initial ADR documenting the use of ADRs.
 If ADRs already exist in the directory, they are preserved.")]
     Init {
-        /// Directory to store ADRs [default: doc/adr]
-        #[arg(default_value = "doc/adr")]
-        directory: PathBuf,
+        /// Directory to store ADRs [default: doc/adr, or the configured adr_dir]
+        directory: Option<PathBuf>,
     },
 
     /// Create a new ADR

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -143,6 +143,149 @@ fn test_init_with_cwd_flag() {
     temp.close().unwrap();
 }
 
+// Regression tests for issue #358: `init` ignored every configured
+// `adr_dir` source (adrs.toml, .adr-dir, ADR_DIRECTORY, global config),
+// always created doc/adr, and clobbered any existing config.
+
+#[test]
+fn test_init_no_config_falls_back_to_default_doc_adr() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    temp.child("doc/adr").assert(predicate::path::is_dir());
+    temp.child(".adr-dir")
+        .assert(predicate::str::contains("doc/adr"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_init_respects_existing_adrs_toml_adr_dir() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let original_config = "adr_dir = \"docs/adr\"\n";
+    temp.child("adrs.toml").write_str(original_config).unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // The configured directory is honored, not doc/adr.
+    temp.child("docs/adr").assert(predicate::path::is_dir());
+    temp.child("doc/adr")
+        .assert(predicate::path::exists().not());
+
+    // The existing config file is left byte-for-byte untouched.
+    let config_after = fs::read_to_string(temp.path().join("adrs.toml")).unwrap();
+    assert_eq!(
+        config_after, original_config,
+        "existing adrs.toml must not be rewritten"
+    );
+
+    // Issue #358's exact failure: a subsequent command must succeed.
+    adrs()
+        .current_dir(temp.path())
+        .arg("list")
+        .assert()
+        .success();
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_init_respects_existing_adr_dir_file() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    temp.child(".adr-dir").write_str("existing/adrs\n").unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    temp.child("existing/adrs")
+        .assert(predicate::path::is_dir());
+    temp.child("doc/adr")
+        .assert(predicate::path::exists().not());
+
+    let config_after = fs::read_to_string(temp.path().join(".adr-dir")).unwrap();
+    assert_eq!(
+        config_after, "existing/adrs\n",
+        "existing .adr-dir must not be repointed"
+    );
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_init_respects_adr_directory_env_var() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .env("ADR_DIRECTORY", "env/configured/adr")
+        .arg("init")
+        .assert()
+        .success();
+
+    temp.child("env/configured/adr")
+        .assert(predicate::path::is_dir());
+    temp.child("doc/adr")
+        .assert(predicate::path::exists().not());
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_init_explicit_directory_overrides_config() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    temp.child("adrs.toml")
+        .write_str("adr_dir = \"docs/adr\"\n")
+        .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["init", "explicit/path"])
+        .assert()
+        .success();
+
+    temp.child("explicit/path")
+        .assert(predicate::path::is_dir());
+    temp.child("docs/adr")
+        .assert(predicate::path::exists().not());
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_init_ng_preserves_existing_config_settings() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let original_config = "adr_dir = \"doc/adr\"\nmode = \"ng\"\ndefault_status = \"accepted\"\n\n[templates]\nformat = \"madr\"\n";
+    temp.child("adrs.toml").write_str(original_config).unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "init"])
+        .assert()
+        .success();
+
+    let config_after = fs::read_to_string(temp.path().join("adrs.toml")).unwrap();
+    assert_eq!(
+        config_after, original_config,
+        "existing adrs.toml settings must survive init"
+    );
+    assert!(config_after.contains("default_status = \"accepted\""));
+    assert!(config_after.contains("format = \"madr\""));
+
+    temp.close().unwrap();
+}
+
 // ============================================================================
 // List Command
 // ============================================================================


### PR DESCRIPTION
## Problem

`adrs init` ignores every configured `adr_dir` (project `adrs.toml`, legacy `.adr-dir`, the `ADR_DIRECTORY` environment variable, and the global config) and always creates `doc/adr`. It then writes its own config over the top, so an existing `.adr-dir` is silently repointed and `adrs --ng init` discards `default_status`, `templates`, `generate`, `export`, and `doctor` settings from an existing `adrs.toml`. Because every other command resolves the directory through `Config::discover()`, a successful `init` in a configured repository leaves every subsequent command failing with "ADR directory not found. Run 'adrs init' to create one."

Reported in #358, verified against main at v0.10.1.

## Root cause

The `Init` clap arg declares `default_value = "doc/adr"`, so `commands::init` always receives an explicit-looking path and passes it straight to `Repository::init`. Config discovery never runs, and `Init` is the only command arm that skips it.

## Plan

1. Change `Commands::Init { directory }` to `Option<PathBuf>` with no clap default, keeping the help text's `[default: doc/adr]` note.
2. In `commands::init`, when no directory is given on the command line, resolve through `adrs_core::config::discover(start_dir)` with the same precedence as every other command (adrs.toml, then .adr-dir, then ADR_DIRECTORY, then global config), falling back to `doc/adr` only when nothing is configured.
3. Stop clobbering existing config: when an `adrs.toml` or `.adr-dir` already exists and agrees with the resolved directory, leave it untouched instead of rewriting it.
4. Add regression tests covering: init with an existing `adrs.toml` (directory honored, config preserved), init with `.adr-dir`, init with `ADR_DIRECTORY`, an explicit CLI directory still overriding config, and the reproduction from the issue (`init` followed by `list` succeeds).

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-features`.

Closes #358.