### PR TITLE
feat: doctor rule for asymmetric link pairs (closes #357)

### DIFF
--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -296,6 +296,7 @@ pub fn lint_all(repo: &Repository) -> Result<LintReport> {
 /// - Duplicate numbers (ADR012)
 /// - Broken links (ADR013)
 /// - Superseded ADRs have replacements (ADR010)
+/// - Asymmetric links (`asymmetric-link`)
 pub fn check_repository(repo: &Repository) -> Result<LintReport> {
     let mut report = LintReport::new();
     let adrs = repo.list()?;
@@ -367,6 +368,60 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
                     message: format!(
                         "ADR {} '{}' links to non-existent ADR {}",
                         adr.number, adr.title, link.target
+                    ),
+                    path: adr.path.clone(),
+                    line: None,
+                    column: None,
+                    adr_number: Some(adr.number),
+                    related_adrs: Vec::new(),
+                });
+            }
+        }
+    }
+
+    // Check that every link is reciprocated (#357). `adrs link` maintains
+    // both halves of a relationship by construction, so an asymmetric pair
+    // is evidence that something outside the tool edited the record -- a
+    // hand edit, a renumber, a badly resolved merge. For each link A -> B,
+    // require that B carries some link back to A.
+    //
+    // The back-link is matched by target only, not by `LinkKind::reverse()`'s
+    // exact kind. `adrs link` accepts an explicit `reverse_kind` override
+    // (see commands/link.rs), so requiring the derived kind exactly would
+    // flag the tool's own supported output as corruption; asking only "does
+    // B link back to A" agrees with the tool by construction.
+    //
+    // Links whose target does not exist are skipped: that is a broken link,
+    // already reported as ADR013 above (frontmatter) or below (markdown
+    // body). Reporting it again as asymmetry would give two diagnostics for
+    // one problem.
+    //
+    // Unlike the frontmatter check above, this is not gated to nextgen mode:
+    // `adr.links` is populated in compatible mode by parsing legacy body
+    // syntax (see parse.rs) and in nextgen mode from frontmatter, and there
+    // is no upstream rule here to conflict with.
+    let adrs_by_number: std::collections::HashMap<u32, &Adr> =
+        adrs.iter().map(|a| (a.number, a)).collect();
+
+    for adr in &adrs {
+        for link in &adr.links {
+            let Some(target_adr) = adrs_by_number.get(&link.target) else {
+                continue;
+            };
+
+            let has_back_link = target_adr
+                .links
+                .iter()
+                .any(|back| back.target == adr.number);
+
+            if !has_back_link {
+                report.add(Issue {
+                    rule_id: "asymmetric-link".to_string(),
+                    rule_name: "adr-asymmetric-link".to_string(),
+                    severity: IssueSeverity::Warning,
+                    message: format!(
+                        "ADR {} '{}' links to ADR {} as '{}' but ADR {} has no link back to ADR {}",
+                        adr.number, adr.title, link.target, link.kind, link.target, adr.number
                     ),
                     path: adr.path.clone(),
                     line: None,
@@ -1042,6 +1097,312 @@ Some consequences.
                 .collect::<Vec<_>>()
         );
         assert_eq!(adr013_issues[0].severity, IssueSeverity::Error);
+    }
+
+    // ========== check_repository asymmetric-link rule (issue #357) ==========
+
+    #[test]
+    fn test_check_repository_asymmetric_link_half_deleted_one_warning() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        // Compatible mode, matching the issue's own reproduction. `init`
+        // creates ADR #1 with no links -- the "half-deleted" state: its
+        // `Superseded by` line was removed by hand, leaving ADR #2's
+        // `Supersedes` link with nothing pointing back (issue #357 case 1).
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr(
+                2,
+                "Second",
+                "Accepted",
+                "\n\nSupersedes [1. Record architecture decisions](0001-record-architecture-decisions.md)\n",
+            ),
+        )
+        .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        let warnings: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "asymmetric-link")
+            .collect();
+        assert_eq!(
+            warnings.len(),
+            1,
+            "expected exactly one asymmetric-link warning, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, &i.message))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(warnings[0].rule_name, "adr-asymmetric-link");
+        assert_eq!(warnings[0].severity, IssueSeverity::Warning);
+        assert_eq!(warnings[0].adr_number, Some(2));
+        assert!(
+            warnings[0].message.contains("ADR 2")
+                && warnings[0].message.contains("ADR 1")
+                && warnings[0].message.contains("no link back to ADR 2"),
+            "unexpected message: {}",
+            warnings[0].message
+        );
+    }
+
+    #[test]
+    fn test_check_repository_asymmetric_link_mis_targeted_two_warnings() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        // Nextgen mode (frontmatter links) -- covers the both-modes requirement.
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // ADR 1's reverse link is repointed at ADR 3, which exists but has no
+        // relationship to either. ADR 2 still claims to supersede ADR 1
+        // (issue #357 case 2). Both halves are independently broken, so this
+        // must produce two warnings, not one.
+        std::fs::write(
+            adr_dir.join("0001-record-architecture-decisions.md"),
+            make_frontmatter_adr(
+                1,
+                "Record architecture decisions",
+                "superseded",
+                "links:\n  - target: 3\n    kind: supersededby\n",
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_frontmatter_adr(
+                2,
+                "Second",
+                "proposed",
+                "links:\n  - target: 1\n    kind: supersedes\n",
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            adr_dir.join("0003-third.md"),
+            make_frontmatter_adr(3, "Third", "proposed", ""),
+        )
+        .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        let warnings: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "asymmetric-link")
+            .collect();
+        assert_eq!(
+            warnings.len(),
+            2,
+            "expected two asymmetric-link warnings, one per independently broken half, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, &i.message))
+                .collect::<Vec<_>>()
+        );
+
+        let adr_numbers: Vec<_> = warnings.iter().filter_map(|i| i.adr_number).collect();
+        assert!(
+            adr_numbers.contains(&1) && adr_numbers.contains(&2),
+            "expected warnings naming both ADR 1 and ADR 2, got: {adr_numbers:?}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .all(|i| i.severity == IssueSeverity::Warning)
+        );
+    }
+
+    #[test]
+    fn test_check_repository_symmetric_link_via_repository_link_no_warning() {
+        use crate::{LinkKind, Repository};
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // ADR 2, so `repo.link` has two existing ADRs to connect.
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_frontmatter_adr(2, "Second", "proposed", ""),
+        )
+        .unwrap();
+
+        // Built through the tool's own API, not by hand, so this test breaks
+        // if the rule and `adrs link` ever disagree about what counts as
+        // symmetric.
+        repo.link(2, 1, LinkKind::Supersedes, LinkKind::SupersededBy)
+            .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        assert!(
+            !report.issues.iter().any(|i| i.rule_id == "asymmetric-link"),
+            "a pair built through Repository::link must not be flagged, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, &i.message))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_check_repository_non_derived_reverse_kind_no_warning() {
+        use crate::{LinkKind, Repository};
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, true).unwrap();
+        let adr_dir = repo.adr_path();
+
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_frontmatter_adr(2, "Second", "proposed", ""),
+        )
+        .unwrap();
+
+        // `adrs link` accepts an explicit `reverse_kind` override
+        // (commands/link.rs), so a pair whose reverse kind is not
+        // `LinkKind::Supersedes.reverse()` (`SupersededBy`) is still valid
+        // tool output, not corruption. Here ADR 1's link back to ADR 2 is
+        // `RelatesTo` rather than the derived `SupersededBy`.
+        repo.link(2, 1, LinkKind::Supersedes, LinkKind::RelatesTo)
+            .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        assert!(
+            !report.issues.iter().any(|i| i.rule_id == "asymmetric-link"),
+            "a non-derived but present reverse link must not be flagged, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, &i.message))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_check_repository_broken_link_no_asymmetric_link_warning() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        // init creates ADR #1 automatically.
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // ADR 2 links to nonexistent ADR 99: a broken link, not an
+        // asymmetric one. It must be reported once, as ADR013, and not
+        // again as asymmetric-link.
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr(
+                2,
+                "Second",
+                "Accepted",
+                "\n\nSupersedes [99. Unknown](0099-unknown.md)\n",
+            ),
+        )
+        .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        assert!(
+            report.issues.iter().any(|i| i.rule_id == "ADR013"),
+            "expected the broken-link diagnostic to still fire"
+        );
+        assert!(
+            !report.issues.iter().any(|i| i.rule_id == "asymmetric-link"),
+            "a link to a nonexistent ADR must not also be flagged as asymmetric, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, &i.message))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_check_repository_symmetric_relates_to_no_warning() {
+        use crate::{LinkKind, Repository};
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr(2, "Second", "Accepted", ""),
+        )
+        .unwrap();
+
+        // `LinkKind::RelatesTo.reverse()` is `RelatesTo` itself, so a
+        // symmetric `RelatesTo` pair is the default `repo.link` output.
+        repo.link(2, 1, LinkKind::RelatesTo, LinkKind::RelatesTo)
+            .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        assert!(
+            !report.issues.iter().any(|i| i.rule_id == "asymmetric-link"),
+            "a symmetric RelatesTo pair must not be flagged, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, &i.message))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_check_repository_one_way_relates_to_one_warning() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        // init creates ADR #1 with no links.
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // ADR 2 relates to ADR 1, but ADR 1 has no reciprocal link -- a
+        // one-way RelatesTo is a plausible hand-written relationship, and
+        // should be a single warning, not silence.
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr(
+                2,
+                "Second",
+                "Accepted",
+                "\n\nRelates to [1. Record architecture decisions](0001-record-architecture-decisions.md)\n",
+            ),
+        )
+        .unwrap();
+
+        let report = check_repository(&repo).unwrap();
+
+        let warnings: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "asymmetric-link")
+            .collect();
+        assert_eq!(
+            warnings.len(),
+            1,
+            "expected exactly one asymmetric-link warning for a one-way RelatesTo, got: {:?}",
+            report
+                .issues
+                .iter()
+                .map(|i| (&i.rule_id, &i.message))
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1726,6 +1726,61 @@ fn test_doctor_nextgen_broken_frontmatter_link_exits_nonzero() {
     temp.close().unwrap();
 }
 
+#[test]
+fn test_doctor_asymmetric_link_reports_warning_exits_zero() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // init() creates ADR #1 with no links; ADR #2 claims to supersede it by
+    // hand, with nothing pointing back (issue #357 case 1).
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        "# 2. Second\n\nDate: 2024-01-01\n\n## Status\n\nAccepted\n\nSupersedes [1. Record architecture decisions](0001-record-architecture-decisions.md)\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\nSome consequences.\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("asymmetric-link"))
+        .stdout(predicate::str::contains("no link back"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_doctor_asymmetric_link_warnings_as_errors_exits_1() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        "# 2. Second\n\nDate: 2024-01-01\n\n## Status\n\nAccepted\n\nSupersedes [1. Record architecture decisions](0001-record-architecture-decisions.md)\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\nSome consequences.\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["doctor", "--warnings-as-errors"])
+        .assert()
+        .failure()
+        .code(1);
+
+    temp.close().unwrap();
+}
+
 // Tests for [doctor].ignore / --ignore and warnings-as-errors config (issue #316)
 
 /// Nygard-format ADR content that trips only warning-severity collection rules


### PR DESCRIPTION
Closes #357.

## Context

`adrs link` maintains both halves of a relationship, so a link pair is symmetric
by construction. An asymmetric pair is therefore evidence that something outside
the tool edited the record: a hand edit, a renumber, a badly resolved merge.
`doctor` reports neither shape.

Two cases from the issue, both reported healthy today:

1. **Half-deleted.** ADR 1's `Superseded by` line is removed; ADR 2 still claims
   to supersede it.
2. **Mis-targeted.** ADR 1's reverse link is repointed at ADR 3, which exists but
   has no relationship to it. ADR 2 still claims to supersede ADR 1.

Case 2 is the one that bit the reporter, and `ADR013` passes it correctly: the
target file exists, so there is no broken link. Nothing looks at whether a
relationship is mutual. `doctor::check_superseded_links` is the closest relative
and still misses both, because it only asserts that a record whose *status* is
`Superseded` has *some* `SupersededBy` link, never looking at the target.

## Decision

Add a repository-level check to `check_repository` in
`crates/adrs-core/src/lint.rs`, next to the frontmatter link check added for
#355. For each link A to B, require that B carries a link back to A.

Four judgment calls, all open to revision in review:

**Reuse `LinkKind::reverse()` as the inverse authority**
(`crates/adrs-core/src/types.rs:324`). It already maps
`Supersedes`/`SupersededBy` and `Amends`/`AmendedBy`, treats `RelatesTo` as
self-inverse, and maps `Custom(s)` to itself. `adrs link` derives the reverse
half from that same method (`crates/adrs/src/commands/link.rs:20`), so a rule
built on it agrees with what the tool writes by construction. Inventing a second
mapping is how the two drift apart.

**Require a back-link by target, not by exact kind.** The rule asks "does B link
back to A", not "does B link back to A with exactly `K.reverse()`". Both of the
issue's cases fire either way. The difference is that `adrs link` accepts an
explicit `reverse_kind` override (`link.rs:18-21`), so a user can deliberately
write a pair whose reverse kind is not the derived one. The strict form would
flag the tool's own supported output as corruption. The looser form does not.

**`Warning` severity**, as the issue proposes. A deliberately one-way link is
plausible, and `[doctor].ignore` plus `--warnings-as-errors` already provide both
escape hatches. This matters more than it looks: a hand-written one-way
`RelatesTo` is common in real repositories, and every one of them will now emit a
warning. That is the intended signal, but it is also the noise source, and it is
why this should not be an error.

**Rule id `asymmetric-link`, not `ADR018`.** The `ADR###` space belongs to the
upstream `mdbook-lint-rulesets` crate, which currently defines ADR001 through
ADR017. Minting `ADR018` locally collides the moment upstream adds its own. The
local `parse-error` rule (`lint.rs:207`) is the existing precedent for a
non-numbered id. `rule_name` is `adr-asymmetric-link`; `check_all_filtered`
matches `--ignore` and `[doctor].ignore` case-insensitively against both id and
name, so `--ignore asymmetric-link` works.

## Task

In `crates/adrs-core/src/lint.rs`, inside `check_repository`:

1. Build a map of ADR number to its links, from `repo.list()`.
2. For each ADR A and each link A to B: if B exists and no link on B targets A,
   emit an `Issue` with `rule_id: "asymmetric-link"`, `rule_name:
   "adr-asymmetric-link"`, `IssueSeverity::Warning`, `path` and `adr_number`
   populated for A.
3. **Skip links whose target does not exist.** That is a broken link, already
   reported as `ADR013` by the frontmatter check or the upstream markdown rule.
   Reporting it again as asymmetry gives two diagnostics for one problem.
4. Message shape, naming both sides and the expected inverse:
   `ADR {a} '{title}' links to ADR {b} as '{kind}' but ADR {b} has no link back
   to ADR {a}`.
5. Report per offending link, not per pair. The issue's case 2 is two
   independently broken halves and should produce two warnings; case 1 has only
   one link and should produce one.

Unlike the #355 check, this applies in **both modes**. `adr.links` is populated
in compatible mode by parsing legacy body syntax and in nextgen mode from
frontmatter, the issue's own reproduction is compatible mode, and there is no
upstream rule to conflict with, so no mode gate is needed. Confirm this holds
rather than assuming it.

## Tests

In the `lint.rs` test module, alongside the #355 tests:

- The issue's case 1 (half-deleted): ADR 2 supersedes ADR 1, ADR 1 has no link
  back. One `asymmetric-link` warning naming ADR 2 and ADR 1.
- The issue's case 2 (mis-targeted): ADR 1 superseded-by ADR 3, ADR 2 supersedes
  ADR 1, ADR 3 has nothing. Two warnings.
- A symmetric pair produced by `Repository::link` yields no warning. Build it
  through the API rather than by hand, so the test breaks if the rule and the
  tool ever disagree.
- A pair written with a non-derived reverse kind (the `reverse_kind` override)
  yields no warning.
- A link to a nonexistent ADR yields the broken-link diagnostic only, no
  asymmetry warning.
- Symmetric `RelatesTo` yields nothing; one-way `RelatesTo` yields one warning.
- Both modes: at least one case each in compatible and nextgen.

A CLI integration test in `crates/adrs/tests/cli.rs` asserting `adrs doctor`
reports the warning and still exits 0 (warning severity), and exits 1 under
`--warnings-as-errors`.

## Constraints

- Do not change `LinkKind::reverse()` or any existing rule's severity.
- Do not change `mdbook-lint-rulesets` or bump its version.
- Do not regress the #355 frontmatter check or its dedup.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and
  `cargo test --all-features` all pass.

## Out of scope

- `adrs renumber` (#356), which is next and is the operation this rule would
  prove correct.
- Consolidating the unreachable `doctor::check` implementation, deferred to the
  next major batch with #341.

## Acceptance

Both reproductions from the issue produce `asymmetric-link` warnings naming the
records involved. A repository whose links were all written by `adrs link` stays
clean.


## What landed

The plan held up; no corrections were needed against the code. The both-modes
claim was verified rather than assumed: `adr.links` is populated by `parse.rs` in
compatible mode via the legacy link regex over the `## Status` section and in
nextgen mode from frontmatter, so the rule reads an already-normalized
representation and needs no mode gate. Case 2 is tested in nextgen, case 1 and
the `RelatesTo` cases in compatible.

**Manual verification against a built binary**, beyond the test suite:

| Scenario | Result |
|---|---|
| compatible: `init`, two `new`, one `link` | clean, exit 0 |
| nextgen: `init`, two `new`, one `link` | clean, exit 0 |
| case 1, half-deleted back link | 1 warning, exit 0 |
| case 2, reverse link repointed at ADR 3 | 2 warnings, exit 0 |
| case 2 under `--warnings-as-errors` | exit 1 |
| case 2 under `--ignore asymmetric-link` | suppressed, "2 issue(s) suppressed" |

Both ordinary workflows stay clean, which is the property that matters most for a
warning-severity rule that runs on every `doctor` invocation.

**One precision cost the design accepts.** Because the back-link is matched by
target and not by kind, a pair whose two halves claim unrelated relationships
(A `RelatesTo` B, B `Custom("blocks")` A) reads as symmetric and is not flagged.
That is the deliberate tradeoff for not flagging `adrs link --reverse-kind`
output, and it is worth knowing before this rule is relied on to prove a renumber
correct in #356.

**Tests:** 801 pass, 0 fail (`cargo test --all-features`). CI green on Clippy,
Format, MSRV (adrs @ 1.90, adrs-core @ 1.88), and tests on macOS, Ubuntu, and
Windows.
