### PR TITLE
fix: doctor checks frontmatter links[].target for broken links (closes #355)

### DIFF
--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -326,14 +326,21 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
     // would change compatible-mode severity/exit-code behavior, which is out
     // of scope for this fix.
     //
-    // Track the markdown fragment the upstream ADR013 rule would emit for
-    // each broken link so its warning can be suppressed once our error
-    // covers the same broken link. Nygard-family templates render an
-    // unresolved link both in frontmatter and as a body markdown link using
-    // the same fallback filename (see template.rs's `resolve_link_titles`,
-    // which falls back to `{:04}-....md` for a target it can't resolve), so
-    // without this a single broken link would otherwise produce two ADR013
-    // issues for the same record.
+    // Track the prefix of the message the upstream ADR013 rule would emit for
+    // each broken link so its warning can be suppressed once our error covers
+    // the same broken link. Nygard-family templates render a link both in
+    // frontmatter and as a body markdown link, so without this a single
+    // broken link would otherwise produce two ADR013 issues for the same
+    // record.
+    //
+    // The prefix stops at the target's zero-padded number rather than
+    // spelling out a whole filename, because the body filename varies: an
+    // unresolvable target renders as the `{:04}-....md` fallback (see
+    // template.rs's `resolve_link_titles`), but a link rendered while its
+    // target still existed keeps that target's real filename, which is the
+    // case #355 was found through. Anchoring on the record's path and the
+    // padded number matches both without matching a different record or a
+    // different target.
     let mut broken_link_fragments: Vec<String> = Vec::new();
 
     if repo.config().is_next_gen() {
@@ -348,7 +355,7 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
 
                 let path = adr.path.clone().unwrap_or_default();
                 broken_link_fragments.push(format!(
-                    "{}: Link to '{:04}-....md' references non-existent ADR file",
+                    "{}: Link to '{:04}",
                     path.display(),
                     link.target
                 ));
@@ -995,6 +1002,40 @@ Some consequences.
             adr013_issues.len(),
             1,
             "a broken link present in both frontmatter and body should report once, got: {:?}",
+            adr013_issues
+                .iter()
+                .map(|i| (&i.severity, &i.message))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(adr013_issues[0].severity, IssueSeverity::Error);
+    }
+
+    #[test]
+    fn test_check_repository_dedups_frontmatter_and_body_link_with_real_filename() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // A link that was rendered while its target still existed carries the
+        // target's real filename, not the `{:04}-....md` unresolved fallback.
+        // This is the case #355 was found through: renumbering left a stale
+        // target behind. It is still one broken link and must report once.
+        let content = "---\nnumber: 2\ntitle: Second\ndate: 2024-01-01\nstatus: proposed\nlinks:\n  - target: 99\n    kind: relatesto\n---\n\n# 2. Second\n\nDate: 2024-01-01\n\n## Status\n\nProposed\n\nRelates to [99. Old Title](0099-old-title.md)\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\nSome consequences.\n";
+        std::fs::write(adr_dir.join("0002-second.md"), content).unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        let adr013_issues: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR013")
+            .collect();
+        assert_eq!(
+            adr013_issues.len(),
+            1,
+            "a broken link whose body filename resolved should report once, got: {:?}",
             adr013_issues
                 .iter()
                 .map(|i| (&i.severity, &i.message))

--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -311,6 +311,66 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
         }
     }
 
