### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adrs"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "adrs-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "adrs-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "deunicode",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 authors = ["josh rotenberg <joshrotenberg@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -47,7 +47,7 @@ schemars = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Internal
-adrs-core = { path = "crates/adrs-core", version = "0.10.1" }
+adrs-core = { path = "crates/adrs-core", version = "0.11.0" }
 
 # Testing
 serial_test = "3.5"

--- a/crates/adrs-core/CHANGELOG.md
+++ b/crates/adrs-core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2026-08-05
+
+### Bug Fixes
+
+- Init respects configured adr_dir and preserves existing config (closes #358)
+- Check frontmatter links[].target in doctor's lint path (closes #355)
+- Dedup ADR013 when a body link keeps its target's real filename
+- Correct renumber's handling of references when the number is duplicated
+- Warn on unrecognized keys in adrs.toml (closes #363)
+- Transliterate non-ASCII titles before slugging (closes #367)
+
+### Features
+
+- Add doctor rule for asymmetric ADR links (closes #357)
+- Add adrs renumber command to repair duplicate ADR numbers (closes #356)
+- Add path-scoped doctor ignore rules (closes #365)
+
+
 ## [0.10.1] - 2026-07-22
 
 ### Bug Fixes

--- a/crates/adrs/CHANGELOG.md
+++ b/crates/adrs/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2026-08-05
+
+### Bug Fixes
+
+- Init respects configured adr_dir and preserves existing config (closes #358)
+- Check frontmatter links[].target in doctor's lint path (closes #355)
+- Correct renumber's handling of references when the number is duplicated
+- Warn on unrecognized keys in adrs.toml (closes #363)
+- Transliterate non-ASCII titles before slugging (closes #367)
+
+### Features
+
+- Add doctor rule for asymmetric ADR links (closes #357)
+- Add adrs renumber command to repair duplicate ADR numbers (closes #356)
+- Add path-scoped doctor ignore rules (closes #365)
+
+
 ## [0.10.1] - 2026-07-22
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `adrs-core`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)
* `adrs`: 0.10.1 -> 0.11.0

### ⚠ `adrs-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DiscoveredConfig.unknown_keys in /tmp/.tmpajW000/adrs/crates/adrs-core/src/config.rs:231

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:AmbiguousRenumberSource in /tmp/.tmpajW000/adrs/crates/adrs-core/src/error.rs:68
  variant Error:RenumberFileMismatch in /tmp/.tmpajW000/adrs/crates/adrs-core/src/error.rs:77
  variant Error:RenumberTargetOccupied in /tmp/.tmpajW000/adrs/crates/adrs-core/src/error.rs:90
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `adrs-core`

<blockquote>

## [0.11.0] - 2026-08-05

### Bug Fixes

- Init respects configured adr_dir and preserves existing config (closes #358)
- Check frontmatter links[].target in doctor's lint path (closes #355)
- Dedup ADR013 when a body link keeps its target's real filename
- Correct renumber's handling of references when the number is duplicated
- Warn on unrecognized keys in adrs.toml (closes #363)
- Transliterate non-ASCII titles before slugging (closes #367)

### Features

- Add doctor rule for asymmetric ADR links (closes #357)
- Add adrs renumber command to repair duplicate ADR numbers (closes #356)
- Add path-scoped doctor ignore rules (closes #365)
</blockquote>

## `adrs`

<blockquote>

## [0.11.0] - 2026-08-05

### Bug Fixes

- Init respects configured adr_dir and preserves existing config (closes #358)
- Check frontmatter links[].target in doctor's lint path (closes #355)
- Correct renumber's handling of references when the number is duplicated
- Warn on unrecognized keys in adrs.toml (closes #363)
- Transliterate non-ASCII titles before slugging (closes #367)

### Features

- Add doctor rule for asymmetric ADR links (closes #357)
- Add adrs renumber command to repair duplicate ADR numbers (closes #356)
- Add path-scoped doctor ignore rules (closes #365)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).