### PR TITLE
fix: warn on unrecognized keys in adrs.toml (closes #363)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "pulldown-cmark 0.13.4",
  "regex",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_yaml_neo",
  "tempfile",
@@ -1892,6 +1893,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 serde_json = "1"
 serde_yaml_neo.workspace = true
 toml.workspace = true
+serde_ignored = "0.1.14"
 pulldown-cmark.workspace = true
 minijinja.workspace = true
 walkdir.workspace = true

--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -70,6 +70,25 @@ impl Default for Config {
     }
 }
 
+/// Deserialize a [`Config`] from TOML content, reporting any keys that do not
+/// match a known field instead of silently dropping them.
+///
+/// Returns the parsed config together with the sorted, deduplicated list of
+/// unrecognized keys as dotted paths (e.g. `"doctor.path"` for a stray `path`
+/// key under `[doctor]`). Malformed TOML still produces `Error::Toml`, exactly
+/// as `toml::from_str` does; only the handling of *unknown but otherwise
+/// well-formed* keys changes.
+fn deserialize_config(content: &str) -> Result<(Config, Vec<String>)> {
+    let mut unknown_keys = Vec::new();
+    let deserializer = toml::Deserializer::new(content);
+    let config: Config = serde_ignored::deserialize(deserializer, |path| {
+        unknown_keys.push(path.to_string());
+    })?;
+    unknown_keys.sort();
+    unknown_keys.dedup();
+    Ok((config, unknown_keys))
+}
+
 impl Config {
     /// Load configuration from the given directory.
     ///
@@ -82,7 +101,7 @@ impl Config {
         let config_path = root.join(CONFIG_FILE);
         if config_path.exists() {
             let content = std::fs::read_to_string(&config_path)?;
-            let config: Config = toml::from_str(&content)?;
+            let (config, _unknown_keys) = deserialize_config(&content)?;
             if config.adr_dir.as_os_str().is_empty() {
                 return Err(Error::ConfigError(
                     "adr_dir cannot be empty in adrs.toml".into(),
@@ -203,6 +222,10 @@ pub struct DiscoveredConfig {
     pub root: PathBuf,
     /// Where the config was loaded from.
     pub source: ConfigSource,
+    /// Dotted paths of any keys in the loaded config file that did not match
+    /// a known field (e.g. `"doctor.path"`). Empty when the config had no
+    /// unrecognized keys, or when no config file was read (`ConfigSource::Default`).
+    pub unknown_keys: Vec<String>,
 }
 
 /// Where the configuration was loaded from.
@@ -233,7 +256,7 @@ pub fn discover(start_dir: &Path) -> Result<DiscoveredConfig> {
         let path = PathBuf::from(&config_path);
         if path.exists() {
             let content = std::fs::read_to_string(&path)?;
-            let mut config: Config = toml::from_str(&content)?;
+            let (mut config, unknown_keys) = deserialize_config(&content)?;
             apply_env_overrides(&mut config);
             return Ok(DiscoveredConfig {
                 config,
@@ -242,29 +265,32 @@ pub fn discover(start_dir: &Path) -> Result<DiscoveredConfig> {
                     .map(|p| p.to_path_buf())
                     .unwrap_or_else(|| start_dir.to_path_buf()),
                 source: ConfigSource::Environment,
+                unknown_keys,
             });
         }
     }
 
     // Search upward for project config
-    if let Some((root, config, source)) = search_upward(start_dir)? {
+    if let Some((root, config, source, unknown_keys)) = search_upward(start_dir)? {
         let mut config = config;
         apply_env_overrides(&mut config);
         return Ok(DiscoveredConfig {
             config,
             root,
             source,
+            unknown_keys,
         });
     }
 
     // Try global config
-    if let Some((config, path)) = load_global_config()? {
+    if let Some((config, path, unknown_keys)) = load_global_config()? {
         let mut config = config;
         apply_env_overrides(&mut config);
         return Ok(DiscoveredConfig {
             config,
             root: start_dir.to_path_buf(),
             source: ConfigSource::Global(path),
+            unknown_keys,
         });
     }
 
@@ -275,11 +301,13 @@ pub fn discover(start_dir: &Path) -> Result<DiscoveredConfig> {
         config,
         root: start_dir.to_path_buf(),
         source: ConfigSource::Default,
+        unknown_keys: Vec::new(),
     })
 }
 
 /// Search upward from the given directory for a config file.
-fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSource)>> {
+#[allow(clippy::type_complexity)]
+fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSource, Vec<String>)>> {
     let mut current = start_dir.to_path_buf();
 
     loop {
@@ -287,8 +315,13 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
         let config_path = current.join(CONFIG_FILE);
         if config_path.exists() {
             let content = std::fs::read_to_string(&config_path)?;
-            let config: Config = toml::from_str(&content)?;
-            return Ok(Some((current, config, ConfigSource::Project(config_path))));
+            let (config, unknown_keys) = deserialize_config(&content)?;
+            return Ok(Some((
+                current,
+                config,
+                ConfigSource::Project(config_path),
+                unknown_keys,
+            )));
         }
 
         // Check for .adr-dir
@@ -305,13 +338,23 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
                 export: ExportConfig::default(),
                 doctor: DoctorConfig::default(),
             };
-            return Ok(Some((current, config, ConfigSource::Project(legacy_path))));
+            return Ok(Some((
+                current,
+                config,
+                ConfigSource::Project(legacy_path),
+                Vec::new(),
+            )));
         }
 
         // Check for default ADR directory (indicates project root)
         let default_dir = current.join(DEFAULT_ADR_DIR);
         if default_dir.exists() {
-            return Ok(Some((current, Config::default(), ConfigSource::Default)));
+            return Ok(Some((
+                current,
+                Config::default(),
+                ConfigSource::Default,
+                Vec::new(),
+            )));
         }
 
         // Stop at git repository root
@@ -330,14 +373,14 @@ fn search_upward(start_dir: &Path) -> Result<Option<(PathBuf, Config, ConfigSour
 }
 
 /// Load the global configuration file.
-fn load_global_config() -> Result<Option<(Config, PathBuf)>> {
+fn load_global_config() -> Result<Option<(Config, PathBuf, Vec<String>)>> {
     let config_dir = dirs_config_dir()?;
     let global_path = config_dir.join("adrs").join(GLOBAL_CONFIG_FILE);
 
     if global_path.exists() {
         let content = std::fs::read_to_string(&global_path)?;
-        let config: Config = toml::from_str(&content)?;
-        return Ok(Some((config, global_path)));
+        let (config, unknown_keys) = deserialize_config(&content)?;
+        return Ok(Some((config, global_path, unknown_keys)));
     }
 
     Ok(None)
@@ -1299,7 +1342,9 @@ variant = "bogus"
 
     #[test]
     fn test_unknown_toml_fields_accepted() {
-        // Serde's default behavior: unknown fields are silently ignored.
+        // Unknown fields don't fail `Config::load` -- they never have, and
+        // still don't after adding unknown-key reporting (see the
+        // `deserialize_config` tests below for the reporting behavior itself).
         let temp = TempDir::new().unwrap();
         std::fs::write(
             temp.path().join("adrs.toml"),
@@ -1315,6 +1360,188 @@ also_unknown = true
 
         let config = Config::load(temp.path()).unwrap();
         assert_eq!(config.adr_dir, PathBuf::from("doc/adr"));
+    }
+
+    // ========== deserialize_config / unknown-key reporting tests (issue #363) ==========
+
+    #[test]
+    fn test_deserialize_config_reports_unknown_top_level_key() {
+        let (config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+made_up_key = "hello"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.adr_dir, PathBuf::from("doc/adr"));
+        assert_eq!(unknown_keys, vec!["made_up_key".to_string()]);
+    }
+
+    #[test]
+    fn test_deserialize_config_reports_nested_doctor_key_as_dotted_path() {
+        // The issue's exact reproduction: an invented `[doctor].path` key.
+        let (_config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+
+[doctor]
+path = "docs/decisions/0025-example.md"
+ignore = ["ADR014"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(unknown_keys, vec!["doctor.path".to_string()]);
+    }
+
+    #[test]
+    fn test_deserialize_config_reports_typo_in_warnings_as_errors() {
+        let (config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+
+[doctor]
+warnings_as_erors = true
+"#,
+        )
+        .unwrap();
+
+        // The typo'd key is reported...
+        assert_eq!(unknown_keys, vec!["doctor.warnings_as_erors".to_string()]);
+        // ...and the real field silently keeps its default, exactly the trap
+        // described in the issue: no diagnostic either way without this fix.
+        assert!(!config.doctor.warnings_as_errors);
+    }
+
+    #[test]
+    fn test_deserialize_config_reports_nothing_for_valid_config() {
+        let (config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+mode = "ng"
+default_status = "accepted"
+no_edit = true
+
+[templates]
+format = "madr"
+variant = "minimal"
+custom = "templates/adr.md"
+
+[generate]
+toc_prefix = "./"
+
+[export]
+base_url = "https://example.com/adr"
+
+[doctor]
+ignore = ["ADR011"]
+warnings_as_errors = true
+"#,
+        )
+        .unwrap();
+
+        assert!(
+            unknown_keys.is_empty(),
+            "expected no unknown keys, got {unknown_keys:?}"
+        );
+        assert_eq!(config.adr_dir, PathBuf::from("doc/adr"));
+    }
+
+    #[test]
+    fn test_deserialize_config_reports_unknown_key_in_templates() {
+        let (_config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+
+[templates]
+format = "madr"
+bogus = "value"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(unknown_keys, vec!["templates.bogus".to_string()]);
+    }
+
+    #[test]
+    fn test_deserialize_config_reports_unknown_key_in_generate() {
+        let (_config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+
+[generate]
+toc_prefix = "./"
+bogus = "value"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(unknown_keys, vec!["generate.bogus".to_string()]);
+    }
+
+    #[test]
+    fn test_deserialize_config_reports_unknown_key_in_export() {
+        let (_config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+
+[export]
+base_url = "https://example.com/adr"
+bogus = "value"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(unknown_keys, vec!["export.bogus".to_string()]);
+    }
+
+    #[test]
+    fn test_deserialize_config_malformed_toml_still_errors() {
+        let result = deserialize_config("this is not valid toml {{{");
+        assert!(result.is_err(), "malformed TOML should still error");
+        assert!(
+            matches!(result, Err(Error::Toml(_))),
+            "malformed TOML should still produce Error::Toml, unchanged from toml::from_str"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_config_written_by_adrs_config_reports_no_unknown_keys() {
+        // Round-trip: a config written by `Config::save` (what `adrs config`
+        // and `adrs init --ng` write) must not itself look like it has
+        // unrecognized keys.
+        let temp = TempDir::new().unwrap();
+        let original = Config {
+            adr_dir: PathBuf::from("docs/decisions"),
+            mode: ConfigMode::NextGen,
+            default_status: Some("accepted".to_string()),
+            no_edit: true,
+            templates: TemplateConfig {
+                format: Some("madr".to_string()),
+                variant: Some("minimal".to_string()),
+                custom: Some(PathBuf::from("templates/adr.md")),
+            },
+            generate: GenerateConfig {
+                toc_prefix: Some("./".to_string()),
+            },
+            export: ExportConfig {
+                base_url: Some("https://example.com/adr".to_string()),
+            },
+            doctor: DoctorConfig {
+                ignore: vec!["ADR011".to_string()],
+                warnings_as_errors: true,
+            },
+        };
+        original.save(temp.path()).unwrap();
+
+        let content = std::fs::read_to_string(temp.path().join("adrs.toml")).unwrap();
+        let (_config, unknown_keys) = deserialize_config(&content).unwrap();
+
+        assert!(
+            unknown_keys.is_empty(),
+            "a config written by Config::save should report no unknown keys, got {unknown_keys:?}"
+        );
     }
 
     #[test]

--- a/crates/adrs/src/commands/init.rs
+++ b/crates/adrs/src/commands/init.rs
@@ -16,7 +16,10 @@ fn resolve_init_target(root: &Path, directory: Option<PathBuf>) -> (PathBuf, Pat
     match directory {
         Some(dir) => (root.to_path_buf(), dir),
         None => match discover(root) {
-            Ok(discovered) => (discovered.root, discovered.config.adr_dir),
+            Ok(discovered) => {
+                crate::warn_unknown_config_keys(&discovered);
+                (discovered.root, discovered.config.adr_dir)
+            }
             Err(_) => (root.to_path_buf(), Config::default().adr_dir),
         },
     }

--- a/crates/adrs/src/main.rs
+++ b/crates/adrs/src/main.rs
@@ -782,6 +782,9 @@ fn main() -> Result<()> {
         }
         Commands::Config => {
             let discovered = discover(&start_dir).ok();
+            if let Some(ref discovered) = discovered {
+                warn_unknown_config_keys(discovered);
+            }
             commands::config_with_discovery(&start_dir, discovered)
         }
         Commands::Doctor {
@@ -1032,9 +1035,13 @@ fn resolve_cli_path(working_dir: Option<&std::path::Path>, path: PathBuf) -> Pat
 /// tools return structured "not initialized" errors without exiting.
 #[cfg(feature = "mcp")]
 fn resolve_mcp_root(start_dir: &std::path::Path) -> PathBuf {
-    discover(start_dir)
-        .map(|discovered| discovered.root)
-        .unwrap_or_else(|_| start_dir.to_path_buf())
+    match discover(start_dir) {
+        Ok(discovered) => {
+            warn_unknown_config_keys(&discovered);
+            discovered.root
+        }
+        Err(_) => start_dir.to_path_buf(),
+    }
 }
 
 /// Discover config or return a helpful error.
@@ -1057,5 +1064,31 @@ fn discover_or_error(
         );
     }
 
+    warn_unknown_config_keys(&discovered);
+
     Ok(discovered)
+}
+
+/// Print a warning to stderr naming the config file and every key in it that
+/// did not match a known field (see issue #363: an unrecognized key, such as
+/// a typo in `warnings_as_errors`, was silently dropped with no diagnostic).
+///
+/// Does not affect the exit code -- the config still loads and the command
+/// proceeds using its defaults for the unrecognized keys.
+pub(crate) fn warn_unknown_config_keys(discovered: &adrs_core::DiscoveredConfig) {
+    if discovered.unknown_keys.is_empty() {
+        return;
+    }
+
+    let source = match &discovered.source {
+        ConfigSource::Project(path) => path.display().to_string(),
+        ConfigSource::Global(path) => format!("{} (global)", path.display()),
+        ConfigSource::Environment => "the ADRS_CONFIG config file".to_string(),
+        ConfigSource::Default => "the config".to_string(),
+    };
+
+    eprintln!(
+        "warning: {source} has unrecognized key(s): {}",
+        discovered.unknown_keys.join(", ")
+    );
 }

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -2145,6 +2145,85 @@ fn test_doctor_ignore_flag_works_without_config() {
     temp.close().unwrap();
 }
 
+// Tests for warning on unrecognized adrs.toml keys (issue #363)
+
+#[test]
+fn test_doctor_unknown_doctor_config_key_warns_on_stderr() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Invented `[doctor].path` key from the issue's reproduction: it is not a
+    // recognized field, so it must be reported, not silently dropped.
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\n\n[doctor]\npath = \"doc/adr/0001-example.md\"\n",
+    )
+    .unwrap();
+
+    // A fresh `init` produces a healthy repo, so doctor exits on the merits
+    // of the ADRs (success), not on the config warning.
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("doctor.path"))
+        .stderr(predicate::str::contains("unrecognized"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_doctor_invented_path_key_no_longer_looks_like_working_scope() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Numbering gap trips the ADR011 warning (ADR #1 from init, plus #2 and
+    // #4, skipping #3).
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        nygard_adr(2, "Second"),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("doc/adr/0004-fourth.md"),
+        nygard_adr(4, "Fourth"),
+    )
+    .unwrap();
+
+    // The issue's exact shape: an invented `path` alongside a real `ignore`
+    // key. `path` never scoped anything -- `ignore` suppresses ADR011
+    // repository-wide, which reads as confirmation that `path` worked.
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\n\n[doctor]\npath = \"doc/adr/0002-second.md\"\nignore = [\"ADR011\"]\n",
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        // The suppression count is real (ignore is a recognized key)...
+        .stdout(predicate::str::contains("suppressed by ignore rules"))
+        // ...but stderr now says outright that `path` did nothing, so the
+        // per-file scope no longer reads as working.
+        .stderr(predicate::str::contains("doctor.path"));
+
+    temp.close().unwrap();
+}
+
 /// Smoke test for MCP feature availability (default since 0.6.1)
 #[test]
 #[cfg(feature = "mcp")]


### PR DESCRIPTION
Closes #363.

## Context

`adrs.toml` is parsed with bare `toml::from_str` and no config struct sets
`deny_unknown_fields`, so any key serde does not recognize is dropped without a
diagnostic. The reporter hit this by inventing a `[doctor].path` key, which was
accepted, produced a real suppression count, and never scoped anything.

Reproduced on current `main`, not just the reported v0.10.1. There is a sharper
case than the one filed: the same hole swallows a typo in an existing key, and
for `warnings_as_errors` that silently disables a CI gate.

```
warnings_as_erors = true    ->  adrs doctor exits 0
warnings_as_errors = true   ->  adrs doctor exits 1
```

Same repository, same single warning, one transposed character, no diagnostic
either way. Someone using `doctor` as a merge gate would see green and conclude
the gate is working.

The affected structs are all of them, not just `DoctorConfig`: `Config`,
`TemplateConfig`, `GenerateConfig`, `ExportConfig`, `DoctorConfig`
(`crates/adrs-core/src/config.rs`). There are four parse sites, and all four
need the same treatment:

| Site | Line |
|---|---|
| `Config::load` | `config.rs:85` |
| `discover`, `ADRS_CONFIG` env path | `config.rs:236` |
| `search_upward` | `config.rs:290` |
| `load_global_config` | `config.rs:339` |

## Decision

**Warn on unrecognized keys; do not adopt `deny_unknown_fields`.** The issue
proposes either. Denying turns every existing config carrying a stray key into a
hard startup failure, including configs that work today and whose owners did
nothing wrong. That is a breaking change landing on the wrong people to fix a
diagnostic gap. A warning delivers the whole signal, which is "this key did
nothing", with no breakage. If the strict version is wanted later, warning first
and denying in a major release is the ordering that does not strand anyone.

**Use `serde_ignored`** (0.1.14, crates.io) rather than hand-maintaining a list
of known keys or bolting `#[serde(flatten)]` catch-alls onto each struct. It
wraps the existing `toml` deserializer and reports full dotted paths, so
`doctor.path` is reported as `doctor.path` rather than as a bare `path` the user
then has to locate. A hand-maintained key list drifts silently the moment a field
is added, which is the same class of bug as the one being fixed.

## Task

1. Add the `serde_ignored` dependency to `crates/adrs-core/Cargo.toml`.
2. In `config.rs`, replace the four `toml::from_str::<Config>` calls with a
   single shared helper that deserializes through `serde_ignored` and returns
   both the `Config` and the sorted list of unrecognized dotted key paths. Keep
   the existing error behavior for genuinely malformed TOML unchanged.
3. Carry the unknown keys out to the caller. `Config` needs a field for them
   marked `#[serde(skip)]` so it never round-trips into a written config, or an
   equivalent that does not change the serialized shape. Verify that `adrs
   config` and anything else that writes `adrs.toml` still produce byte-identical
   output for an unchanged config.
4. Surface the warning once per invocation, to stderr, naming the config file and
   each unrecognized key. `discover_or_error` in `crates/adrs/src/main.rs` is the
   funnel most commands pass through; check whether every path that loads a
   config reaches it, and cover the ones that do not.
5. The warning must not change any exit code. A config with unknown keys still
   runs; it just says so.

## Tests

In `config.rs`:

- An unknown top-level key is reported, and the rest of the config still loads.
- An unknown key inside `[doctor]` is reported as `doctor.path`, not `path`.
- A typo'd `warnings_as_erors` is reported, and `warnings_as_errors` retains its
  default rather than the intended value.
- A config with only recognized keys reports nothing.
- Unknown keys in `[templates]`, `[generate]`, and `[export]` are each reported,
  so the fix is not `[doctor]`-only.
- Malformed TOML still errors as it does today, with the same error type.
- Round-trip: a config written by `adrs config` reports no unknown keys.

In `crates/adrs/tests/cli.rs`:

- `adrs doctor` against a config with an invented `[doctor].path` prints the
  warning to stderr and still exits on the merits of the ADRs, not on the config.
- The issue's exact reproduction: `path` plus `ignore` no longer looks like a
  working per-file scope.

## Constraints

- No `deny_unknown_fields` anywhere in this PR.
- No exit-code change for a config carrying unknown keys.
- Warnings go to stderr, so stdout stays parseable.
- Do not change the serialized shape of a written `adrs.toml`.
- Do not edit `CLAUDE.md`.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and
  `cargo test --all-features` all pass.

## Out of scope

- Per-file or glob scoping for `[doctor].ignore`, split out as #365. That is the
  capability the reporter wanted; this PR only closes the silent-drop hole that
  made the attempt look successful.

## Acceptance

The issue's config prints a warning naming `doctor.path`, and a typo'd
`warnings_as_errors` is called out rather than silently reverting to its default.


## What landed

**One deliberate divergence from the plan, and it is the right call.** The plan
said give all four parse sites the same treatment. `Config::load` now routes
through the shared helper for consistent malformed-TOML behavior but discards
the unknown-key list rather than exposing it, because in the CLI flow
`Repository::open` is always handed the root `discover_or_error` already
resolved and warned about. Surfacing it there too would parse the same
`adrs.toml` twice and warn twice for one file.

Three call sites bypass `discover_or_error` and are covered directly: the
`Commands::Config` arm, `commands::init::resolve_init_target`, and
`resolve_mcp_root`.

**Verified against the built binary**, config carrying three unrecognized keys
across two tables:

```
$ adrs doctor 2>/dev/null          # stdout stays clean and parseable
warning: [asymmetric-link] ...
Found 0 error(s), 1 warning(s), 0 info(s)
exit=0

$ adrs doctor 2>&1 >/dev/null      # stderr carries the config warning
warning: /tmp/.../adrs.toml has unrecognized key(s): doctor.path, doctor.warnings_as_erors, templates.fomat
```

Dotted paths, so `doctor.path` locates itself. Exit code unchanged. Confirmed
the warning also fires on `list`, `config show`, `search`, `generate toc`,
`export json`, and a re-run of `init`.

## One thing to decide before merge

`DiscoveredConfig` gains a public `unknown_keys` field, and the struct is not
`#[non_exhaustive]`, so `DiscoveredConfig { config, root, source }` compiles
against the published crate today and will not after this. That is a technically
breaking change to `adrs-core`, landing under a `fix:` commit that release-plz
will cut as a patch.

Practical risk is close to zero, since the struct is a return value from
`discover()` and there is little reason to build one by hand. But this project
batches breaking changes deliberately (#341 is held for the next major), so it
should be a decision rather than a side effect. Three options:

1. Ship as is and accept a theoretical break in a patch.
2. Add `#[non_exhaustive]` in this PR, making the break explicit now and
   preventing the next one.
3. Hold the field and compute unknown keys entirely inside the CLI, leaving
   `adrs-core`'s API untouched at the cost of parsing the config twice.

**Tests:** 831 pass, 0 fail (`cargo test --all-features`). CI green on Clippy,
Format, MSRV (adrs @ 1.90, adrs-core @ 1.88), Audit and Security audit (which
matter here, since this adds a dependency), and tests on macOS, Ubuntu, and
Windows.
