### PR TITLE
fix: transliterate non-ASCII titles into filename slugs (closes #367)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
 name = "adrs-core"
 version = "0.10.1"
 dependencies = [
+ "deunicode",
  "fuzzy-matcher",
  "globset",
  "mdbook-lint-core",

--- a/crates/adrs-core/Cargo.toml
+++ b/crates/adrs-core/Cargo.toml
@@ -28,6 +28,7 @@ time.workspace = true
 fuzzy-matcher.workspace = true
 regex.workspace = true
 globset.workspace = true
+deunicode = "1.6.2"
 
 # Linting (mdbook-lint integration)
 mdbook-lint-core = "0.14.4"

--- a/crates/adrs-core/src/types.rs
+++ b/crates/adrs-core/src/types.rs
@@ -98,8 +98,16 @@ impl Adr {
     }
 
     /// Returns the formatted filename for this ADR.
+    ///
+    /// If the title's slug is empty (e.g. a punctuation-only title, or a
+    /// title in a script that transliterates to nothing usable), falls back
+    /// to `untitled` so the filename never ends up with a bare trailing
+    /// dash like `0005-.md`. The `{:04}-` number prefix is always present,
+    /// since `Repository::renumber` parses filenames by stripping it.
     pub fn filename(&self) -> String {
-        format!("{:04}-{}.md", self.number, slug(&self.title))
+        let slug = slug(&self.title);
+        let slug = if slug.is_empty() { "untitled" } else { &slug };
+        format!("{:04}-{}.md", self.number, slug)
     }
 
     /// Returns the full title with number prefix (e.g., "1. Use Rust").
@@ -335,10 +343,18 @@ impl LinkKind {
 
 /// Convert a title to a URL-safe slug.
 ///
-/// Only ASCII alphanumeric characters are preserved; everything else becomes a dash.
+/// Non-ASCII characters are first transliterated to their closest ASCII
+/// equivalent (e.g. "café" -> "cafe", "魚" -> "yu"). ASCII input passes
+/// through the transliteration step unchanged. After that, only ASCII
+/// alphanumeric characters are preserved; everything else becomes a dash.
 /// Consecutive dashes are collapsed, and leading/trailing dashes are removed.
+///
+/// A title that transliterates to nothing usable (e.g. punctuation-only, or
+/// scripts with no ASCII approximation) produces an empty string. Callers
+/// that need a non-empty filename component must apply their own fallback;
+/// see `Adr::filename`.
 fn slug(title: &str) -> String {
-    title
+    deunicode::deunicode(title)
         .to_lowercase()
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
@@ -434,11 +450,57 @@ mod tests {
     #[test_case("Hello, World!" => "hello-world"; "punctuation")]
     #[test_case("C++ vs Rust" => "c-vs-rust"; "special chars")]
     #[test_case("100% Complete" => "100-complete"; "percentage")]
-    #[test_case("Über Design" => "ber-design"; "unicode umlaut")]
-    #[test_case("日本語" => ""; "japanese characters")]
-    #[test_case("café" => "caf"; "accented characters")]
+    #[test_case("Über Design" => "uber-design"; "unicode umlaut is transliterated")]
+    #[test_case("日本語" => "ri-ben-yu"; "japanese characters are transliterated")]
+    #[test_case("café" => "cafe"; "accented characters are transliterated")]
+    #[test_case("魚" => "yu"; "reporter's exact case (issue #367)")]
+    #[test_case("Использовать Redis" => "ispol-zovat-redis"; "cyrillic transliteration")]
+    #[test_case("Café déjà vu" => "cafe-deja-vu"; "accented latin transliteration")]
+    #[test_case("日本語のタイトル" => "ri-ben-yu-notaitoru"; "cjk transliteration")]
+    #[test_case("Redis と 日本語" => "redis-to-ri-ben-yu"; "mixed scripts in one title")]
+    #[test_case("???" => ""; "punctuation-only title still slugs to nothing")]
     fn test_slug_cases(input: &str) -> String {
         slug(input)
+    }
+
+    #[test]
+    fn test_slug_ascii_passthrough_unchanged() {
+        // `deunicode` is documented to pass ASCII through unchanged, but every
+        // existing repository's filenames depend on that being true, so confirm
+        // it directly rather than assuming.
+        let ascii_titles = [
+            "Use Rust",
+            "API v2.0 Design",
+            "  Multiple   Spaces  ",
+            "CamelCase",
+            "kebab-case",
+            "snake_case",
+            "MixedCase-and_stuff",
+            "",
+            "---",
+            "Hello, World!",
+            "C++ vs Rust",
+            "100% Complete",
+        ];
+        for title in ascii_titles {
+            assert_eq!(
+                deunicode::deunicode(title),
+                title,
+                "deunicode altered ASCII input: {title:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_slug_two_stage_composition() {
+        // deunicode transliterates the em dash to a run of ASCII hyphens
+        // (not a single one), which the slug pipeline's dash-collapsing must
+        // then reduce back to a single separator. This confirms the two
+        // stages (transliterate, then lowercase/replace/collapse/trim)
+        // compose correctly rather than leaving artifacts behind.
+        let result = slug("Naïve — approach");
+        assert_eq!(result, "naive-approach");
+        assert!(!result.contains("--"));
     }
 
     proptest! {
@@ -489,8 +551,25 @@ mod tests {
     #[test_case(999, "Last Decision" => "0999-last-decision.md"; "three digits")]
     #[test_case(9999, "Max Normal" => "9999-max-normal.md"; "four digits")]
     #[test_case(10000, "Beyond Four Digits" => "10000-beyond-four-digits.md"; "five digits")]
+    #[test_case(5, "魚" => "0005-yu.md"; "reporter's exact case (issue #367)")]
+    #[test_case(3, "Использовать Redis" => "0003-ispol-zovat-redis.md"; "cyrillic title")]
+    #[test_case(4, "Café déjà vu" => "0004-cafe-deja-vu.md"; "accented latin title")]
+    #[test_case(5, "日本語のタイトル" => "0005-ri-ben-yu-notaitoru.md"; "cjk title")]
+    #[test_case(1, "???" => "0001-untitled.md"; "punctuation-only title falls back to untitled")]
+    #[test_case(2, "!!! ... ---" => "0002-untitled.md"; "another punctuation-only title falls back")]
     fn test_adr_filename(number: u32, title: &str) -> String {
         Adr::new(number, title).filename()
+    }
+
+    #[test]
+    fn test_adr_filename_fallback_never_leaves_trailing_dash() {
+        // The number prefix ("{:04}-") must stay intact even when the slug
+        // is empty, since `Repository::renumber` parses filenames with
+        // `strip_prefix("{from:04}-")`.
+        let filename = Adr::new(7, "???").filename();
+        assert_eq!(filename, "0007-untitled.md");
+        assert!(!filename.ends_with("-.md"));
+        assert!(filename.starts_with("0007-"));
     }
 
     #[test]

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1570,6 +1570,94 @@ fn test_new_no_edit_flag() {
 }
 
 // ============================================================================
+// Unicode Title Slugs (issue #367)
+// ============================================================================
+
+#[test]
+fn test_new_unicode_title_produces_non_empty_slug() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    // Reporter's exact case: a title with no ASCII letters must not collapse
+    // to an empty slug (which used to produce a bare "0002-.md").
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "魚"])
+        .assert()
+        .success();
+
+    let adr_path = temp.child("doc/adr/0002-yu.md");
+    adr_path.assert(predicate::path::exists());
+
+    // The record's title and heading keep the original characters; only the
+    // filename is transliterated.
+    let content = fs::read_to_string(adr_path.path()).unwrap();
+    assert!(content.contains("魚"));
+    assert!(!content.contains("yu"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_unicode_title_round_trip_list_doctor_renumber() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "--no-edit", "日本語のタイトル"])
+        .assert()
+        .success();
+
+    temp.child("doc/adr/0002-ri-ben-yu-notaitoru.md")
+        .assert(predicate::path::exists());
+
+    // `adrs list` should surface the transliterated filename without erroring.
+    adrs()
+        .current_dir(temp.path())
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0002-ri-ben-yu-notaitoru.md"));
+
+    // `adrs doctor` should treat the record as a normal, healthy ADR.
+    adrs()
+        .current_dir(temp.path())
+        .arg("doctor")
+        .assert()
+        .success();
+
+    // `adrs renumber` should move the record and preserve its slug.
+    adrs()
+        .current_dir(temp.path())
+        .args(["renumber", "2", "5"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0002-ri-ben-yu-notaitoru.md"))
+        .stdout(predicate::str::contains("0005-ri-ben-yu-notaitoru.md"));
+
+    temp.child("doc/adr/0002-ri-ben-yu-notaitoru.md")
+        .assert(predicate::path::missing());
+    let renumbered = temp.child("doc/adr/0005-ri-ben-yu-notaitoru.md");
+    renumbered.assert(predicate::path::exists());
+
+    let content = fs::read_to_string(renumbered.path()).unwrap();
+    assert!(content.contains("日本語のタイトル"));
+
+    temp.close().unwrap();
+}
+
+// ============================================================================
 // Custom Template Flag Tests
 // ============================================================================
 


### PR DESCRIPTION
Closes #367.

## Context

`slug` (`crates/adrs-core/src/types.rs:340`) maps every character that is not
`is_ascii_alphanumeric` to a dash, then collapses and trims. For a title with no
ASCII letters that leaves nothing, and `adrs new` writes `0005-.md`.

The reported case is CJK, but the damage is wider, and the middle row is worse
than the empty one:

| Title | Today | Problem |
|---|---|---|
| `魚` | `0002-.md` | no slug at all |
| `Использовать Redis` | `0003-redis.md` | silently keeps only the ASCII word, so the filename looks fine and means something else |
| `Café déjà vu` | `0004-caf-d-j-vu.md` | accented Latin mangled, which reaches far more users than non-Latin scripts do |
| `日本語のタイトル` | `0005-.md` | no slug at all |

## Decision

**Transliterate to ASCII with `deunicode`** (1.6.2, crates.io) before slugging,
rather than preserving Unicode letters in filenames.

The reporter asked for either an error or preserved characters. Preserving them
is the more literal answer and was the alternative considered. It was rejected
because non-ASCII filenames in a git repository carry known rough edges that this
project would then own: macOS normalizes to NFD in places where Linux and Windows
keep NFC, git needs `core.precomposeunicode` to paper over it, and `adrs` itself
compares filenames as strings in `renumber` and in link hrefs. Transliteration
keeps every downstream path pure ASCII and sidesteps all of it.

The cost is honest and worth stating: romanization is lossy, and `魚` becoming
`yu` will read oddly to a Japanese speaker. The title itself is preserved
verbatim in the record's frontmatter and H1; only the filename is romanized.

Resulting filenames:

```
0002-yu.md
0003-ispolzovat-redis.md
0004-cafe-deja-vu.md
0005-nihongo-no-taitoru.md
```

## Task

1. Add `deunicode` to `crates/adrs-core/Cargo.toml`.
2. In `slug`, transliterate first, then apply the existing lowercase, replace,
   collapse, and trim pipeline unchanged. ASCII input must be byte-for-byte
   unaffected, since `deunicode` passes ASCII through; confirm with a test rather
   than assuming.
3. **Handle the still-empty case.** Transliteration makes it rare but not
   impossible: a title of only punctuation (`???`) still slugs to nothing. `slug`
   returning empty must not produce `0005-.md`. Apply a fallback where the
   filename is built (`Adr::filename`), not inside `slug`, since the fallback
   wants the ADR number and `slug` does not have it.
   Keep the `{:04}-` prefix intact in the fallback. `Repository::renumber` parses
   filenames with `strip_prefix("{from:04}-")`, so a fallback that drops the dash
   would break renumbering the very records this fix creates.
4. Check the other `slug` callers before changing it, and confirm none of them
   depend on the current stripping behavior.

## Tests

In `types.rs`:

- The reporter's exact case: `魚` produces a non-empty slug.
- Cyrillic, accented Latin, and CJK cases from the table above.
- ASCII titles are unchanged, including existing punctuation and spacing
  behavior. This is the regression guard for every existing repository.
- A punctuation-only title hits the fallback and never yields a trailing-dash
  filename.
- Mixed scripts in one title.
- A title that transliterates to something containing characters the slug
  pipeline then strips, so the two stages compose correctly.

In `crates/adrs/tests/cli.rs`: `adrs new "魚"` writes a file whose name has a
slug, and the record's title and H1 still read `魚` rather than the romanization.

Round-trip: create a record with a non-ASCII title, then `adrs list`, `adrs
doctor`, and `adrs renumber` on it all behave.

## Constraints

- ASCII titles must produce byte-identical filenames to today.
- Do not rename any existing file. This changes how new filenames are derived,
  nothing else.
- The title in frontmatter and in the H1 keeps its original characters. Only the
  filename is transliterated.
- Do not edit `CLAUDE.md`.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and
  `cargo test --all-features` all pass.

## Out of scope

- Renaming existing records with degraded slugs. `adrs renumber` can move a
  record but there is no rename-in-place command; worth its own issue if wanted.

## Acceptance

`adrs new "魚"` writes a file with a real slug rather than `0005-.md`, and every
existing ASCII title produces exactly the filename it does today.


## What landed, and where the plan's predictions were wrong

The predicted filenames in the Decision section above were a guess and two of
them are wrong. Actual output, verified against the built binary:

| Title | Predicted | Actual |
|---|---|---|
| `魚` | `0002-yu.md` | `0002-yu.md` |
| `Использовать Redis` | `0003-ispolzovat-redis.md` | `0003-ispol-zovat-redis.md` |
| `Café déjà vu` | `0004-cafe-deja-vu.md` | `0004-cafe-deja-vu.md` |
| `日本語のタイトル` | `0005-nihongo-no-taitoru.md` | `0005-ri-ben-yu-notaitoru.md` |

Two things to know about the misses:

**Cyrillic gains a dash.** `ь` transliterates to an apostrophe, and the existing
slug pipeline turns apostrophes into dashes, so `Использовать` becomes
`ispol-zovat`. This is the same rule that already turns `Don't repeat yourself`
into `don-t-repeat-yourself`. Changing it would alter ASCII slugs and break the
byte-identical guarantee, so it is left alone.

**CJK is romanized through Chinese readings, not Japanese ones.** `deunicode` is
not language-aware, so 日本語 becomes `ri-ben-yu` (character-by-character pinyin
style) rather than `nihongo`, and the kana run through as `notaitoru`. The
filename is stable, ASCII, and unique, but it is not what a Japanese speaker
would write. The title itself is untouched: the record still reads
`# 5. 日本語のタイトル` in both frontmatter and H1.

If that is unacceptable, the alternatives are preserving Unicode in filenames
(rejected in the Decision above for the git normalization hazards) or adding a
language-aware transliterator, which helps one language and adds a dependency.
Neither is done here.

## ASCII-unchanged guarantee

Holds, and is now asserted directly rather than assumed:
`test_slug_ascii_passthrough_unchanged` checks
`deunicode::deunicode(title) == title` across the existing ASCII fixture set. No
existing ASCII test expectation changed.

Three existing **non-ASCII** expectations did change, because they pinned the
broken behavior this issue is about:

| Title | Was | Now |
|---|---|---|
| `Über Design` | `ber-design` | `uber-design` |
| `日本語` | `` (empty) | `ri-ben-yu` |
| `café` | `caf` | `cafe` |

## Dependency

`deunicode` 1.6.2 was already in the tree transitively, via
`mdbook-lint-core` -> `comrak` -> `slug`, at the same version. Promoting it to a
direct dependency of `adrs-core` adds no new supply-chain surface. Confirmed with
`cargo tree -i`, and both Audit and Security audit pass.

## Verified end to end

`adrs new` with each title above, then `doctor` clean, then `renumber 5 9`
producing `0009-ri-ben-yu-notaitoru.md` with the slug and the original title
intact. `???` produces `0006-untitled.md`, never a bare trailing dash.

**Tests:** 848 pass, 0 fail. CI green on all eleven checks including Audit,
Security audit, MSRV, and tests on macOS, Ubuntu, and Windows.