+    // Resolve frontmatter `links[].target` against the ADR numbers actually
+    // present in the repository. This is distinct from the upstream ADR013
+    // rule below, which only checks markdown link *filenames* in the
+    // rendered body and has no notion of frontmatter (#355). A frontmatter
+    // link is a structured reference to an ADR number, so an unresolvable
+    // target is unambiguously broken and reported at `Error` rather than the
+    // upstream rule's `Warning`.
+    //
+    // Gated to nextgen mode: in compatible mode, `adr.links` is populated by
+    // parsing legacy body syntax like `Supersedes [1. Title](0001-title.md)`
+    // (see parse.rs), not frontmatter, and that path is already covered by
+    // the upstream markdown-filename check below. Checking it again here
+    // would change compatible-mode severity/exit-code behavior, which is out
+    // of scope for this fix.
+    //
+    // Track the markdown fragment the upstream ADR013 rule would emit for
+    // each broken link so its warning can be suppressed once our error
+    // covers the same broken link. Nygard-family templates render an
+    // unresolved link both in frontmatter and as a body markdown link using
+    // the same fallback filename (see template.rs's `resolve_link_titles`,
+    // which falls back to `{:04}-....md` for a target it can't resolve), so
+    // without this a single broken link would otherwise produce two ADR013
+    // issues for the same record.
+    let mut broken_link_fragments: Vec<String> = Vec::new();
+
+    if repo.config().is_next_gen() {
+        let existing_numbers: std::collections::HashSet<u32> =
+            adrs.iter().map(|a| a.number).collect();
+
+        for adr in &adrs {
+            for link in &adr.links {
+                if existing_numbers.contains(&link.target) {
+                    continue;
+                }
+
+                let path = adr.path.clone().unwrap_or_default();
+                broken_link_fragments.push(format!(
+                    "{}: Link to '{:04}-....md' references non-existent ADR file",
+                    path.display(),
+                    link.target
+                ));
+
+                report.add(Issue {
+                    rule_id: "ADR013".to_string(),
+                    rule_name: "adr-valid-adr-links".to_string(),
+                    severity: IssueSeverity::Error,
+                    message: format!(
+                        "ADR {} '{}' links to non-existent ADR {}",
+                        adr.number, adr.title, link.target
+                    ),
+                    path: adr.path.clone(),
+                    line: None,
+                    column: None,
+                    adr_number: Some(adr.number),
+                    related_adrs: Vec::new(),
+                });
+            }
+        }
+    }
+
     // Run collection rules
     let collection_rules: Vec<Box<dyn CollectionRule>> = vec![
         Box::new(Adr010),
@@ -323,6 +383,17 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
         match rule.check_collection(&documents) {
             Ok(violations) => {
                 for violation in violations {
+                    // Suppress the upstream markdown-filename ADR013 warning
+                    // when the frontmatter check above already reported the
+                    // same broken link as an error (see comment above).
+                    if violation.rule_id == "ADR013"
+                        && broken_link_fragments
+                            .iter()
+                            .any(|fragment| violation.message.contains(fragment.as_str()))
+                    {
+                        continue;
+                    }
+
                     // Collection rule violations may have path in the message
                     // We need to parse it out or handle it differently
                     report.add(Issue {
@@ -806,6 +877,130 @@ Some consequences.
             "Expected ADR013 broken-link issue, got: {:?}",
             report.issues.iter().map(|i| &i.rule_id).collect::<Vec<_>>()
         );
+    }
+
+    fn make_frontmatter_adr(number: u32, title: &str, status: &str, links_yaml: &str) -> String {
+        format!(
+            "---\nnumber: {}\ntitle: {}\ndate: 2024-01-01\nstatus: {}\n{}---\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\nSome consequences.\n",
+            number, title, status, links_yaml
+        )
+    }
+
+    #[test]
+    fn test_check_repository_frontmatter_broken_link_adr013_error() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        // nextgen mode: links live in YAML frontmatter (issue #355 repro)
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // ADR 2 has a frontmatter link to nonexistent ADR 99
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_frontmatter_adr(
+                2,
+                "Second",
+                "proposed",
+                "links:\n  - target: 99\n    kind: relatesto\n",
+            ),
+        )
+        .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        let broken = report
+            .issues
+            .iter()
+            .find(|i| i.rule_id == "ADR013" && i.severity == IssueSeverity::Error);
+        assert!(
+            broken.is_some(),
+            "Expected ADR013 error for frontmatter link to non-existent ADR 99, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, i.severity, &i.message))
+                .collect::<Vec<_>>()
+        );
+        let issue = broken.unwrap();
+        assert_eq!(issue.adr_number, Some(2));
+        assert!(
+            issue.path.is_some(),
+            "expected a file location on the issue"
+        );
+        assert!(
+            issue.message.contains("links to non-existent ADR 99"),
+            "unexpected message: {}",
+            issue.message
+        );
+        assert!(
+            report.has_errors(),
+            "a broken frontmatter link must make the report (and doctor's exit code) nonzero"
+        );
+    }
+
+    #[test]
+    fn test_check_repository_frontmatter_link_to_existing_adr_no_issue() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // init() creates ADR #1; link ADR 2 to it.
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_frontmatter_adr(
+                2,
+                "Second",
+                "proposed",
+                "links:\n  - target: 1\n    kind: relatesto\n",
+            ),
+        )
+        .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        assert!(
+            !report.issues.iter().any(|i| i.rule_id == "ADR013"),
+            "link to an existing ADR should not produce ADR013, got: {:?}",
+            report.issues.iter().map(|i| &i.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_check_repository_dedups_frontmatter_and_body_broken_link() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // A Nygard-format nextgen render puts a broken link's target in both
+        // the frontmatter `links:` block and a body markdown link, with the
+        // same unresolved fallback filename (see template.rs's
+        // `resolve_link_titles`, which falls back to `{:04}-....md` for a
+        // target it can't find). One broken link should report once.
+        let content = "---\nnumber: 2\ntitle: Second\ndate: 2024-01-01\nstatus: proposed\nlinks:\n  - target: 99\n    kind: relatesto\n---\n\n# 2. Second\n\nDate: 2024-01-01\n\n## Status\n\nProposed\n\nRelates to [99. ...](0099-....md)\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\nSome consequences.\n";
+        std::fs::write(adr_dir.join("0002-second.md"), content).unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        let adr013_issues: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR013")
+            .collect();
+        assert_eq!(
+            adr013_issues.len(),
+            1,
+            "a broken link present in both frontmatter and body should report once, got: {:?}",
+            adr013_issues
+                .iter()
+                .map(|i| (&i.severity, &i.message))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(adr013_issues[0].severity, IssueSeverity::Error);
     }
 
     #[test]

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1553,6 +1553,36 @@ fn test_doctor_without_ng_flag_prints_no_note() {
     temp.close().unwrap();
 }
 
+#[test]
+fn test_doctor_nextgen_broken_frontmatter_link_exits_nonzero() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "init"])
+        .assert()
+        .success();
+
+    // init() creates ADR #1; add ADR #2 with a frontmatter link to a
+    // nonexistent ADR 99 (issue #355's reproduction).
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        "---\nnumber: 2\ntitle: Second\ndate: 2024-01-01\nstatus: proposed\nlinks:\n  - target: 99\n    kind: relatesto\n---\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\nSome consequences.\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("ADR013"))
+        .stdout(predicate::str::contains("links to non-existent ADR 99"));
+
+    temp.close().unwrap();
+}
+
 // Tests for [doctor].ignore / --ignore and warnings-as-errors config (issue #316)
 
 /// Nygard-format ADR content that trips only warning-severity collection rules


