### PR TITLE
fix: derive generate toc/graph/book link filenames from on-disk paths

### DIFF
--- a/crates/adrs-core/src/repository.rs
+++ b/crates/adrs-core/src/repository.rs
@@ -416,28 +416,11 @@ impl Repository {
             if let Ok(target_adr) = self.get(link.target) {
                 map.insert(
                     link.target,
-                    (target_adr.title.clone(), Self::link_href(&target_adr)),
+                    (target_adr.title.clone(), target_adr.link_filename()),
                 );
             }
         }
         map
-    }
-
-    /// The href to use when rendering a link to `target_adr`.
-    ///
-    /// Prefers the target's actual on-disk filename over a filename
-    /// re-derived from its title. The two can diverge (hand-named files,
-    /// files renamed after a title edit), and re-deriving produces hrefs
-    /// that point at files that don't exist (#325). Falls back to the
-    /// title-derived filename only when the target has no resolvable path.
-    fn link_href(target_adr: &Adr) -> String {
-        target_adr
-            .path
-            .as_ref()
-            .and_then(|p| p.file_name())
-            .and_then(|f| f.to_str())
-            .map(str::to_string)
-            .unwrap_or_else(|| target_adr.filename())
     }
 
     /// Create a new ADR.
@@ -3398,25 +3381,22 @@ Context.
     }
 
     #[test]
