### PR TITLE
fix: honor --status and default_status when superseding (closes #371)

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -465,9 +465,15 @@ impl Repository {
     }
 
     /// Create a new ADR that supersedes another.
+    ///
+    /// The new ADR honors `config.default_status` the same way `new_adr()`
+    /// does (#371); only the superseded ADR is forced to `Superseded`.
     pub fn supersede(&self, title: impl Into<String>, superseded: u32) -> Result<(Adr, PathBuf)> {
         let number = self.next_number()?;
         let mut adr = Adr::new(number, title);
+        if let Some(default_status) = self.config.default_status.as_deref() {
+            adr.status = default_status.parse::<AdrStatus>().unwrap();
+        }
         adr.add_link(AdrLink::new(superseded, LinkKind::Supersedes));
 
         // Create the new ADR first so its file exists on disk when
@@ -1949,6 +1955,31 @@ default_status = "draft"
         let (adr, _) = repo.new_adr("Custom status ADR").unwrap();
 
         assert_eq!(adr.status, AdrStatus::Custom("draft".into()));
+    }
+
+    #[test]
+    fn test_supersede_uses_custom_default_status_from_config() {
+        // #371: the superseding ADR must honor default_status like new_adr()
+        // does; only the superseded ADR is forced to Superseded.
+        let temp = TempDir::new().unwrap();
+        Repository::init(temp.path(), None, false).unwrap();
+
+        std::fs::write(
+            temp.path().join("adrs.toml"),
+            r#"
+adr_dir = "doc/adr"
+mode = "compatible"
+default_status = "accepted"
+"#,
+        )
+        .unwrap();
+
+        let repo = Repository::open(temp.path()).unwrap();
+        repo.new_adr("Original decision").unwrap();
+        let (adr, _) = repo.supersede("Replacement decision", 2).unwrap();
+
+        assert_eq!(adr.status, AdrStatus::Accepted);
+        assert_eq!(repo.get(2).unwrap().status, AdrStatus::Superseded);
     }
 
     // ========== Get and Find Tests ==========

--- a/crates/adrs/src/commands/new.rs
+++ b/crates/adrs/src/commands/new.rs
@@ -91,10 +91,11 @@ pub fn new(
         repo.new_adr(&title).context("Failed to create new ADR")?
     };
 
-    // Apply explicit CLI status if specified (superseding sets its own status).
-    if supersedes.is_none()
-        && let Some(status) = cli_status
-    {
+    // Apply explicit CLI status if specified. This also covers the supersede
+    // path: only the superseded ADR's status is forced (to Superseded), the
+    // new ADR follows the usual --status > default_status > proposed
+    // precedence (#371).
+    if let Some(status) = cli_status {
         adr.status = status;
         repo.update_metadata(&adr)
             .context("Failed to update ADR status")?;

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -1570,6 +1570,104 @@ fn test_new_no_edit_flag() {
 }
 
 // ============================================================================
+// Supersede status handling (issue #371)
+// ============================================================================
+
+#[test]
+fn test_new_supersedes_honors_explicit_status() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "init"])
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "new", "--no-edit", "First decision"])
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "--ng",
+            "new",
+            "--no-edit",
+            "--supersedes",
+            "2",
+            "--status",
+            "accepted",
+            "Replacement decision",
+        ])
+        .assert()
+        .success();
+
+    // #371: the superseding ADR used to land as proposed, silently ignoring
+    // --status. It must carry the explicit status.
+    let new_content =
+        fs::read_to_string(temp.path().join("doc/adr/0003-replacement-decision.md")).unwrap();
+    assert!(new_content.contains("status: accepted"));
+
+    // The superseded ADR is still forced to superseded.
+    let old_content =
+        fs::read_to_string(temp.path().join("doc/adr/0002-first-decision.md")).unwrap();
+    assert!(old_content.contains("status: superseded"));
+
+    temp.close().unwrap();
+}
+
+#[test]
+fn test_new_supersedes_honors_default_status_from_config() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "init"])
+        .assert()
+        .success();
+
+    // Prepend so the top-level key can't land inside a [table] section.
+    let config_path = temp.path().join("adrs.toml");
+    let config = fs::read_to_string(&config_path).unwrap();
+    fs::write(
+        &config_path,
+        format!("default_status = \"accepted\"\n{config}"),
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["--ng", "new", "--no-edit", "First decision"])
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args([
+            "--ng",
+            "new",
+            "--no-edit",
+            "--supersedes",
+            "2",
+            "Replacement decision",
+        ])
+        .assert()
+        .success();
+
+    let new_content =
+        fs::read_to_string(temp.path().join("doc/adr/0003-replacement-decision.md")).unwrap();
+    assert!(new_content.contains("status: accepted"));
+
+    let old_content =
+        fs::read_to_string(temp.path().join("doc/adr/0002-first-decision.md")).unwrap();
+    assert!(old_content.contains("status: superseded"));
+
+    temp.close().unwrap();
+}
+
+// ============================================================================
 // Unicode Title Slugs (issue #367)
 // ============================================================================
 


### PR DESCRIPTION
Closes #371.

## Problem

`adrs new --supersedes N` always creates the superseding ADR with `status: proposed`, silently ignoring both an explicit `--status` flag and the `default_status` configured in `adrs.toml`. The non-superseding path honors both.

## Plan

- `Repository::supersede()` applies `config.default_status` to the new ADR the same way `new_adr()` does, before the file is rendered.
- `commands/new.rs` drops the `supersedes.is_none()` guard so an explicit `--status` also applies on the supersede path. The old ADR still gets `Superseded` as before.
- Precedence on the supersede path matches the normal path: `--status` > `default_status` > `proposed`.

## Tests

- Core: `supersede()` with `default_status` configured produces the new ADR with that status, mirroring `test_new_adr_uses_custom_default_status_from_config`.
- CLI: `new --supersedes N --status accepted` writes `status: accepted` frontmatter on the new ADR while the superseded ADR is marked `superseded`.