### PR DESCRIPTION
Closes #355.

## Context

In nextgen mode, links live in YAML frontmatter as `links[].target` (an ADR
number). `adrs doctor` never checks them: a record linking to a nonexistent
ADR 99 is reported as `No issues found. Your ADR repository is healthy!`

The cause is that two broken-link implementations exist and the one the tools
reach is the wrong one:

- `adrs-core::doctor::check_broken_links` (`crates/adrs-core/src/doctor.rs:244`)
  resolves `adr.links[].target` against the set of existing ADR numbers and
  emits `Severity::Error`. This is the frontmatter-aware version. It is
  exported as `doctor_check` but **no caller reaches it**: the CLI
  (`crates/adrs/src/commands/doctor.rs:30`) uses `check_all_filtered`, and the
  MCP `run_doctor` tool (`crates/adrs/src/mcp.rs:1918`) uses `check_all`. Both
  are lint-path entry points.
- `ADR013`, reached through `lint::check_repository`'s collection set
  (`crates/adrs-core/src/lint.rs:315-320`), comes from the upstream
  `mdbook-lint-rulesets` crate (0.14.4, crates.io). It checks markdown link
  targets by **filename** and emits a warning. It has no notion of frontmatter.

So the frontmatter path is unverified, and even when the markdown path does
fire, `doctor` exits 0.

## Decision

Add a frontmatter-aware broken-link check to the lint path, which is what the
CLI and MCP actually run. Do not modify the upstream `mdbook-lint-rulesets`
rule; do not delete the `doctor.rs` implementation in this PR (see Out of
scope).

Two judgment calls, made here and open to revision in review:

**Rule id: reuse `ADR013`.** The issue reports the expected diagnostic as an
`ADR013`, and reusing the id means an existing `--ignore ADR013` or
`doctor.ignore` entry continues to suppress the whole broken-link class rather
than half of it.

**Severity: `Error` for the frontmatter check, leave the upstream markdown
check at `Warning`.** These are not the same claim. A frontmatter
`links[].target` is a structured reference to an ADR number; if no ADR has that
number it is unambiguously broken. The markdown-filename check is a heuristic
over link text and can fire on legitimate links to non-ADR documents, so
raising it to error would be a breaking change for existing compatible-mode
repositories. The result is that one rule id emits both severities depending on
which link form is broken. That is deliberate, and it gives #355 what it asks
for: a broken frontmatter link makes `doctor` exit nonzero, so it works as a
pre-commit and merge gate.

## Task

In `crates/adrs-core/src/lint.rs`:

