### PR TITLE
feat: path-scoped doctor ignores (closes #365)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ name = "adrs-core"
 version = "0.10.1"
 dependencies = [
  "fuzzy-matcher",
+ "globset",
  "mdbook-lint-core",
  "mdbook-lint-rulesets",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ time = { version = "0.3", features = ["local-offset", "formatting", "macros", "s
 # Utilities
 fuzzy-matcher = "0.3"
 regex = "1"
+globset = "0.4"
 
 # CLI only
 anyhow = "1"

--- a/book/src/commands/doctor.md
+++ b/book/src/commands/doctor.md
@@ -113,6 +113,30 @@ from config, so you can suppress an extra rule for a single run without editing
 `[doctor].warnings_as_errors`, so either one being set is enough to make warnings
 fail the check.
 
+### Suppressing a rule for specific records
+
+`[doctor].ignore` applies to the whole repository, which means one record with a
+false positive costs you the rule everywhere. To scope a suppression instead, add
+one or more `[[doctor.ignore_path]]` entries:
+
+```toml
+[[doctor.ignore_path]]
+glob = "doc/adr/0025-*.md"
+rules = ["ADR014"]
+```
+
+`glob` is matched against each record's path relative to the project root, using
+forward slashes on every platform. `rules` accepts rule IDs or rule names, matched
+case-insensitively, the same as `[doctor].ignore`.
+
+Two cases produce a warning on stderr rather than failing:
+
+- A glob that does not compile. The rest of the config still applies, but the
+  entry does not, so you are told instead of assuming the exemption is live.
+- An entry naming `ADR010`, `ADR011`, or `ADR012`. Those rules report on the
+  repository as a whole rather than on a file, so there is no path to match and a
+  scoped exemption for them can never fire. Use `[doctor].ignore` for those.
+
 ## Pre-commit Hook
 
 `adrs` ships a [pre-commit](https://pre-commit.com) hook (also compatible

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -67,6 +67,14 @@ no_edit = false
 # If omitted, defaults to false
 # warnings_as_errors = false
 
+# Suppress rules for records matching a glob, instead of repository-wide.
+# Use this when one record trips a rule you want kept everywhere else.
+# 'glob' is matched against each record's path relative to the project root.
+# Repeat the block for more than one exemption.
+# [[doctor.ignore_path]]
+# glob = "doc/adr/0025-*.md"
+# rules = ["ADR014"]
+
 # Template configuration
 [templates]
 # Default format: "nygard" or "madr"

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -27,6 +27,7 @@ walkdir.workspace = true
 time.workspace = true
 fuzzy-matcher.workspace = true
 regex.workspace = true
+globset.workspace = true
 
 # Linting (mdbook-lint integration)
 mdbook-lint-core = "0.14.4"

--- a/crates/adrs-core/src/config.rs
+++ b/crates/adrs-core/src/config.rs
@@ -210,6 +210,9 @@ impl Config {
         if other.doctor.warnings_as_errors {
             self.doctor.warnings_as_errors = other.doctor.warnings_as_errors;
         }
+        if !other.doctor.ignore_path.is_empty() {
+            self.doctor.ignore_path = other.doctor.ignore_path.clone();
+        }
     }
 }
 
@@ -461,12 +464,41 @@ pub struct ExportConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct DoctorConfig {
-    /// Rule IDs or rule names to suppress (e.g. "ADR011", "adr-numbering-sequential").
-    /// Matched case-insensitively against both Issue.rule_id and Issue.rule_name.
+    /// Rule IDs or rule names to suppress repository-wide (e.g. "ADR011",
+    /// "adr-numbering-sequential"). Matched case-insensitively against both
+    /// Issue.rule_id and Issue.rule_name.
     pub ignore: Vec<String>,
 
     /// When true, `adrs doctor` exits with status 1 if there are warnings, not just errors.
     pub warnings_as_errors: bool,
+
+    /// Path-scoped rule exemptions (issue #365). Unlike `ignore`, which
+    /// suppresses a rule everywhere, each entry here suppresses `rules` only
+    /// for diagnostics whose path (relative to the repository root) matches
+    /// `glob`.
+    pub ignore_path: Vec<DoctorIgnorePath>,
+}
+
+/// A single path-scoped rule exemption under `[[doctor.ignore_path]]`.
+///
+/// `glob` is matched, using `globset`, against a diagnostic's path relative
+/// to the repository root with separators normalized to `/`. `rules` is
+/// matched the same way `[doctor].ignore` is: case-insensitively against
+/// both `Issue.rule_id` and `Issue.rule_name`.
+///
+/// Only diagnostics that carry a path can be scoped this way -- some rules
+/// (the upstream collection rules ADR010-ADR012) never populate `path`, so
+/// an entry that names only those rules can never suppress anything. See
+/// `lint::check_all_filtered`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DoctorIgnorePath {
+    /// Glob pattern matched against the diagnostic's path relative to the
+    /// repository root (forward slashes, even on Windows).
+    pub glob: String,
+
+    /// Rule IDs or rule names to suppress when `glob` matches.
+    pub rules: Vec<String>,
 }
 
 #[cfg(test)]
@@ -1531,6 +1563,7 @@ bogus = "value"
             doctor: DoctorConfig {
                 ignore: vec!["ADR011".to_string()],
                 warnings_as_errors: true,
+                ignore_path: Vec::new(),
             },
         };
         original.save(temp.path()).unwrap();
@@ -1920,6 +1953,7 @@ warnings_as_errors = true
             doctor: DoctorConfig {
                 ignore: vec!["ADR011".to_string()],
                 warnings_as_errors: false,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -1932,6 +1966,7 @@ warnings_as_errors = true
             doctor: DoctorConfig {
                 ignore: vec!["ADR011".to_string()],
                 warnings_as_errors: false,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -1952,6 +1987,7 @@ warnings_as_errors = true
             doctor: DoctorConfig {
                 ignore: vec![],
                 warnings_as_errors: true,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -1971,6 +2007,7 @@ warnings_as_errors = true
             doctor: DoctorConfig {
                 ignore: vec!["ADR011".to_string()],
                 warnings_as_errors: true,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -1980,5 +2017,148 @@ warnings_as_errors = true
 
         assert_eq!(loaded.doctor.ignore, vec!["ADR011".to_string()]);
         assert!(loaded.doctor.warnings_as_errors);
+    }
+
+    // ========== DoctorConfig / ignore_path Tests (issue #365) ==========
+
+    #[test]
+    fn test_doctor_ignore_path_default_empty() {
+        let config = DoctorConfig::default();
+        assert!(config.ignore_path.is_empty());
+    }
+
+    #[test]
+    fn test_doctor_ignore_path_from_toml() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+
+[doctor]
+ignore = ["ADR011"]
+
+[[doctor.ignore_path]]
+glob = "doc/adr/0025-*.md"
+rules = ["ADR014"]
+
+[[doctor.ignore_path]]
+glob = "doc/adr/legacy/**"
+rules = ["ADR001", "adr-required-sections"]
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert_eq!(config.doctor.ignore, vec!["ADR011".to_string()]);
+        assert_eq!(config.doctor.ignore_path.len(), 2);
+        assert_eq!(config.doctor.ignore_path[0].glob, "doc/adr/0025-*.md");
+        assert_eq!(
+            config.doctor.ignore_path[0].rules,
+            vec!["ADR014".to_string()]
+        );
+        assert_eq!(config.doctor.ignore_path[1].glob, "doc/adr/legacy/**");
+        assert_eq!(
+            config.doctor.ignore_path[1].rules,
+            vec!["ADR001".to_string(), "adr-required-sections".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_doctor_ignore_path_absent_defaults_empty() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("adrs.toml"), "adr_dir = \"doc/adr\"\n").unwrap();
+
+        let config = Config::load(temp.path()).unwrap();
+        assert!(config.doctor.ignore_path.is_empty());
+    }
+
+    #[test]
+    fn test_doctor_ignore_path_save_load_roundtrip() {
+        let temp = TempDir::new().unwrap();
+        let original = Config {
+            mode: ConfigMode::NextGen,
+            doctor: DoctorConfig {
+                ignore: vec!["ADR011".to_string()],
+                warnings_as_errors: true,
+                ignore_path: vec![DoctorIgnorePath {
+                    glob: "doc/adr/0025-*.md".to_string(),
+                    rules: vec!["ADR014".to_string()],
+                }],
+            },
+            ..Default::default()
+        };
+
+        original.save(temp.path()).unwrap();
+        let loaded = Config::load(temp.path()).unwrap();
+
+        assert_eq!(loaded.doctor.ignore_path.len(), 1);
+        assert_eq!(loaded.doctor.ignore_path[0].glob, "doc/adr/0025-*.md");
+        assert_eq!(
+            loaded.doctor.ignore_path[0].rules,
+            vec!["ADR014".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_config_merge_doctor_ignore_path() {
+        let mut base = Config::default();
+        let other = Config {
+            doctor: DoctorConfig {
+                ignore_path: vec![DoctorIgnorePath {
+                    glob: "doc/adr/0025-*.md".to_string(),
+                    rules: vec!["ADR014".to_string()],
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        base.merge(&other);
+        assert_eq!(base.doctor.ignore_path.len(), 1);
+        assert_eq!(base.doctor.ignore_path[0].glob, "doc/adr/0025-*.md");
+
+        // An empty ignore_path list in `other` must not clobber an existing base list.
+        let mut base = Config {
+            doctor: DoctorConfig {
+                ignore_path: vec![DoctorIgnorePath {
+                    glob: "doc/adr/0025-*.md".to_string(),
+                    rules: vec!["ADR014".to_string()],
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let other = Config::default(); // doctor.ignore_path is empty
+
+        base.merge(&other);
+        assert_eq!(
+            base.doctor.ignore_path.len(),
+            1,
+            "merge with empty doctor.ignore_path should not overwrite existing value"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_config_reports_unknown_key_in_doctor_ignore_path() {
+        // The #363 warning walks the whole document, so an unknown key inside
+        // an array-of-tables entry must be reported the same way as an unknown
+        // top-level or nested-table key.
+        let (_config, unknown_keys) = deserialize_config(
+            r#"
+adr_dir = "doc/adr"
+
+[[doctor.ignore_path]]
+glob = "doc/adr/0025-*.md"
+rules = ["ADR014"]
+reason = "false positive on this record"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            unknown_keys,
+            vec!["doctor.ignore_path.0.reason".to_string()]
+        );
     }
 }

--- a/crates/adrs-core/src/lint.rs
+++ b/crates/adrs-core/src/lint.rs
@@ -5,13 +5,36 @@
 //! (sequential numbering, duplicate detection, broken links).
 
 use crate::{Adr, Repository, Result};
+use globset::Glob;
 use mdbook_lint_core::Document;
 use mdbook_lint_core::rule::{CollectionRule, Rule};
 use mdbook_lint_rulesets::adr::{
     Adr001, Adr002, Adr003, Adr004, Adr005, Adr006, Adr007, Adr008, Adr009, Adr010, Adr011, Adr012,
     Adr013, Adr014, Adr015, Adr016, Adr017, AdrFormat,
 };
+use std::collections::HashSet;
 use std::path::PathBuf;
+
+/// Rule IDs and rule names that are *always* produced without a path.
+///
+/// These are the upstream collection rules whose only source is
+/// `check_repository`'s `CollectionRule::check_collection` loop (`path: None`
+/// there -- see the comment on that loop). `ADR013` / `adr-valid-adr-links` is
+/// deliberately excluded: that rule id is also used by the frontmatter
+/// broken-link check above the collection-rule loop, which *does* set a path,
+/// so a `[[doctor.ignore_path]]` entry naming it can fire for that source even
+/// though it can never match the collection-rule source.
+///
+/// Used to warn when a `[[doctor.ignore_path]]` entry names a rule that can
+/// never be suppressed by path (issue #365).
+const ALWAYS_PATHLESS_RULES: &[&str] = &[
+    "ADR010",
+    "adr-superseded-has-replacement",
+    "ADR011",
+    "adr-sequential-numbering",
+    "ADR012",
+    "adr-no-duplicate-numbers",
+];
 
 /// Severity level for lint issues.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -499,18 +522,35 @@ pub fn check_repository(repo: &Repository) -> Result<LintReport> {
     Ok(report)
 }
 
-/// Run all checks and filter out issues matching ignored rule IDs/names.
+/// A compiled `[[doctor.ignore_path]]` entry, ready to match against issue paths.
+struct CompiledIgnorePath {
+    matcher: globset::GlobMatcher,
+    rules: HashSet<String>,
+}
+
+/// Run all checks and filter out issues matching ignored rule IDs/names,
+/// repository-wide or path-scoped.
 ///
-/// Ignored rules are `repo.config().doctor.ignore` unioned with `extra_ignore`
-/// (e.g. CLI `--ignore` flags for a single invocation). Matching is
-/// case-insensitive against both `Issue.rule_id` and `Issue.rule_name`.
+/// Repository-wide ignores are `repo.config().doctor.ignore` unioned with
+/// `extra_ignore` (e.g. CLI `--ignore` flags for a single invocation).
+/// Path-scoped ignores are `repo.config().doctor.ignore_path`: each entry
+/// suppresses its `rules` only for issues whose path, relative to the
+/// repository root with separators normalized to `/`, matches its `glob`.
+/// Both forms match rules case-insensitively against `Issue.rule_id` and
+/// `Issue.rule_name` (issue #365).
 ///
-/// Returns the filtered report and the count of issues that were suppressed.
+/// Returns the filtered report, the count of issues that were suppressed
+/// (repository-wide and path-scoped combined, each issue counted once even
+/// if it matched both), and any config warnings: an invalid glob that could
+/// not be compiled, or a `[[doctor.ignore_path]]` entry naming a rule that
+/// only ever produces path-less diagnostics and so can never be suppressed
+/// this way.
 pub fn check_all_filtered(
     repo: &Repository,
     extra_ignore: &[String],
-) -> Result<(LintReport, usize)> {
+) -> Result<(LintReport, usize, Vec<String>)> {
     let mut report = LintReport::new();
+    let mut warnings = Vec::new();
 
     // Use list_with_errors to capture parse failures
     let (adrs, parse_errors) = repo.list_with_errors()?;
@@ -543,7 +583,7 @@ pub fn check_all_filtered(
 
     report.sort();
 
-    let ignore_set: std::collections::HashSet<String> = repo
+    let ignore_set: HashSet<String> = repo
         .config()
         .doctor
         .ignore
@@ -552,18 +592,69 @@ pub fn check_all_filtered(
         .map(|s| s.to_lowercase())
         .collect();
 
-    if ignore_set.is_empty() {
-        return Ok((report, 0));
+    // Compile each `[[doctor.ignore_path]]` entry. An invalid glob is a
+    // config error in the same family as #363 -- the user believes an
+    // exemption is active when it is not -- so it is reported as a warning
+    // rather than silently dropped, and the rest of the config still loads
+    // and applies (see `warn_unknown_config_keys` in the CLI for the same
+    // non-fatal-warning convention).
+    let mut compiled_ignore_paths: Vec<CompiledIgnorePath> = Vec::new();
+    for entry in &repo.config().doctor.ignore_path {
+        match Glob::new(&entry.glob) {
+            Ok(glob) => compiled_ignore_paths.push(CompiledIgnorePath {
+                matcher: glob.compile_matcher(),
+                rules: entry.rules.iter().map(|s| s.to_lowercase()).collect(),
+            }),
+            Err(e) => warnings.push(format!(
+                "[[doctor.ignore_path]] glob '{}' is invalid and will not be applied: {e}",
+                entry.glob
+            )),
+        }
+
+        for rule in &entry.rules {
+            if ALWAYS_PATHLESS_RULES
+                .iter()
+                .any(|pathless| pathless.eq_ignore_ascii_case(rule))
+            {
+                warnings.push(format!(
+                    "[[doctor.ignore_path]] entry for glob '{}' names rule '{}', which only ever produces diagnostics without a path; this exemption can never suppress it",
+                    entry.glob, rule
+                ));
+            }
+        }
     }
 
+    if ignore_set.is_empty() && compiled_ignore_paths.is_empty() {
+        return Ok((report, 0, warnings));
+    }
+
+    let root = repo.root();
     let before = report.issues.len();
     report.issues.retain(|issue| {
-        !ignore_set.contains(&issue.rule_id.to_lowercase())
-            && !ignore_set.contains(&issue.rule_name.to_lowercase())
+        if ignore_set.contains(&issue.rule_id.to_lowercase())
+            || ignore_set.contains(&issue.rule_name.to_lowercase())
+        {
+            return false;
+        }
+
+        let Some(path) = &issue.path else {
+            return true;
+        };
+
+        let relative = path.strip_prefix(root).unwrap_or(path);
+        let relative_str = relative.to_string_lossy().replace('\\', "/");
+
+        let rule_id = issue.rule_id.to_lowercase();
+        let rule_name = issue.rule_name.to_lowercase();
+
+        !compiled_ignore_paths.iter().any(|entry| {
+            entry.matcher.is_match(&relative_str)
+                && (entry.rules.contains(&rule_id) || entry.rules.contains(&rule_name))
+        })
     });
     let suppressed = before - report.issues.len();
 
-    Ok((report, suppressed))
+    Ok((report, suppressed, warnings))
 }
 
 /// Run all checks: per-file lint + repository-level checks.
@@ -571,7 +662,7 @@ pub fn check_all_filtered(
 /// Also reports files that look like ADRs (digit-prefixed `.md` files in the
 /// ADR directory) but could not be parsed (e.g., invalid YAML frontmatter).
 pub fn check_all(repo: &Repository) -> Result<LintReport> {
-    check_all_filtered(repo, &[]).map(|(report, _)| report)
+    check_all_filtered(repo, &[]).map(|(report, _, _)| report)
 }
 
 #[cfg(test)]
@@ -1610,11 +1701,362 @@ Some consequences.
         .unwrap();
         let repo = Repository::open(temp.path()).unwrap();
 
-        let (filtered, suppressed_count) = check_all_filtered(&repo, &[]).unwrap();
+        let (filtered, suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
         assert_eq!(suppressed_count, unfiltered_adr011);
         assert!(
             filtered.issues.iter().all(|i| i.rule_id != "ADR011"),
             "filtered report should not contain ADR011"
+        );
+        assert!(
+            warnings.is_empty(),
+            "no [[doctor.ignore_path]] entries configured, expected no warnings"
+        );
+    }
+
+    // ========== check_all_filtered / [[doctor.ignore_path]] (issue #365) ==========
+
+    /// An ADR with an explicit Consequences body, so a test can trigger
+    /// ADR014's placeholder-text check on demand.
+    fn make_nygard_adr_with_consequences(
+        number: u32,
+        title: &str,
+        status: &str,
+        consequences: &str,
+    ) -> String {
+        format!(
+            "# {number}. {title}\n\nDate: 2024-01-01\n\n## Status\n\n{status}\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\n{consequences}\n"
+        )
+    }
+
+    #[test]
+    fn test_check_all_filtered_scoped_ignore_suppresses_on_matching_record_only() {
+        // The headline test (#365): a scoped ignore suppresses ADR014 on the
+        // record it names and leaves ADR014 firing on a different record that
+        // trips the same placeholder-text check.
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+
+        // ADR 1 (created by init) already has real content; add two more ADRs
+        // that both trip ADR014 via placeholder text in Consequences.
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr_with_consequences(2, "Second", "Accepted", "TBD"),
+        )
+        .unwrap();
+        std::fs::write(
+            adr_dir.join("0003-third.md"),
+            make_nygard_adr_with_consequences(3, "Third", "Accepted", "TBD"),
+        )
+        .unwrap();
+
+        // Unfiltered: both records trip ADR014.
+        let (unfiltered, _, _) = check_all_filtered(&repo, &[]).unwrap();
+        let unfiltered_adr014_paths: Vec<_> = unfiltered
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR014")
+            .filter_map(|i| i.path.clone())
+            .collect();
+        assert!(
+            unfiltered_adr014_paths
+                .iter()
+                .any(|p| p.ends_with("0002-second.md")),
+            "expected ADR014 on 0002-second.md before scoping, got: {unfiltered_adr014_paths:?}"
+        );
+        assert!(
+            unfiltered_adr014_paths
+                .iter()
+                .any(|p| p.ends_with("0003-third.md")),
+            "expected ADR014 on 0003-third.md before scoping, got: {unfiltered_adr014_paths:?}"
+        );
+
+        // Scope the exemption to 0002-second.md only.
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\n\n[[doctor.ignore_path]]\nglob = \"doc/adr/0002-*.md\"\nrules = [\"ADR014\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (filtered, suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings, got {warnings:?}"
+        );
+        assert!(suppressed_count > 0);
+
+        let filtered_adr014_paths: Vec<_> = filtered
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR014")
+            .filter_map(|i| i.path.clone())
+            .collect();
+        assert!(
+            !filtered_adr014_paths
+                .iter()
+                .any(|p| p.ends_with("0002-second.md")),
+            "0002-second.md's ADR014 should be suppressed, got: {filtered_adr014_paths:?}"
+        );
+        assert!(
+            filtered_adr014_paths
+                .iter()
+                .any(|p| p.ends_with("0003-third.md")),
+            "0003-third.md's ADR014 should still fire, got: {filtered_adr014_paths:?}"
+        );
+    }
+
+    #[test]
+    fn test_check_all_filtered_scoped_ignore_double_star_matches_subdirectory() {
+        // `**` must span the intermediate directory components of a nested
+        // `adr_dir` (e.g. "docs/architecture/decisions", the shape used in
+        // #363's own reproduction), not just match within a single directory.
+        // `Repository::list` only reads ADR files directly inside `adr_dir`
+        // (`max_depth(1)`), so the subdirectory being spanned here is
+        // `adr_dir` itself relative to the repository root, not a
+        // subdirectory of `adr_dir`.
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(
+            temp.path(),
+            Some(PathBuf::from("docs/architecture/decisions")),
+            false,
+        )
+        .unwrap();
+        let adr_dir = repo.adr_path();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr_with_consequences(2, "Second", "Accepted", "TBD"),
+        )
+        .unwrap();
+
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"docs/architecture/decisions\"\n\n[[doctor.ignore_path]]\nglob = \"**/0002-*.md\"\nrules = [\"ADR014\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (filtered, suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings, got {warnings:?}"
+        );
+        assert!(
+            suppressed_count > 0,
+            "expected the ** glob to match the nested record"
+        );
+        assert!(
+            !filtered.issues.iter().any(|i| i.rule_id == "ADR014"
+                && i.path
+                    .as_ref()
+                    .is_some_and(|p| p.ends_with("0002-second.md"))),
+            "nested record's ADR014 should be suppressed by the ** glob"
+        );
+    }
+
+    #[test]
+    fn test_check_all_filtered_scoped_ignore_matching_nothing_suppresses_nothing() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr_with_consequences(2, "Second", "Accepted", "TBD"),
+        )
+        .unwrap();
+
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\n\n[[doctor.ignore_path]]\nglob = \"doc/adr/9999-*.md\"\nrules = [\"ADR014\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (filtered, suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings, got {warnings:?}"
+        );
+        assert_eq!(
+            suppressed_count, 0,
+            "a glob matching nothing should suppress nothing"
+        );
+        assert!(
+            filtered.issues.iter().any(|i| i.rule_id == "ADR014"),
+            "ADR014 should still fire since the glob did not match"
+        );
+    }
+
+    #[test]
+    fn test_check_all_filtered_scoped_and_repo_wide_ignores_compose() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+        // 0002 trips ADR014 (scoped away below); 0003/0005 create a numbering
+        // gap that trips ADR011 (suppressed repository-wide below).
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr_with_consequences(2, "Second", "Accepted", "TBD"),
+        )
+        .unwrap();
+        std::fs::write(
+            adr_dir.join("0003-third.md"),
+            make_nygard_adr(3, "Third", "Accepted", ""),
+        )
+        .unwrap();
+        std::fs::write(
+            adr_dir.join("0005-fifth.md"),
+            make_nygard_adr(5, "Fifth", "Accepted", ""),
+        )
+        .unwrap();
+
+        let (unfiltered, _, _) =
+            check_all_filtered(&Repository::open(temp.path()).unwrap(), &[]).unwrap();
+        let unfiltered_adr014 = unfiltered
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR014")
+            .count();
+        let unfiltered_adr011 = unfiltered
+            .issues
+            .iter()
+            .filter(|i| i.rule_id == "ADR011")
+            .count();
+        assert!(unfiltered_adr014 > 0);
+        assert!(unfiltered_adr011 > 0);
+
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\n\n[doctor]\nignore = [\"ADR011\"]\n\n[[doctor.ignore_path]]\nglob = \"doc/adr/0002-*.md\"\nrules = [\"ADR014\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (filtered, suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings, got {warnings:?}"
+        );
+        assert_eq!(
+            suppressed_count,
+            unfiltered_adr014 + unfiltered_adr011,
+            "both the scoped and repository-wide ignores should count, with no double counting"
+        );
+        assert!(!filtered.issues.iter().any(|i| i.rule_id == "ADR014"));
+        assert!(!filtered.issues.iter().any(|i| i.rule_id == "ADR011"));
+    }
+
+    #[test]
+    fn test_check_all_filtered_scoped_ignore_matches_by_rule_name() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr_with_consequences(2, "Second", "Accepted", "TBD"),
+        )
+        .unwrap();
+
+        // Confirm ADR014's rule name before relying on it below.
+        let (unfiltered, _, _) =
+            check_all_filtered(&Repository::open(temp.path()).unwrap(), &[]).unwrap();
+        let rule_name = unfiltered
+            .issues
+            .iter()
+            .find(|i| i.rule_id == "ADR014")
+            .map(|i| i.rule_name.clone())
+            .expect("expected an ADR014 issue");
+
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            format!(
+                "adr_dir = \"doc/adr\"\n\n[[doctor.ignore_path]]\nglob = \"doc/adr/0002-*.md\"\nrules = [\"{rule_name}\"]\n"
+            ),
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (filtered, suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings, got {warnings:?}"
+        );
+        assert!(suppressed_count > 0);
+        assert!(!filtered.issues.iter().any(|i| i.rule_id == "ADR014"));
+    }
+
+    #[test]
+    fn test_check_all_filtered_invalid_glob_warns_and_config_still_loads() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr_with_consequences(2, "Second", "Accepted", "TBD"),
+        )
+        .unwrap();
+
+        // '[' with no closing ']' is an invalid glob pattern.
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\n\n[[doctor.ignore_path]]\nglob = \"doc/adr/[0002-*.md\"\nrules = [\"ADR014\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (filtered, suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
+        assert_eq!(
+            suppressed_count, 0,
+            "an invalid glob must not suppress anything"
+        );
+        assert!(
+            filtered.issues.iter().any(|i| i.rule_id == "ADR014"),
+            "ADR014 should still fire since the invalid glob was not applied"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("doc/adr/[0002-*.md")),
+            "expected a warning naming the invalid glob, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn test_check_all_filtered_ignore_path_naming_collection_rule_warns() {
+        use crate::Repository;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path(), None, false).unwrap();
+        let adr_dir = repo.adr_path();
+        std::fs::write(
+            adr_dir.join("0002-second.md"),
+            make_nygard_adr(2, "Second", "Accepted", ""),
+        )
+        .unwrap();
+
+        // ADR011 (sequential numbering) is an upstream collection rule and
+        // never carries a path, so this exemption can never fire.
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            "adr_dir = \"doc/adr\"\n\n[[doctor.ignore_path]]\nglob = \"doc/adr/0002-*.md\"\nrules = [\"ADR011\"]\n",
+        )
+        .unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
+
+        let (_filtered, _suppressed_count, warnings) = check_all_filtered(&repo, &[]).unwrap();
+        assert!(
+            warnings.iter().any(|w| w.contains("ADR011")),
+            "expected a warning naming the rule that can never fire, got: {warnings:?}"
         );
     }
 }

--- a/crates/adrs/src/commands/doctor.rs
+++ b/crates/adrs/src/commands/doctor.rs
@@ -26,8 +26,11 @@ pub fn doctor(root: &Path, ng: bool, ignore: Vec<String>, warnings_as_errors: bo
     let repo =
         Repository::open(root).context("Failed to open repository. Have you run 'adrs init'?")?;
 
-    let (report, suppressed_count) =
+    let (report, suppressed_count, config_warnings) =
         check_all_filtered(&repo, &ignore).context("Failed to run health checks")?;
+    for warning in &config_warnings {
+        eprintln!("warning: {warning}");
+    }
     let warnings_as_errors = warnings_as_errors || repo.config().doctor.warnings_as_errors;
 
     if report.issues.is_empty() {

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -2224,6 +2224,57 @@ fn test_doctor_invented_path_key_no_longer_looks_like_working_scope() {
     temp.close().unwrap();
 }
 
+// Tests for path-scoped doctor ignores (issue #365)
+
+fn nygard_adr_with_consequences(number: u32, title: &str, consequences: &str) -> String {
+    format!(
+        "# {number}. {title}\n\nDate: 2024-01-01\n\n## Status\n\nAccepted\n\n## Context\n\nSome context.\n\n## Decision\n\nA decision.\n\n## Consequences\n\n{consequences}\n"
+    )
+}
+
+#[test]
+fn test_doctor_ignore_path_scopes_suppression_to_matching_record() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Both records trip ADR014 (placeholder text in Consequences); only
+    // 0002 should be exempted.
+    fs::write(
+        temp.path().join("doc/adr/0002-second.md"),
+        nygard_adr_with_consequences(2, "Second", "TBD"),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("doc/adr/0003-third.md"),
+        nygard_adr_with_consequences(3, "Third", "TBD"),
+    )
+    .unwrap();
+
+    fs::write(
+        temp.path().join("adrs.toml"),
+        "adr_dir = \"doc/adr\"\n\n[[doctor.ignore_path]]\nglob = \"doc/adr/0002-*.md\"\nrules = [\"ADR014\"]\n",
+    )
+    .unwrap();
+
+    // ADR014 is a Warning, so doctor exits 0 without --warnings-as-errors;
+    // the important assertions are what shows up in the report.
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0002-second.md").not())
+        .stdout(predicate::str::contains("0003-third.md"))
+        .stdout(predicate::str::contains("suppressed by ignore rules"));
+
+    temp.close().unwrap();
+}
+
 /// Smoke test for MCP feature availability (default since 0.6.1)
 #[test]
 #[cfg(feature = "mcp")]


### PR DESCRIPTION
Closes #365.

## Context

`[doctor].ignore` is repository-wide. A rule that fires a false positive on one
record can only be silenced everywhere, which disables it on every record where
it was working. This is what the #363 reporter was reaching for when they
invented a `[doctor].path` key, and #363 only closed the silent-drop hole that
made the invented key look successful.

## Decision

Ship the local, path-scoped config key rather than waiting on `mdbook-lint#469`.
Inline directives remain the better long-term answer, since the exception lives
with the record and survives a rename or a renumber, but they are not landed
upstream and this is reachable now. The two are not exclusive.

**Config shape.** An array of tables, so multiple exemptions can coexist and the
shape can grow a `reason` field later without breaking:

```toml
[doctor]
ignore = ["ADR011"]            # repository-wide, unchanged

[[doctor.ignore_path]]
glob = "doc/adr/0025-*.md"
rules = ["ADR014"]
```

`glob` is matched against the diagnostic's path **relative to the repository
root**, which is how a user naturally writes it and how the #363 reporter did.
Normalize to forward slashes before matching so the same config works on Windows,
where CI runs.

**Use `globset`** for matching. It is the ripgrep glob engine, handles `**`, and
is well maintained. `[doctor].ignore` keeps its existing case-insensitive match
against both `Issue.rule_id` and `Issue.rule_name`; scoped rules match the same
way, so `rules = ["adr-madr-decision-outcome"]` works as well as `["ADR014"]`.

**The important constraint: scoping can only apply to diagnostics that carry a
path, and not every one does.**

| Source | Path populated? |
|---|---|
| Per-file rules via `lint_adr` (`lint.rs:525`) | yes |
| Frontmatter broken-link check, #355 (`lint.rs:372`) | yes |
| Asymmetric-link check, #357 (`lint.rs:426`) | yes |
| Parse errors (`lint.rs:211`, `lint.rs:265`) | yes |
| Upstream collection rules ADR010 to ADR013 (`lint.rs:466`) | **no** |

Upstream collection-rule violations set `path: None` and embed the file in the
message text instead. ADR014 is a per-file rule, so the reporter's own case is
covered, but a scoped ignore naming an upstream collection rule will not match.

Do **not** parse the path out of the message to work around this. That coupling
already exists once, in the #360 dedup, and it is the fragile seam in that PR.
Adding a second dependency on an upstream crate's message wording to decide
whether to suppress a diagnostic trades a visible limitation for a silent one.
Report the limitation instead, per below.

## Task

1. **Config** (`crates/adrs-core/src/config.rs`): add the `ignore_path` field to
   `DoctorConfig` as a `Vec` of a new struct with `glob: String` and
   `rules: Vec<String>`. Both `#[serde(default)]`, consistent with the rest of
   the file. Unknown keys inside the new struct are already covered by the #363
   warning, since it walks the whole document; confirm that with a test.
2. **Filtering** (`crates/adrs-core/src/lint.rs`): extend `check_all_filtered`.
   Today it builds one ignore set and filters. It should additionally, for each
   issue that has a path, check every `ignore_path` entry whose glob matches that
   path relative to the repo root, and suppress when the issue's rule id or name
   is in that entry's `rules`. Suppressed-by-scope issues count toward the same
   suppressed total the CLI already reports.
3. **Invalid globs must not be silently ignored.** A glob that fails to compile
   is a config error in the same family as #363: the user believes an exemption
   is active when it is not. Surface it, following whatever #363's warning path
   established, and make sure the rest of the config still loads.
4. **Report the collection-rule limitation.** If a scoped entry names a rule that
   only ever produces path-less diagnostics, the user has written an exemption
   that cannot fire. Warn naming the rule, so this does not become the same class
   of silent no-op that #363 was about.

## Tests

In `lint.rs`:

- A scoped ignore suppresses ADR014 on the matching record and leaves the same
  rule firing on a different record. This is #363's motivating case and the
  headline test.
- A `**` glob spanning a subdirectory matches.
- A glob matching nothing suppresses nothing and does not error.
- Scoped and repository-wide ignores compose: both counted, no double count.
- Rule matching by name as well as id.
- Scoped entries naming an upstream collection rule produce the warning from (4).
- Suppressed counts stay correct, since #363 showed a wrong-feeling count is how
  users are misled.

In `config.rs`: the new shape round-trips, and an unknown key inside
`[[doctor.ignore_path]]` is reported by the #363 warning.

In `crates/adrs/tests/cli.rs`: the reporter's scenario end to end, and a Windows
path separator case if the harness allows it.

## Constraints

- `[doctor].ignore` behavior is unchanged for every existing config.
- No parsing of upstream rule message text to recover a path.
- Do not change any rule's severity.
- Do not edit `CLAUDE.md`.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and
  `cargo test --all-features` all pass.

## Out of scope

- Inline suppression directives, which belong upstream in `mdbook-lint#469`.
- Giving upstream collection rules a real path, which is an upstream change.

## Acceptance

A single record tripping ADR014 can be exempted by path while the rule keeps
firing everywhere else, and an exemption that cannot possibly fire says so
instead of silently doing nothing.


## What landed

**Correction to the plan above.** The table claiming ADR010 through ADR013 are
always path-less is wrong about ADR013. That rule id is also emitted by the
frontmatter broken-link check added in #355, which does set a path, so a scoped
exemption naming ADR013 can legitimately fire for that source even though it can
never match the upstream collection-rule source. Only ADR010, ADR011, and ADR012
are always path-less, and only those three trigger the cannot-fire warning. The
table stands otherwise.

**The #363 warning path split in two.** Unknown keys nested inside
`[[doctor.ignore_path]]` are already reported by #363's mechanism for free, since
`serde_ignored` walks array-of-tables generically. The invalid-glob and
cannot-fire warnings could not reuse it: both need lint-time knowledge (compiling
the glob, knowing which rules are collection-only) that does not exist at
config-parse time. They are returned from `check_all_filtered` and printed with
the same `warning: ` stderr convention.

That changes `check_all_filtered`'s signature from `(LintReport, usize)` to
`(LintReport, usize, Vec<String>)`, a breaking change to `adrs-core`. The pending
release is already v0.11.0, so it lands in a minor, which is where a 0.x breaking
change belongs.

**Docs added** in a follow-up commit, covering the config reference and the
doctor command page including both warning cases. The worker correctly left these
out of scope; a config key nobody can discover is a half-shipped feature.

**Verified end to end**, two records both tripping ADR014:

```
$ adrs doctor          # with glob = "doc/adr/0002-*.md", rules = ["ADR014"]
warning: [ADR014] ... [.../0003-rec-3.md:3]
warning: [ADR014] ... [.../0003-rec-3.md:7]
Found 0 error(s), 2 warning(s), 0 info(s)
2 issue(s) suppressed by ignore rules
```

Suppressed on the matching record, still firing on the other, count correct. Both
warning paths confirmed on stderr with a deliberately broken glob and an entry
naming ADR011, and confirmed that an entry naming ADR013 correctly does not warn.
Findings stay on stdout and config warnings on stderr, verified by capturing the
streams to separate files.

**Tests:** 845 pass, 0 fail. CI green on all twelve checks including Audit,
Security audit, the book build, and tests on macOS, Ubuntu, and Windows.