-    fn test_link_href_prefers_actual_path_over_slugified_title() {
+    fn test_link_filename_prefers_actual_path_over_slugified_title() {
         let target = Adr {
             path: Some(PathBuf::from("/repo/doc/adr/0003-use-rust-for-backend.md")),
             ..Adr::new(3, "Use Rust for backend services")
         };
-        assert_eq!(
-            Repository::link_href(&target),
-            "0003-use-rust-for-backend.md"
-        );
+        assert_eq!(target.link_filename(), "0003-use-rust-for-backend.md");
     }
 
     #[test]
-    fn test_link_href_falls_back_to_slugified_title_when_path_missing() {
+    fn test_link_filename_falls_back_to_slugified_title_when_path_missing() {
         let target = Adr {
             path: None,
             ..Adr::new(3, "Use Rust for backend services")
         };
         assert_eq!(
-            Repository::link_href(&target),
+            target.link_filename(),
             "0003-use-rust-for-backend-services.md"
         );
     }

--- a/crates/adrs-core/src/types.rs
+++ b/crates/adrs-core/src/types.rs
@@ -110,6 +110,22 @@ impl Adr {
         format!("{:04}-{}.md", self.number, slug)
     }
 
+    /// Returns the filename to use when linking to this ADR.
+    ///
+    /// Prefers the actual on-disk file name over one re-derived from the
+    /// title. The two can diverge when the file was created under an older
+    /// slug scheme or renamed by hand, and a re-derived name points at a
+    /// file that doesn't exist. Falls back to [`Adr::filename`] when the
+    /// ADR has no path (not yet written to disk).
+    pub fn link_filename(&self) -> String {
+        self.path
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .and_then(|f| f.to_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| self.filename())
+    }
+
     /// Returns the full title with number prefix (e.g., "1. Use Rust").
     pub fn full_title(&self) -> String {
         format!("{}. {}", self.number, self.title)

--- a/crates/adrs/src/commands/generate.rs
+++ b/crates/adrs/src/commands/generate.rs
@@ -39,7 +39,7 @@ pub fn generate_toc(
             bullet,
             adr.full_title(),
             prefix,
-            adr.filename()
+            adr.link_filename()
         );
     }
 
@@ -66,7 +66,9 @@ pub fn generate_graph(root: &Path, prefix: Option<String>, extension: &str) -> R
 
     // Create nodes
     for adr in &adrs {
-        let filename = adr.filename().replace(".md", &format!(".{}", extension));
+        let filename = adr
+            .link_filename()
+            .replace(".md", &format!(".{}", extension));
         println!(
             "  _{} [label=\"{}\"; URL=\"{}{}\"];",
             adr.number,
@@ -136,12 +138,16 @@ build-dir = "book"
     // Create SUMMARY.md
     let mut summary = String::from("# Summary\n\n");
     for adr in &adrs {
-        summary.push_str(&format!("- [{}]({})\n", adr.full_title(), adr.filename()));
+        // Link and copy destination must both use the on-disk filename,
+        // which can differ from the title-derived one (renamed files,
+        // older slug schemes).
+        let filename = adr.link_filename();
+        summary.push_str(&format!("- [{}]({})\n", adr.full_title(), filename));
 
         // Copy ADR file to src
         if let Some(path) = &adr.path {
             let content = fs::read_to_string(path)?;
-            fs::write(src_dir.join(adr.filename()), content)?;
+            fs::write(src_dir.join(&filename), content)?;
         }
     }
     fs::write(src_dir.join("SUMMARY.md"), summary)?;

--- a/crates/adrs/tests/cli.rs
+++ b/crates/adrs/tests/cli.rs
@@ -444,6 +444,46 @@ fn test_generate_toc_ordered() {
     temp.close().unwrap();
 }
 
+/// TOC links must use the file's actual on-disk name, not one re-derived
+/// from the title. The two diverge for files created under an older slug
+/// scheme or renamed by hand.
+#[test]
+fn test_generate_toc_uses_on_disk_filename_for_renamed_file() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["new", "Use PostgreSQL"])
+        .env("EDITOR", "true") // Use 'true' as a no-op editor
+        .assert()
+        .success();
+
+    // Rename on disk, keeping the number prefix.
+    fs::rename(
+        temp.path().join("doc/adr/0002-use-postgresql.md"),
+        temp.path().join("doc/adr/0002-use-postgres-db.md"),
+    )
+    .unwrap();
+
+    adrs()
+        .current_dir(temp.path())
+        .args(["generate", "toc"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "[2. Use PostgreSQL](0002-use-postgres-db.md)",
+        ))
+        .stdout(predicate::str::contains("0002-use-postgresql.md").not());
+
+    temp.close().unwrap();
+}
+
 #[test]
 fn test_generate_graph_help() {
     adrs()


### PR DESCRIPTION
## Context

`generate toc`, `generate graph`, and `generate book` build link targets from `Adr::filename()`, which recomputes the slug from the title. The slug scheme has changed twice (pre-0.11.0 produced `0002-.md` for non-ASCII titles, 0.11.0 transliterated to `0002-ri-ben-yu-notaitoru.md`, and after #373 slugs preserve Unicode). Any repository holding files created under an older scheme, or files renamed by hand, gets TOC and graph links that point at filenames that do not exist on disk. `Repository::resolve_link_titles` already solved this for in-document links via `link_href` (#325); the generate commands never got the same treatment.

## Plan

1. Add `Adr::link_filename()` to `adrs-core` (types.rs): return the file name of `adr.path` when set, falling back to `Adr::filename()` when the ADR has no path.
2. Refactor `Repository::link_href` to delegate to it, so there is one implementation of the rule.
3. Use `link_filename()` in `crates/adrs/src/commands/generate.rs`:
   - `generate_toc`: TOC bullet links
   - `generate_graph`: node URL attributes (with the extension rewrite applied to the on-disk name)
   - `generate_book`: both the SUMMARY.md link and the copy destination in `src/`, so they stay consistent and preserve the user's actual filenames
4. Unit tests in `adrs-core` for `link_filename()` (path present, path absent).
5. CLI test: create an ADR, rename the file on disk keeping the number prefix, run `adrs generate toc`, assert the emitted link uses the on-disk name.

## Acceptance

- Generated TOC/graph/book links resolve for repositories with files from any slug scheme or hand-renamed files.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` pass.