1. Add a repository-level frontmatter link check to `check_repository`,
   alongside the existing collection rules. It resolves each `adr.links[].target`
   against the set of numbers present in `repo.list()` and emits an `Issue` with
   `rule_id: "ADR013"`, a rule name matching the upstream rule's, and
   `IssueSeverity::Error`.
2. Populate `path` and `adr_number` on the issue. The upstream collection rules
   leave both `None` (see the comment at `lint.rs:326-333`); the new check knows
   the owning ADR, so it should report them. This is what makes the CLI print a
   file location rather than a bare message.
3. Message shape: `ADR {n} '{title}' links to non-existent ADR {target}`,
   matching the existing `doctor.rs` wording and the issue's stated expectation.
4. **Deduplicate against the upstream rule.** In nextgen mode a link may be
   rendered both in frontmatter and as a markdown link in the body. Check
   whether `template.rs` emits a body Links section for nextgen records; if a
   single broken link can produce both an upstream `ADR013` warning and the new
   error, suppress the duplicate (keep the error). Verify with a test, do not
   assume.

## Tests

Add to the `lint.rs` test module, next to the existing Nygard fixture at
`lint.rs:780`:

- A nextgen/frontmatter ADR with `links: [{target: 99, kind: relatesto}]` and no
  ADR 99 present produces an `ADR013` issue at `Error` severity. This is the
  issue's exact reproduction and currently fails.
- A frontmatter link to an ADR that **does** exist produces no `ADR013`.
- The existing Nygard markdown fixture still produces its warning, unchanged.
- The error propagates to a nonzero exit: assert the report has errors, so
  `adrs doctor` fails the gate.
- If dedup applies, a record with both a frontmatter and a body link to the same
  missing target reports once.

Add a CLI integration test asserting `adrs doctor` exits nonzero on a nextgen
repository with a broken frontmatter link, if the existing CLI test layout has a
natural home for it.

## Constraints

- Do not change `mdbook-lint-rulesets` or bump its version.
- Do not change the severity of the existing upstream markdown-filename check.
- No behavior change for compatible-mode repositories.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and
  `cargo test --all-features` all pass.

## Out of scope

- Removing or rewiring the unreachable `doctor::check` implementation. It is
  public API (`adrs_core::doctor_check`), so consolidating it is a breaking
  change; it belongs with #341 in the next major batch. This PR notes the
  duplication and leaves it.
- The asymmetric-link-pair check (#357) and `adrs renumber` (#356), both of
  which build on the link resolution this PR establishes.

## Acceptance

The issue's reproduction, run against a nextgen repository, prints an `ADR013`
error naming ADR 99 and exits nonzero.


## What landed, and where it differs from the plan

**Gated to nextgen mode.** The plan did not say this and it turned out to be
necessary. In compatible mode `adr.links` is populated by parsing legacy body
syntax (`Supersedes [1. Title](0001-title.md)`, see `parse.rs`), not
frontmatter, and that path is already covered by the upstream markdown-filename
rule at `Warning`. Ungated, every compatible-mode repository with a broken link
would have gained an `Error` and a changed exit code, which the constraints
ruled out.

**Dedup was needed, and for a wider set of cases than expected.** The plan said
to verify rather than assume. The finding: the MADR template renders links only
in frontmatter, so nextgen plus MADR never duplicates. But the Nygard-family
templates render a body markdown link loop unconditionally, and
`TemplateFormat::default()` is Nygard, so a nextgen repository without an
explicit `format = "madr"` does render the same link in both places. Confirmed
by disabling the filter and watching the test report two issues instead of one.

The dedup keys on the record's path plus the target's zero-padded number, not
on a whole filename. The first implementation matched only the
`{:04}-....md` fallback that `template.rs` renders for an unresolvable target,
which missed the case this issue was actually found through: a link rendered
while its target still existed keeps that target's real filename
(`0099-old-title.md`), so the upstream warning did not match and the same
broken link reported twice. Covered by
`test_check_repository_dedups_frontmatter_and_body_link_with_real_filename`,
which fails against the first implementation.

The dedup is still a string match against an upstream crate's message wording,
because the collection-rule API surfaces no structured target. If
`mdbook-lint-rulesets` changes that message, the dedup silently stops matching
and duplicates reappear rather than anything breaking loudly. The tests would
catch it on a dependency bump.

**Tests:** 786 pass, 0 fail (`cargo test --all-features`). CI green on Clippy,
Format, MSRV (adrs @ 1.90, adrs-core @ 1.88), and tests on macOS, Ubuntu, and
Windows.
